### PR TITLE
fix(transport): stop connection pool from leaking in_use slots (#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Connection pool no longer leaks `in_use` capacity
+  ([#6](https://github.com/praxiomlabs/mcpkit/issues/6)). A failing connection
+  factory now rolls back its reserved slot, and dropping a
+  `PooledConnectionGuard` releases its slot, so the pool can no longer drain to
+  permanent exhaustion. `in_use`/`peak_in_use` are tracked with atomics so a
+  slot can be freed from synchronous (drop) contexts.
 - Resolved Clippy lints surfaced by newer stable toolchains (`map_unwrap_or`,
   `unnecessary_map_or`, `unnecessary_sort_by`) across `mcpkit-core`,
   `mcpkit-transport`, `mcpkit-server`, and `mcpkit-testing`, restoring a clean

--- a/crates/mcpkit-transport/src/pool/connection.rs
+++ b/crates/mcpkit-transport/src/pool/connection.rs
@@ -76,19 +76,22 @@ impl<T> PooledConnection<T> {
     }
 }
 
-/// A simple wrapper for pools that provides automatic connection release.
+/// A guard that frees its pool slot when dropped.
 ///
-/// When dropped, the connection is released. For proper async release back to
-/// the pool, use the `take()` method to extract the connection and call
-/// `Pool::release()` directly.
+/// When the guard is dropped without first calling [`take`](Self::take), the
+/// reserved `in_use` slot is released back to the pool so capacity is not
+/// leaked. The connection itself is closed rather than returned for reuse,
+/// because release in a `Drop` context cannot be async.
+///
+/// To return a connection to the pool **for reuse**, call [`take`](Self::take)
+/// to extract it and pass it to [`Pool::release`] directly.
 pub struct PooledConnectionGuard<'a, T, F, Fut>
 where
     T: Transport,
     F: Fn() -> Fut + Send + Sync,
     Fut: Future<Output = Result<T, TransportError>> + Send,
 {
-    /// Reference to the pool (kept for future async release support).
-    #[allow(dead_code)]
+    /// Pool the slot belongs to, used to release the slot on drop.
     pool: &'a Pool<T, F, Fut>,
     conn: Option<PooledConnection<T>>,
 }
@@ -134,16 +137,15 @@ where
             .expect("take() called twice on PooledConnectionGuard")
     }
 
-    /// Release the connection back to the pool.
+    /// Release the reserved pool slot in a synchronous (drop) context.
     ///
-    /// This is a best-effort operation in synchronous context.
-    /// For proper async release, use `Pool::release()` directly.
+    /// We cannot await here to return the connection to the pool's idle set, so
+    /// the connection is dropped (closed) and only its `in_use` slot is freed.
+    /// If [`take`](Self::take) was already called there is nothing to release.
     fn release_sync(&mut self) {
-        // In drop context, we cannot await, so we just drop the connection.
-        // Proper async release should use Pool::release() before dropping.
-        // The connection count will be decremented when the Pool detects
-        // the connection is no longer available.
-        self.conn.take();
+        if self.conn.take().is_some() {
+            self.pool.release_slot();
+        }
     }
 }
 

--- a/crates/mcpkit-transport/src/pool/manager.rs
+++ b/crates/mcpkit-transport/src/pool/manager.rs
@@ -17,12 +17,8 @@ use super::connection::PooledConnection;
 pub struct PoolState<T> {
     /// Available connections.
     pub available: VecDeque<PooledConnection<T>>,
-    /// Number of connections currently in use.
-    pub in_use: usize,
     /// Whether the pool is closed.
     pub closed: bool,
-    /// Peak number of concurrent connections ever in use.
-    pub peak_in_use: usize,
 }
 
 /// A connection pool for managing MCP transport connections.
@@ -38,6 +34,15 @@ where
     config: PoolConfig,
     factory: F,
     pub(crate) state: AsyncMutex<PoolState<T>>,
+    /// Number of connections currently in use.
+    ///
+    /// Kept outside [`PoolState`] (which is behind an async mutex) so the
+    /// `in_use` count can be decremented from synchronous contexts such as
+    /// `Drop` and factory-error rollback. Increments happen while holding the
+    /// state lock so the `max_connections` invariant is preserved.
+    in_use: AtomicUsize,
+    /// Peak number of concurrent connections ever in use.
+    peak_in_use: AtomicUsize,
     /// Notification for waiters when a connection becomes available.
     notify: Notify,
     next_id: AtomicU64,
@@ -68,10 +73,10 @@ where
             factory,
             state: AsyncMutex::new(PoolState {
                 available: VecDeque::new(),
-                in_use: 0,
                 closed: false,
-                peak_in_use: 0,
             }),
+            in_use: AtomicUsize::new(0),
+            peak_in_use: AtomicUsize::new(0),
             notify: Notify::new(),
             next_id: AtomicU64::new(1),
             stats_created: AtomicU64::new(0),
@@ -83,6 +88,44 @@ where
             stats_recycled_lifetime: AtomicU64::new(0),
             stats_recycled_health: AtomicU64::new(0),
         }
+    }
+
+    /// Reserve one `in_use` slot and update the peak counter.
+    ///
+    /// Callers must hold the state lock when calling this so the reservation is
+    /// serialized against the `max_connections` capacity check.
+    fn inc_in_use(&self) {
+        let new_in_use = self.in_use.fetch_add(1, Ordering::AcqRel) + 1;
+        self.peak_in_use.fetch_max(new_in_use, Ordering::AcqRel);
+    }
+
+    /// Release one `in_use` slot, saturating at zero so a double release can
+    /// never underflow the counter.
+    fn dec_in_use(&self) {
+        let mut cur = self.in_use.load(Ordering::Acquire);
+        while cur > 0 {
+            match self.in_use.compare_exchange_weak(
+                cur,
+                cur - 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(actual) => cur = actual,
+            }
+        }
+    }
+
+    /// Release a reserved `in_use` slot without returning a connection to the
+    /// pool, then wake one waiter.
+    ///
+    /// Used by `Drop` of [`PooledConnectionGuard`] and by factory-error rollback,
+    /// where the connection cannot be returned for reuse (those paths are
+    /// synchronous / have no connection to return). The slot is freed so pool
+    /// capacity is not leaked.
+    pub(crate) fn release_slot(&self) {
+        self.dec_in_use();
+        self.notify.notify(1);
     }
 
     /// Warm up the pool by pre-creating connections.
@@ -98,7 +141,7 @@ where
 
         for _ in 0..min_connections {
             let state = self.state.lock().await;
-            let total = state.available.len() + state.in_use;
+            let total = state.available.len() + self.in_use.load(Ordering::Acquire);
             drop(state);
 
             if total >= min_connections {
@@ -135,12 +178,12 @@ where
             acquires: self.stats_acquires.load(Ordering::Relaxed),
             releases: self.stats_releases.load(Ordering::Relaxed),
             timeouts: self.stats_timeouts.load(Ordering::Relaxed),
-            in_use: state.in_use,
+            in_use: self.in_use.load(Ordering::Acquire),
             idle: state.available.len(),
             waiters: self.stats_waiters.load(Ordering::Relaxed),
             recycled_lifetime: self.stats_recycled_lifetime.load(Ordering::Relaxed),
             recycled_health: self.stats_recycled_health.load(Ordering::Relaxed),
-            peak_in_use: state.peak_in_use,
+            peak_in_use: self.peak_in_use.load(Ordering::Acquire),
         }
     }
 
@@ -194,31 +237,32 @@ where
                 }
 
                 conn.touch();
-                state.in_use += 1;
-
-                // Track peak usage
-                if state.in_use > state.peak_in_use {
-                    state.peak_in_use = state.in_use;
-                }
+                // Reserve the slot while holding the lock so the capacity check
+                // stays serialized against other acquirers.
+                self.inc_in_use();
 
                 self.stats_acquires.fetch_add(1, Ordering::Relaxed);
                 return Ok(conn);
             }
 
             // Check if we can create a new connection
-            let total = state.available.len() + state.in_use;
+            let total = state.available.len() + self.in_use.load(Ordering::Acquire);
             if total < self.config.max_connections {
-                state.in_use += 1;
-
-                // Track peak usage
-                if state.in_use > state.peak_in_use {
-                    state.peak_in_use = state.in_use;
-                }
+                // Reserve the slot under the lock to preserve the
+                // max_connections invariant, then create outside the lock.
+                self.inc_in_use();
 
                 drop(state);
 
-                // Create new connection outside the lock
-                let connection = (self.factory)().await?;
+                // Create new connection outside the lock. On failure, roll back
+                // the reserved slot so a failing factory cannot leak capacity.
+                let connection = match (self.factory)().await {
+                    Ok(connection) => connection,
+                    Err(e) => {
+                        self.release_slot();
+                        return Err(e);
+                    }
+                };
                 let id = self.next_id.fetch_add(1, Ordering::Relaxed);
 
                 self.stats_created.fetch_add(1, Ordering::Relaxed);
@@ -260,9 +304,7 @@ where
     pub async fn release(&self, mut conn: PooledConnection<T>) {
         let mut state = self.state.lock().await;
 
-        if state.in_use > 0 {
-            state.in_use -= 1;
-        }
+        self.dec_in_use();
 
         // Check if pool is closed or connection is unhealthy
         if state.closed {

--- a/crates/mcpkit-transport/src/pool/mod.rs
+++ b/crates/mcpkit-transport/src/pool/mod.rs
@@ -640,4 +640,82 @@ mod stress_tests {
         assert!(stats.idle > 0, "Should have idle connections");
         assert_eq!(stats.timeouts, 0, "Should have no timeouts");
     }
+
+    // =========================================================================
+    // Capacity-leak regression tests (#6)
+    // =========================================================================
+
+    /// Regression test for #6: a failing connection factory must not leak an
+    /// `in_use` slot. Otherwise the pool drains to permanent exhaustion.
+    #[tokio::test]
+    async fn factory_error_does_not_leak_capacity() {
+        let config = PoolConfig::new()
+            .max_connections(2)
+            .acquire_timeout(Duration::from_millis(200));
+
+        // Fail the first two factory calls, then succeed.
+        let attempts = Arc::new(AtomicU64::new(0));
+        let factory: Box<dyn Fn() -> MockFuture + Send + Sync> = {
+            let attempts = Arc::clone(&attempts);
+            Box::new(move || {
+                let n = attempts.fetch_add(1, Ordering::Relaxed);
+                Box::pin(async move {
+                    if n < 2 {
+                        Err(TransportError::Connection {
+                            message: "factory boom".to_string(),
+                        })
+                    } else {
+                        Ok(MockTransport::new(n))
+                    }
+                }) as MockFuture
+            })
+        };
+        let pool = Pool::new(config, factory);
+
+        assert!(pool.acquire().await.is_err(), "first factory call fails");
+        assert!(pool.acquire().await.is_err(), "second factory call fails");
+
+        assert_eq!(
+            pool.stats().await.in_use,
+            0,
+            "a failed factory call must roll back the reserved in_use slot"
+        );
+
+        // The pool must still be able to create connections (not deadlocked at
+        // capacity because of leaked slots).
+        let conn = pool
+            .acquire()
+            .await
+            .expect("pool should still hand out connections after factory failures");
+        pool.release(conn).await;
+    }
+
+    /// Regression test for #6: dropping a `PooledConnectionGuard` must free the
+    /// `in_use` slot, otherwise guard users silently exhaust the pool.
+    #[tokio::test]
+    async fn dropping_guard_frees_the_slot() {
+        let config = PoolConfig::new()
+            .max_connections(1)
+            .acquire_timeout(Duration::from_millis(200));
+        let pool = create_mock_pool(config);
+
+        {
+            let conn = pool.acquire().await.expect("acquire");
+            let _guard = PooledConnectionGuard::new(&pool, conn);
+            assert_eq!(pool.stats().await.in_use, 1, "slot is in use while held");
+        } // guard dropped here
+
+        assert_eq!(
+            pool.stats().await.in_use,
+            0,
+            "dropping the guard must release the in_use slot"
+        );
+
+        // Pool is at max_connections=1; this only succeeds if the slot was freed.
+        let conn = pool
+            .acquire()
+            .await
+            .expect("should reacquire after the guard frees the slot");
+        pool.release(conn).await;
+    }
 }


### PR DESCRIPTION
Closes #6.

## Problem
Two paths permanently leaked pool capacity (`in_use` count), draining the pool until `acquire()` could never succeed:

1. **Factory error:** `acquire()` did `in_use += 1`, dropped the lock, then `(factory)().await?` — an early return on error never rolled back the reserved slot (`manager.rs:211`/`:221`).
2. **Guard drop:** `PooledConnectionGuard::release_sync` discarded the connection without decrementing `in_use`, and even claimed in a comment that "the Pool will detect" it — nothing did (`connection.rs:141`).

**Root cause:** `in_use` lived inside the async-mutex-guarded `PoolState`, so it couldn't be decremented from synchronous contexts (`Drop`, error rollback).

## Fix
- Move `in_use`/`peak_in_use` to `AtomicUsize` on `Pool`. Increments still happen **while holding the state lock**, so the `max_connections` invariant is preserved; decrements are lock-free and saturating (a double release can't underflow).
- Roll back the reserved slot when the factory errors.
- Release the slot + wake a waiter when a guard is dropped without `take()`. Docs updated to be honest: the guard frees the slot but closes the connection rather than returning it for reuse (async return isn't possible in `Drop`).

## Scope note
`acquire()` still returns a bare `PooledConnection` whose contract is manual `pool.release(conn)`. Making `acquire()` return an RAII guard by default (so the bare-drop path also auto-releases) is an API change I deliberately left out of this fix — happy to file it as a follow-up enhancement.

## Tests
Two regression tests, both **confirmed failing before** this change:
- `factory_error_does_not_leak_capacity` — two failing factory calls, then asserts `in_use == 0` and that the pool still hands out connections.
- `dropping_guard_frees_the_slot` — asserts a dropped guard frees the slot and the pool (max_connections=1) is reusable.

All 234 `mcpkit-transport` tests pass (incl. the 500-task concurrency and stats-accuracy suites, which exercise the atomic accounting under load). fmt + clippy `-D warnings` + doc gate green.