### PR TITLE
ci: pin Rust toolchain to 1.96 instead of @stable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
         with:
           components: rustfmt
       - run: cargo fmt --all -- --check
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-features --all-targets
 
@@ -103,7 +103,7 @@ jobs:
     needs: [fmt, clippy, check]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
 
@@ -118,7 +118,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
         with:
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
@@ -158,7 +158,7 @@ jobs:
     needs: [fmt, clippy, check]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
       - name: Build documentation
         run: cargo doc --no-deps --all-features
@@ -196,7 +196,7 @@ jobs:
         os: [macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
       # Use --features full instead of --all-features to exclude regenerate-proto
       # (protobuf-src fails to build on Windows due to abseil-cpp linker issues)
@@ -215,7 +215,7 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-semver-checks
         run: cargo install cargo-semver-checks --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
 
       - name: Extract version from tag
@@ -45,7 +45,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
 
       # Publish crates in dependency order

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
 
       - uses: Swatinem/rust-cache@v2
 
@@ -146,7 +146,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
 
       - uses: Swatinem/rust-cache@v2
 
@@ -190,7 +190,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
 
       - uses: Swatinem/rust-cache@v2
 
@@ -271,7 +271,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Why
CI used `dtolnay/rust-toolchain@stable`, so the toolchain — and the set of enforced clippy lints — silently advanced whenever a new stable Rust released (it had drifted ~1.92 → 1.96). Combined with `Swatinem/rust-cache`, this made green PRs break unpredictably: a PR that invalidated the cache would suddenly surface lints introduced by a newer clippy (this is exactly what happened with #26 → #28).

## What
Pin the **gating** workflows to a fixed minor version:
- `ci.yml`, `release.yml`, `stress-test.yml`: `dtolnay/rust-toolchain@stable` → `@1.96` (14 references).
- **Unchanged:** the MSRV job stays `@1.85`, and `fuzz.yml` stays `@nightly` (required by `cargo-fuzz`).

Now toolchain upgrades are a deliberate, reviewable one-line change rather than a surprise CI break. `@1.96` (minor) still picks up patch releases but not new-lint-bearing minor bumps.

No code or dependency changes; CI config only.

Based on top of #28, so `clippy -D warnings` under the pinned 1.96 is already clean.