### PR TITLE
fix(server): park cancellation future instead of busy-spinning (#8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `Context::cancelled()` no longer busy-spins at 100% CPU while waiting
+  ([#8](https://github.com/praxiomlabs/mcpkit/issues/8)). The cancellation
+  future now parks on an `event_listener::Event` and is woken by `cancel()`,
+  instead of re-waking itself on every poll.
 - Connection pool no longer leaks `in_use` capacity
   ([#6](https://github.com/praxiomlabs/mcpkit/issues/6)). A failing connection
   factory now rolls back its reserved slot, and dropping a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ name = "mcpkit-server"
 version = "0.5.0"
 dependencies = [
  "chrono",
+ "event-listener",
  "futures",
  "mcpkit-core",
  "mcpkit-transport",

--- a/crates/mcpkit-server/Cargo.toml
+++ b/crates/mcpkit-server/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 futures = { workspace = true }
+event-listener = "5.4"
 tokio = { version = "1", features = ["sync", "rt"], optional = true }
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/mcpkit-server/src/context.rs
+++ b/crates/mcpkit-server/src/context.rs
@@ -51,6 +51,9 @@ use std::future::Future;
 use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::task::{Context as TaskContext, Poll};
+
+use event_listener::Event;
 
 /// Trait for sending messages to the peer (client or server).
 ///
@@ -66,11 +69,12 @@ pub trait Peer: Send + Sync {
 
 /// A cancellation token for tracking request cancellation.
 ///
-/// This is a simple wrapper around an atomic boolean that can be
-/// shared across threads and checked for cancellation.
-#[derive(Debug, Clone)]
+/// Wraps an atomic flag plus an [`event_listener::Event`] so waiters can park
+/// until cancellation instead of busy-polling the flag.
+#[derive(Clone)]
 pub struct CancellationToken {
     cancelled: Arc<AtomicBool>,
+    event: Arc<Event>,
 }
 
 impl CancellationToken {
@@ -79,6 +83,7 @@ impl CancellationToken {
     pub fn new() -> Self {
         Self {
             cancelled: Arc::new(AtomicBool::new(false)),
+            event: Arc::new(Event::new()),
         }
     }
 
@@ -91,20 +96,26 @@ impl CancellationToken {
     /// Request cancellation.
     pub fn cancel(&self) {
         self.cancelled.store(true, Ordering::SeqCst);
+        // Wake every task currently waiting in `cancelled()`.
+        self.event.notify(usize::MAX);
     }
 
     /// Wait for cancellation.
     ///
-    /// Returns a future that completes when cancellation is requested.
-    ///
-    /// Note: In a production implementation, this would integrate with the
-    /// runtime's notification system. This simple implementation polls
-    /// the atomic flag.
+    /// Returns a future that completes when cancellation is requested. The
+    /// future parks on an [`event_listener::Event`] and is woken by
+    /// [`cancel`](Self::cancel); it does not busy-poll.
     #[must_use]
     pub fn cancelled(&self) -> CancelledFuture {
-        CancelledFuture {
-            cancelled: self.cancelled.clone(),
-        }
+        CancelledFuture::new(self.cancelled.clone(), self.event.clone())
+    }
+}
+
+impl std::fmt::Debug for CancellationToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CancellationToken")
+            .field("cancelled", &self.is_cancelled())
+            .finish()
     }
 }
 
@@ -115,25 +126,41 @@ impl Default for CancellationToken {
 }
 
 /// A future that completes when cancellation is requested.
+///
+/// Parks on the token's [`event_listener::Event`] until cancellation, rather
+/// than waking itself on every poll.
 pub struct CancelledFuture {
-    cancelled: Arc<AtomicBool>,
+    inner: Pin<Box<dyn Future<Output = ()> + Send>>,
+}
+
+impl CancelledFuture {
+    fn new(cancelled: Arc<AtomicBool>, event: Arc<Event>) -> Self {
+        Self {
+            inner: Box::pin(async move {
+                loop {
+                    if cancelled.load(Ordering::SeqCst) {
+                        return;
+                    }
+                    // Register a listener *before* the final flag check so a
+                    // `cancel()` that races with us cannot be missed: if it set
+                    // the flag after our first check, the re-check below catches
+                    // it; if it fires after, the listener is woken.
+                    let listener = event.listen();
+                    if cancelled.load(Ordering::SeqCst) {
+                        return;
+                    }
+                    listener.await;
+                }
+            }),
+        }
+    }
 }
 
 impl Future for CancelledFuture {
     type Output = ();
 
-    fn poll(
-        self: Pin<&mut Self>,
-        cx: &mut std::task::Context<'_>,
-    ) -> std::task::Poll<Self::Output> {
-        if self.cancelled.load(Ordering::SeqCst) {
-            std::task::Poll::Ready(())
-        } else {
-            // Wake up later to check again
-            // In production, this would register with a proper notification system
-            cx.waker().wake_by_ref();
-            std::task::Poll::Pending
-        }
+    fn poll(mut self: Pin<&mut Self>, cx: &mut TaskContext<'_>) -> Poll<Self::Output> {
+        self.inner.as_mut().poll(cx)
     }
 }
 
@@ -380,6 +407,63 @@ mod tests {
         assert!(!token.is_cancelled());
         token.cancel();
         assert!(token.is_cancelled());
+    }
+
+    /// Regression test for #8: `cancelled()` must park on a waker instead of
+    /// busy-spinning (the old impl called `wake_by_ref()` on every poll). We
+    /// poll with a waker that counts wake-ups and assert the future does not
+    /// wake itself, then that `cancel()` wakes it and it resolves.
+    #[test]
+    fn cancelled_future_parks_and_wakes_on_cancel() {
+        use std::sync::atomic::AtomicUsize;
+        use std::task::{Wake, Waker};
+
+        struct CountingWaker(AtomicUsize);
+        impl Wake for CountingWaker {
+            fn wake(self: Arc<Self>) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+            fn wake_by_ref(self: &Arc<Self>) {
+                self.0.fetch_add(1, Ordering::SeqCst);
+            }
+        }
+
+        let counter = Arc::new(CountingWaker(AtomicUsize::new(0)));
+        let waker = Waker::from(counter.clone());
+        let mut cx = TaskContext::from_waker(&waker);
+
+        let token = CancellationToken::new();
+        let mut fut = Box::pin(token.cancelled());
+
+        // First poll: not cancelled -> must be Pending and must NOT have woken
+        // itself (a busy-spin would wake immediately).
+        assert_eq!(fut.as_mut().poll(&mut cx), Poll::Pending);
+        assert_eq!(
+            counter.0.load(Ordering::SeqCst),
+            0,
+            "cancelled future must park, not busy-spin (no self-wake)"
+        );
+
+        // Cancelling wakes the registered waker and the future resolves.
+        token.cancel();
+        assert!(
+            counter.0.load(Ordering::SeqCst) >= 1,
+            "cancel() must wake the parked waiter"
+        );
+        assert_eq!(fut.as_mut().poll(&mut cx), Poll::Ready(()));
+    }
+
+    /// A token already cancelled before `cancelled()` is awaited resolves
+    /// immediately.
+    #[test]
+    fn cancelled_future_ready_when_already_cancelled() {
+        let waker = std::task::Waker::noop();
+        let mut cx = TaskContext::from_waker(waker);
+
+        let token = CancellationToken::new();
+        token.cancel();
+        let mut fut = Box::pin(token.cancelled());
+        assert_eq!(fut.as_mut().poll(&mut cx), Poll::Ready(()));
     }
 
     #[test]


### PR DESCRIPTION
Closes #8.

## Problem
`CancelledFuture::poll` (context.rs) called `cx.waker().wake_by_ref()` and returned `Pending` on every poll while the token was uncancelled. That re-schedules the task immediately, so any handler awaiting `ctx.cancelled()` **pegs a CPU core** until cancellation fires. The code comment even acknowledged it ("In production, this would register with a proper notification system").

## Fix
Back `CancellationToken` with an `event_listener::Event` — the same runtime-agnostic primitive the transport layer already uses (`runtime::Notify = event_listener::Event`), so no new runtime coupling:
- `cancel()` sets the atomic flag **and** `event.notify(usize::MAX)`.
- `cancelled()` returns a future that registers a listener and parks (`listener.await`), re-checking the flag after registering to avoid a lost-wakeup race.

Public API unchanged (`CancellationToken` keeps `Debug`/`Clone`; `CancelledFuture` keeps its name and is constructed only via `cancelled()`).

## Tests
- `cancelled_future_parks_and_wakes_on_cancel` — polls with a **wake-counting** waker and asserts the future does **not** wake itself (the old busy-spin would), then that `cancel()` wakes it and it resolves. Runtime-free, so no hang risk.
- `cancelled_future_ready_when_already_cancelled` — already-cancelled fast path.
- Existing async cancellation tests (wait-for-cancellation, multiple waiters, etc.) still pass, confirming end-to-end behavior in a real runtime.

Local gate (1.96): `mcpkit-server` suite green, clippy `-D warnings` + fmt + doc clean.

Note: this fixes the CPU busy-spin specifically. The separate concern that cancellation can't be observed mid-request under the serial handler loop is tracked in #9 (panic isolation / concurrency).