### PR TITLE
ci: stop running benchmarks on every PR; cancel superseded runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,13 @@ on:
   pull_request:
     branches: [main, master]
 
+# Cancel superseded in-progress runs for the same PR/branch so rapid pushes
+# don't pile up and contend for runners. Pushes to the default branch are not
+# cancelled (so post-merge runs always complete).
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -20,13 +20,10 @@ on:
         required: false
         default: 'false'
         type: boolean
-  # Run on PRs that modify benchmarks or core performance code
-  pull_request:
-    paths:
-      - 'benches/**'
-      - 'crates/mcpkit-core/src/**'
-      - 'crates/mcpkit-transport/src/**'
-      - 'crates/mcpkit-server/src/**'
+  # NOTE: benchmarks intentionally do NOT run on pull_request. Criterion timings
+  # on shared CI runners are too noisy to gate PRs on, and a full run adds ~18
+  # minutes per PR. Run them on the weekly schedule or manually via
+  # workflow_dispatch instead.
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Investigated the slow PR checks you flagged. Findings + fix.

## What's slow, and why
Authoritative per-job times (`gh pr checks`):

| Check | Time | Verdict |
|---|---|---|
| **Criterion Benchmarks** | **~18 min** | misconfigured for PRs |
| Code Coverage | 8.5 min | expected (instruments + re-runs tests; informational) |
| Test (windows/macos) | 8–9 min | expected (cross-platform build+test) |
| Semver Check | 5.5 min | expected (builds the API twice to diff) |
| Check / Clippy / Test Suite | 3–6 min | expected (workspace compile) |

The outlier is **Criterion Benchmarks**: `stress-test.yml` triggered on `pull_request` for any change under `crates/*/src/**` or `benches/**`, then ran 5 suites at full sampling. Benchmark timings on shared GitHub runners are noisy, so the "Regression Check" signal on PRs isn't trustworthy — it was ~18 min of unreliable data per PR.

Separately, **no workflow had a `concurrency` group**, so every push (including the force-push rebases during this issue sweep) started a *fresh* full run without cancelling the prior one, compounding runner queue contention.

## Change
- **Remove the `pull_request` trigger from `stress-test.yml`.** Benchmarks still run weekly (`schedule`) and on-demand (`workflow_dispatch`). PRs no longer pay the ~18 min + 4 heavy jobs.
- **Add a `concurrency` group to `ci.yml`** that cancels superseded in-progress runs for the same PR/branch; default-branch pushes are not cancelled.

CI-config only; no code changes. Coverage (8.5m) and Semver (5.5m) are left as-is — they're slower than ideal but expected for what they do and don't block merges.