### PR TITLE
fix(ci): enable disabled CI jobs and fix MSRV inconsistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,12 @@ env:
   RUSTFLAGS: -Dwarnings
 
 jobs:
-  check:
-    name: Check
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
-      - run: cargo check --all-features --all-targets
+  # ==========================================================================
+  # Fast checks - run first, fail fast
+  # ==========================================================================
 
   fmt:
-    name: Rustfmt
+    name: Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -41,14 +36,32 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
-  test:
-    name: Test Suite
+  check:
+    name: Check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-features --all-targets
+
+  # ==========================================================================
+  # Core tests - run after fast checks pass
+  # ==========================================================================
+
+  test:
+    name: Test Suite
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, check]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
+
+  # ==========================================================================
+  # Security & compliance
+  # ==========================================================================
 
   deny:
     name: Cargo Deny
@@ -59,33 +72,71 @@ jobs:
         with:
           command: check all
 
-  # === DISABLED FOR SPEED - Re-enable for releases ===
-  # test-matrix:
-  #   name: Test Suite (Full Matrix)
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, macos-latest, windows-latest]
-  #       rust: [stable, "1.85"]
-  #
-  # test-arm64:
-  #   name: Test ARM64
-  #   runs-on: ubuntu-24.04-arm
-  #
-  # coverage:
-  #   name: Code Coverage
-  #
-  # docs:
-  #   name: Documentation
-  #
-  # msrv:
-  #   name: Minimum Supported Rust Version
-  #
-  # semver:
-  #   name: Semver Check
-  #
-  # bench:
-  #   name: Benchmarks
-  #
-  # security:
-  #   name: Security Audit
+  # ==========================================================================
+  # Documentation
+  # ==========================================================================
+
+  docs:
+    name: Documentation
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, check]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build documentation
+        run: cargo doc --no-deps --all-features
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+
+  # ==========================================================================
+  # MSRV - Minimum Supported Rust Version
+  # ==========================================================================
+
+  msrv:
+    name: MSRV (1.85)
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, check]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.85
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check --all-features --all-targets
+
+  # ==========================================================================
+  # Cross-platform matrix - PRs only (to save CI minutes)
+  # ==========================================================================
+
+  test-matrix:
+    name: Test (${{ matrix.os }})
+    if: github.event_name == 'pull_request'
+    runs-on: ${{ matrix.os }}
+    needs: [test]
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --all-features
+
+  # ==========================================================================
+  # Semver check - ensure no accidental breaking changes
+  # ==========================================================================
+
+  semver:
+    name: Semver Check
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, check]
+    # Only run on PRs (not pushes to main) to compare against baseline
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-semver-checks
+        run: cargo install cargo-semver-checks --locked
+      - name: Check semver
+        run: cargo semver-checks check-release --package mcpkit

--- a/Justfile
+++ b/Justfile
@@ -27,7 +27,7 @@
 
 project_name := "mcpkit"
 version := "0.2.0"
-msrv := "1.75"
+msrv := "1.85"
 edition := "2021"
 docker_image := project_name
 docker_tag := version

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcpkit.svg)](https://crates.io/crates/mcpkit)
 [![Documentation](https://docs.rs/mcpkit/badge.svg)](https://docs.rs/mcpkit)
 [![License](https://img.shields.io/crates/l/mcpkit.svg)](LICENSE-MIT)
-[![MSRV](https://img.shields.io/badge/MSRV-1.75-blue.svg)](https://blog.rust-lang.org/2023/12/28/Rust-1.75.0.html)
+[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue.svg)](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0.html)
 
 A Rust SDK for the Model Context Protocol (MCP) that simplifies server development through a unified `#[mcp_server]` macro.
 


### PR DESCRIPTION
## Summary

- Enable previously disabled CI jobs: docs, msrv, test-matrix, semver
- Fix MSRV mismatch: README and Justfile said 1.75 but Cargo.toml specifies 1.85
- Add job dependencies for better CI efficiency
- Cross-platform tests (macOS, Windows) only run on PRs to save CI minutes
- Semver checks only run on PRs to compare against published baseline

## Changes

| Job | Before | After | Trigger |
|-----|--------|-------|---------|
| fmt | ✅ | ✅ | Always |
| clippy | ✅ | ✅ | Always |
| check | ✅ | ✅ | Always |
| test | ✅ | ✅ (after fast checks) | Always |
| deny | ✅ | ✅ | Always |
| **docs** | ❌ disabled | ✅ enabled | Always |
| **msrv** | ❌ disabled | ✅ enabled | Always |
| **test-matrix** | ❌ disabled | ✅ enabled | PRs only |
| **semver** | ❌ disabled | ✅ enabled | PRs only |

## Test plan

- [x] Local CI passes (`just ci`)
- [x] MSRV check passes with Rust 1.85
- [ ] GitHub Actions CI passes