### PR TITLE
style: fix clippy lints surfaced by stable Rust 1.96

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Resolved Clippy lints surfaced by newer stable toolchains (`map_unwrap_or`,
+  `unnecessary_map_or`, `unnecessary_sort_by`) across `mcpkit-core`,
+  `mcpkit-transport`, `mcpkit-server`, and `mcpkit-testing`, restoring a clean
+  `clippy -D warnings` on current stable Rust
 - Clippy warning for `from_str` method naming in `mcpkit-core::auth::jwt` (renamed to `parse`)
 - Clippy warnings in `mcpkit-transport` for single-pattern match expressions
 

--- a/crates/mcpkit-core/src/auth/jwt.rs
+++ b/crates/mcpkit-core/src/auth/jwt.rs
@@ -444,8 +444,7 @@ pub fn decode_claims_unverified(token: &str) -> Result<TokenClaims, JwtError> {
 pub fn validate_claims(claims: &TokenClaims, validation: &TokenValidation) -> Result<(), JwtError> {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_secs());
 
     // Validate expiration (use saturating arithmetic to prevent overflow)
     if validation.validate_exp {

--- a/crates/mcpkit-core/src/debug/inspector.rs
+++ b/crates/mcpkit-core/src/debug/inspector.rs
@@ -27,9 +27,7 @@ impl MessageRecord {
     /// Create a new message record.
     #[must_use]
     pub fn new(direction: MessageDirection, message: Message) -> Self {
-        let size_bytes = serde_json::to_string(&message)
-            .map(|s| s.len())
-            .unwrap_or(0);
+        let size_bytes = serde_json::to_string(&message).map_or(0, |s| s.len());
 
         Self {
             timestamp: Instant::now(),
@@ -184,7 +182,7 @@ impl MessageInspector {
     /// Check if capturing is enabled.
     #[must_use]
     pub fn is_enabled(&self) -> bool {
-        self.enabled.read().map(|e| *e).unwrap_or(false)
+        self.enabled.read().is_ok_and(|e| *e)
     }
 
     /// Record an outbound message.
@@ -245,7 +243,7 @@ impl MessageInspector {
     /// Get the number of captured records.
     #[must_use]
     pub fn len(&self) -> usize {
-        self.records.read().map(|r| r.len()).unwrap_or(0)
+        self.records.read().map_or(0, |r| r.len())
     }
 
     /// Check if there are no captured records.

--- a/crates/mcpkit-core/src/debug/recorder.rs
+++ b/crates/mcpkit-core/src/debug/recorder.rs
@@ -227,7 +227,7 @@ impl SessionRecorder {
     /// Check if recording is active.
     #[must_use]
     pub fn is_recording(&self) -> bool {
-        self.state.read().map(|s| s.recording).unwrap_or(false)
+        self.state.read().is_ok_and(|s| s.recording)
     }
 
     /// Stop recording.
@@ -295,7 +295,7 @@ impl SessionRecorder {
     /// Get the number of recorded events.
     #[must_use]
     pub fn event_count(&self) -> usize {
-        self.state.read().map(|s| s.events.len()).unwrap_or(0)
+        self.state.read().map_or(0, |s| s.events.len())
     }
 
     /// Finalize and return the recorded session.

--- a/crates/mcpkit-server/src/metrics.rs
+++ b/crates/mcpkit-server/src/metrics.rs
@@ -248,7 +248,7 @@ impl MetricsSnapshot {
     #[must_use]
     pub fn top_methods(&self, limit: usize) -> Vec<(&String, &MethodStats)> {
         let mut methods: Vec<_> = self.per_method.iter().collect();
-        methods.sort_by(|a, b| b.1.requests.cmp(&a.1.requests));
+        methods.sort_by_key(|m| std::cmp::Reverse(m.1.requests));
         methods.into_iter().take(limit).collect()
     }
 

--- a/crates/mcpkit-testing/src/client.rs
+++ b/crates/mcpkit-testing/src/client.rs
@@ -276,19 +276,19 @@ impl MockClient {
     /// Get pending request count.
     #[must_use]
     pub fn pending_count(&self) -> usize {
-        self.pending.read().map(|p| p.len()).unwrap_or(0)
+        self.pending.read().map_or(0, |p| p.len())
     }
 
     /// Get the total request count.
     #[must_use]
     pub fn request_count(&self) -> usize {
-        self.requests.read().map(|r| r.len()).unwrap_or(0)
+        self.requests.read().map_or(0, |r| r.len())
     }
 
     /// Get the total response count.
     #[must_use]
     pub fn response_count(&self) -> usize {
-        self.responses.read().map(|r| r.len()).unwrap_or(0)
+        self.responses.read().map_or(0, |r| r.len())
     }
 
     /// Clear all recorded data.

--- a/crates/mcpkit-testing/src/scenario.rs
+++ b/crates/mcpkit-testing/src/scenario.rs
@@ -462,25 +462,25 @@ impl MessageQueue {
     /// Check if there are pending outgoing messages.
     #[must_use]
     pub fn has_outgoing(&self) -> bool {
-        self.outgoing.read().map(|q| !q.is_empty()).unwrap_or(false)
+        self.outgoing.read().is_ok_and(|q| !q.is_empty())
     }
 
     /// Check if there are pending incoming messages.
     #[must_use]
     pub fn has_incoming(&self) -> bool {
-        self.incoming.read().map(|q| !q.is_empty()).unwrap_or(false)
+        self.incoming.read().is_ok_and(|q| !q.is_empty())
     }
 
     /// Get count of outgoing messages.
     #[must_use]
     pub fn outgoing_count(&self) -> usize {
-        self.outgoing.read().map(|q| q.len()).unwrap_or(0)
+        self.outgoing.read().map_or(0, |q| q.len())
     }
 
     /// Get count of incoming messages.
     #[must_use]
     pub fn incoming_count(&self) -> usize {
-        self.incoming.read().map(|q| q.len()).unwrap_or(0)
+        self.incoming.read().map_or(0, |q| q.len())
     }
 
     /// Clear all messages.

--- a/crates/mcpkit-transport/src/middleware/batching.rs
+++ b/crates/mcpkit-transport/src/middleware/batching.rs
@@ -259,7 +259,7 @@ impl<T: Transport> BatchingTransport<T> {
     /// Estimate the size of a message.
     fn estimate_size(msg: &Message) -> usize {
         // Simple estimate based on JSON serialization
-        serde_json::to_string(msg).map(|s| s.len()).unwrap_or(100)
+        serde_json::to_string(msg).map_or(100, |s| s.len())
     }
 }
 

--- a/crates/mcpkit-transport/src/middleware/rate_limit/mod.rs
+++ b/crates/mcpkit-transport/src/middleware/rate_limit/mod.rs
@@ -308,8 +308,7 @@ impl RateLimiter {
         self.store
             .get_stats(&self.key)
             .await
-            .map(|s| s.current_tokens)
-            .unwrap_or(0)
+            .map_or(0, |s| s.current_tokens)
     }
 
     /// Get statistics about rate limiting.


### PR DESCRIPTION
## Why
CI uses `dtolnay/rust-toolchain@stable`, which has advanced to **1.96** since the last green run (~1.92, Jan 2026). Newer clippy flags patterns the old one didn't. These were **masked by `Swatinem/rust-cache`** — a PR that doesn't invalidate the cache (e.g. #25) gets a cache hit and never re-runs clippy, while one that does (e.g. the dependency bump in #26) surfaces them. So `main` is latently clippy-red on current stable; this restores green.

## What
Mechanical, behavior-preserving rewrites (16 sites across 4 crates), all clippy-`--fix`/suggestion-driven:
- `map(f).unwrap_or(x)` → `map_or(x, f)` (`map_unwrap_or`)
- `map(f).unwrap_or(false)` → `is_ok_and(f)` (`unnecessary_map_or`)
- `sort_by(|a, b| b.k.cmp(&a.k))` → `sort_by_key(|m| Reverse(m.k))` (`unnecessary_sort_by`)

Crates touched: `mcpkit-core`, `mcpkit-transport`, `mcpkit-server`, `mcpkit-testing`. No public API or runtime behavior change.

## Verification (under stable 1.96 locally)
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` → **clean** (was 16 warnings).
- `cargo fmt --all --check` → clean.
- Tests for all 4 touched crates pass (incl. the `top_methods` sort).

Recommend landing this **first**; it unblocks #26 (whose clippy job is red purely from these pre-existing lints) and keeps the other PRs green as their caches rotate.