### PR TITLE
fix(transport): enforce message-size limit during read to prevent OOM (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `time` → 0.3.47, `rsa` → 0.9.10, and `rand` → 0.8.6 / 0.9.3. The remaining
   advisories (`rsa` Marvin timing sidechannel and `rustls-pemfile` unmaintained)
   are dev-only/unfixed and already documented as ignores in `deny.toml`.
+- Newline-framed transports now enforce the message-size limit **during** the
+  read instead of after, so a peer that streams data without a newline can no
+  longer exhaust memory before the cap is checked
+  ([#7](https://github.com/praxiomlabs/mcpkit/issues/7)). Covers stdio, spawned
+  subprocess, Unix sockets, and Windows named pipes.
 
 ### Changed
 

--- a/crates/mcpkit-transport/src/runtime.rs
+++ b/crates/mcpkit-transport/src/runtime.rs
@@ -254,6 +254,14 @@ impl std::error::Error for TimeoutError {}
 
 use bytes::{Bytes, BytesMut};
 
+/// Default maximum size (16 MiB) of a single line/message accepted by
+/// [`BufReader::read_line_bytes`].
+///
+/// Matches the per-transport `MAX_MESSAGE_SIZE` constants. Reads that accumulate
+/// more than this without a newline are rejected during accumulation so a peer
+/// cannot exhaust memory.
+pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
 /// A runtime-agnostic buffered reader with zero-copy support.
 ///
 /// This implementation uses `BytesMut` internally for efficient buffer management
@@ -263,6 +271,7 @@ pub struct BufReader<R> {
     inner: R,
     buffer: BytesMut,
     capacity: usize,
+    max_message_size: usize,
 }
 
 impl<R> BufReader<R> {
@@ -277,7 +286,19 @@ impl<R> BufReader<R> {
             inner,
             buffer: BytesMut::with_capacity(capacity),
             capacity,
+            max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
         }
+    }
+
+    /// Set the maximum size of a single line/message.
+    ///
+    /// A read that accumulates more than this many bytes without encountering a
+    /// newline fails with [`io::ErrorKind::InvalidData`] instead of growing the
+    /// buffer without bound.
+    #[must_use]
+    pub const fn with_max_message_size(mut self, max_message_size: usize) -> Self {
+        self.max_message_size = max_message_size;
+        self
     }
 
     /// Get a reference to the underlying reader.
@@ -343,6 +364,21 @@ impl<R: AsyncRead + Unpin> BufReader<R> {
         let mut line_buf: Option<BytesMut> = None;
 
         loop {
+            // Enforce the maximum message size *during* accumulation so a peer
+            // that never sends a newline cannot exhaust memory. Each iteration
+            // reads at most `capacity` bytes, so the buffer can overshoot the
+            // limit by at most one chunk before this check fires.
+            let accumulated = line_buf.as_ref().map_or(0, BytesMut::len) + self.buffer.len();
+            if accumulated > self.max_message_size {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "incoming message exceeds maximum size of {} bytes",
+                        self.max_message_size
+                    ),
+                ));
+            }
+
             // Look for newline in current buffer
             if let Some(newline_pos) = self.buffer.iter().position(|&b| b == b'\n') {
                 // Found a newline - split the buffer at this position
@@ -511,6 +547,46 @@ mod tests {
         let eof = reader.read_line_bytes().await?;
         assert!(eof.is_empty());
         Ok(())
+    }
+
+    /// Regression test for #7: a line that exceeds `max_message_size` without a
+    /// newline must be rejected during accumulation, not buffered in full.
+    #[cfg(feature = "tokio-runtime")]
+    #[tokio::test]
+    async fn read_line_bytes_rejects_oversized_line() {
+        use futures::io::Cursor;
+
+        // 10_000 bytes, no newline, with a 100-byte cap and small read chunks.
+        let data = vec![b'a'; 10_000];
+        let cursor = Cursor::new(data);
+        let mut reader = BufReader::with_capacity(64, cursor).with_max_message_size(100);
+
+        let err = reader
+            .read_line_bytes()
+            .await
+            .expect_err("oversized line must be rejected");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+        // The buffer must not have grown anywhere near the full input: at most
+        // the cap plus one read chunk.
+        assert!(reader.buffered() <= 100 + 64);
+    }
+
+    /// A line at or below the limit (and with a trailing newline) is still read.
+    #[cfg(feature = "tokio-runtime")]
+    #[tokio::test]
+    async fn read_line_bytes_accepts_line_within_limit() {
+        use futures::io::Cursor;
+
+        let mut data = vec![b'a'; 90];
+        data.push(b'\n');
+        let cursor = Cursor::new(data);
+        let mut reader = BufReader::with_capacity(64, cursor).with_max_message_size(100);
+
+        let line = reader
+            .read_line_bytes()
+            .await
+            .expect("line within limit should be read");
+        assert_eq!(line.len(), 91);
     }
 
     /// Test that JSON can be parsed directly from `Bytes` without intermediate String.

--- a/crates/mcpkit-transport/src/stdio.rs
+++ b/crates/mcpkit-transport/src/stdio.rs
@@ -320,7 +320,14 @@ impl SyncStdioTransport {
             message: "stdin lock poisoned".to_string(),
         })?;
 
-        let bytes_read = stdin.read_line(&mut line)?;
+        // Bound the read to one byte past the limit so a peer that never sends a
+        // newline cannot grow `line` without bound before the size check below.
+        let bytes_read = {
+            use std::io::Read as _;
+            (&mut *stdin)
+                .take(MAX_MESSAGE_SIZE as u64 + 1)
+                .read_line(&mut line)?
+        };
 
         if bytes_read == 0 {
             self.connected.store(false, Ordering::SeqCst);

--- a/crates/mcpkit-transport/src/unix.rs
+++ b/crates/mcpkit-transport/src/unix.rs
@@ -36,7 +36,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 #[cfg(feature = "tokio-runtime")]
 use tokio::{
-    io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter},
+    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader, BufWriter},
     net::{UnixListener as TokioUnixListener, UnixStream},
 };
 
@@ -297,10 +297,18 @@ impl Transport for UnixTransport {
         // Clear the buffer and read a line
         state.line_buffer.clear();
 
-        // We need to read into a separate buffer to avoid borrow issues
+        // We need to read into a separate buffer to avoid borrow issues.
+        // Bound the read to one byte past the limit so a peer that never sends a
+        // newline cannot grow `line_buffer` without bound; the size check below
+        // then rejects it. Without this, `read_line` would buffer unboundedly
+        // before the post-read check could fire.
+        let max = self.config.max_message_size;
         let (result, reader) = {
             let mut reader = reader;
-            let result = reader.read_line(&mut state.line_buffer).await;
+            let result = {
+                let mut limited = (&mut reader).take(max as u64 + 1);
+                limited.read_line(&mut state.line_buffer).await
+            };
             (result, reader)
         };
 
@@ -633,6 +641,31 @@ mod tests {
         let path = socket.to_path();
         assert_eq!(path[0], 0u8);
         assert_eq!(&path[1..], b"mcp-test");
+    }
+
+    /// Regression test for #7: a peer that sends more than `max_message_size`
+    /// without a newline must get a `MessageTooLarge` error rather than causing
+    /// `read_line` to buffer the input without bound.
+    #[cfg(feature = "tokio-runtime")]
+    #[tokio::test]
+    async fn recv_rejects_oversized_line() {
+        let (server_stream, mut client_stream) = UnixStream::pair().expect("socketpair");
+        let config = UnixSocketConfig::new("/unused").with_max_message_size(1024);
+        let transport = UnixTransport::from_stream(config, server_stream, true);
+
+        // Client sends 8 KiB with no newline and keeps the stream open.
+        let writer = tokio::spawn(async move {
+            let data = vec![b'a'; 8192];
+            let _ = client_stream.write_all(&data).await;
+            tokio::time::sleep(std::time::Duration::from_secs(30)).await;
+        });
+
+        let result = transport.recv().await;
+        assert!(
+            matches!(result, Err(TransportError::MessageTooLarge { .. })),
+            "oversized line must be rejected, got {result:?}"
+        );
+        writer.abort();
     }
 
     /// Integration test: Test Unix socket client-server communication.

--- a/crates/mcpkit-transport/src/windows.rs
+++ b/crates/mcpkit-transport/src/windows.rs
@@ -377,6 +377,21 @@ impl NamedPipeTransport {
         })?;
         state.line_buffer.push_str(chunk);
 
+        // Reject a partial line that already exceeds the limit without a
+        // newline, so `line_buffer` cannot grow without bound across recv calls.
+        // Drop the accumulated data so a stuck oversized stream doesn't keep
+        // growing the buffer on every subsequent read.
+        if state.line_buffer.len() > self.config.max_message_size
+            && !state.line_buffer.contains('\n')
+        {
+            let size = state.line_buffer.len();
+            state.line_buffer.clear();
+            return Err(TransportError::MessageTooLarge {
+                size,
+                max: self.config.max_message_size,
+            });
+        }
+
         // Check if we now have a complete line
         if let Some(newline_pos) = state.line_buffer.find('\n') {
             let line = state.line_buffer[..newline_pos].to_string();


### PR DESCRIPTION
Closes #7.

## Problem
Every newline-framed transport read the **entire** incoming line into memory and only checked `MAX_MESSAGE_SIZE` *after* the read returned. A peer that streams gigabytes with no newline OOMs the process before the cap is ever evaluated (`read_line_bytes` / tokio `read_line` / the Windows `line_buffer` all accumulate without bound).

## Fix — move the cap *inside* the read
- **`runtime::BufReader::read_line_bytes`** (used by **stdio** and **spawned-subprocess** transports) gains a configurable `max_message_size` (default 16 MiB, matching the existing constants) and errors with `InvalidData` once accumulation exceeds it. Overshoot is bounded to one read chunk.
- **Unix sockets**: wrap `read_line` in `.take(max + 1)` so the existing post-read size check fires on bounded input.
- **Windows named pipes**: reject (and drop) a partial line that exceeds the limit without a newline, instead of growing `line_buffer` across `recv` calls.
- **Sync stdio** (`recv_sync`): bound the `std` `read_line` with `Read::take`.

No public behavior change for normal-sized messages; oversized messages now fail fast with a bounded memory footprint.

## Tests
- `read_line_bytes_rejects_oversized_line` + `read_line_bytes_accepts_line_within_limit` (covers stdio + spawn, the shared path), asserting the error **and** that the buffer didn't grow past `cap + chunk`.
- `recv_rejects_oversized_line` — end-to-end Unix socketpair test: 8 KiB no-newline payload against a 1 KiB cap → `MessageTooLarge`, no hang.
- Windows + sync-stdio bounds are compile-verified (incl. a Windows cross-compile) and use the same `take`/cap pattern.

Local gate (stable 1.96): full `mcpkit-transport` suite (237 tests) green, `clippy --all-features --all-targets -D warnings` clean, fmt + doc clean, Windows cross-compile clean.