### PR TITLE
fix(auth): enforce JWT required_claims on the verifying path (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- JWT `required_claims` are now actually enforced by the signature-verifying
+  validator ([#10](https://github.com/praxiomlabs/mcpkit/issues/10)). Previously
+  custom claims were silently ignored and configuring any `required_claims`
+  dropped the default `exp`-presence requirement (a per-item
+  `set_required_spec_claims` loop that only handled registered claims and
+  replaced the set). Required claims are now checked on the decoded token.
 - A panicking request handler no longer tears down the whole connection
   ([#9](https://github.com/praxiomlabs/mcpkit/issues/9)). Each request runs with
   panic isolation; a panic is caught and returned as a JSON-RPC internal error,

--- a/crates/mcpkit-core/src/auth/jwt.rs
+++ b/crates/mcpkit-core/src/auth/jwt.rs
@@ -507,10 +507,23 @@ pub fn validate_claims(claims: &TokenClaims, validation: &TokenValidation) -> Re
     }
 
     // Validate required custom claims
-    for claim_name in &validation.required_claims {
-        if !claims.extra.contains_key(claim_name) {
-            // Check standard claims too
-            let has_claim = match claim_name.as_str() {
+    check_required_claims(claims, &validation.required_claims)?;
+
+    Ok(())
+}
+
+/// Ensure every configured required claim is present on the token.
+///
+/// Checks custom claims (in `extra`) as well as the registered claims, so
+/// `required_claims` works for arbitrary names. We enforce this ourselves
+/// rather than delegating to `jsonwebtoken::Validation::set_required_spec_claims`,
+/// which only understands the five registered claims and *replaces* (rather
+/// than extends) the required set — silently ignoring custom claims and
+/// dropping the default `exp`-presence requirement.
+fn check_required_claims(claims: &TokenClaims, required: &[String]) -> Result<(), JwtError> {
+    for claim_name in required {
+        let present = claims.extra.contains_key(claim_name)
+            || match claim_name.as_str() {
                 "iss" => claims.iss.is_some(),
                 "sub" => claims.sub.is_some(),
                 "aud" => claims.aud.is_some(),
@@ -521,14 +534,12 @@ pub fn validate_claims(claims: &TokenClaims, validation: &TokenValidation) -> Re
                 "scope" => claims.scope.is_some(),
                 _ => false,
             };
-            if !has_claim {
-                return Err(JwtError::MissingClaim {
-                    claim: claim_name.clone(),
-                });
-            }
+        if !present {
+            return Err(JwtError::MissingClaim {
+                claim: claim_name.clone(),
+            });
         }
     }
-
     Ok(())
 }
 
@@ -648,10 +659,11 @@ fn build_jwt_validation(
     // Set expiration validation
     jwt_validation.validate_exp = validation.validate_exp;
 
-    // Add required claims
-    for claim in &validation.required_claims {
-        jwt_validation.set_required_spec_claims(&[claim.as_str()]);
-    }
+    // Required custom claims are enforced after decoding (see
+    // `check_required_claims` in `validate_token`). We deliberately do not call
+    // `set_required_spec_claims` here: it only handles registered claims and
+    // replaces the required set, which would silently drop the default
+    // `exp`-presence requirement.
 
     jwt_validation
 }
@@ -758,7 +770,8 @@ pub fn validate_token(
             },
         })?;
 
-    // Additional scope validation (jsonwebtoken doesn't handle this)
+    // Additional validation jsonwebtoken doesn't handle: required scopes and
+    // required custom claims.
     let claims = token_data.claims;
     for required_scope in &validation.required_scopes {
         if !claims.has_scope(required_scope) {
@@ -767,6 +780,7 @@ pub fn validate_token(
             });
         }
     }
+    check_required_claims(&claims, &validation.required_claims)?;
 
     Ok(claims)
 }
@@ -1315,6 +1329,94 @@ mod signature_tests {
 
         let validated_claims = result.unwrap();
         assert_eq!(validated_claims.sub, Some("user123".to_string()));
+    }
+
+    /// Regression test for #10: custom required claims must actually be
+    /// enforced by the signature-verifying path (the old code delegated to
+    /// `set_required_spec_claims`, which ignores non-registered claims and
+    /// dropped the default `exp` requirement).
+    #[test]
+    fn test_validate_token_enforces_custom_required_claims() {
+        use base64::Engine;
+        use p256::ecdsa::{SigningKey, VerifyingKey};
+        use p256::elliptic_curve::sec1::ToEncodedPoint;
+        use p256::pkcs8::EncodePrivateKey as EcEncodePrivateKey;
+        use rand::rngs::OsRng;
+
+        let signing_key = SigningKey::random(&mut OsRng);
+        let verifying_key = VerifyingKey::from(&signing_key);
+        let point = verifying_key.as_affine().to_encoded_point(false);
+        let x = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(point.x().expect("x"));
+        let y = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(point.y().expect("y"));
+
+        let jwks = JwksSet {
+            keys: vec![Jwk {
+                kty: "EC".to_string(),
+                kid: Some("ec-1".to_string()),
+                key_use: Some("sig".to_string()),
+                alg: Some("ES256".to_string()),
+                n: None,
+                e: None,
+                crv: Some("P-256".to_string()),
+                x: Some(x),
+                y: Some(y),
+            }],
+        };
+        let pkcs8 = signing_key.to_pkcs8_der().expect("encode EC key");
+        let encoding_key = jsonwebtoken::EncodingKey::from_ec_der(pkcs8.as_bytes());
+
+        let validation = TokenValidation::new()
+            .with_issuer("https://auth.example.com")
+            .with_audience("https://mcp.example.com")
+            .with_required_claim("tenant_id");
+
+        // A signed, otherwise-valid token WITHOUT the custom claim must be
+        // rejected (the old code accepted it).
+        let token = create_test_jwt(
+            jsonwebtoken::Algorithm::ES256,
+            &encoding_key,
+            Some("ec-1"),
+            &make_test_claims(),
+        );
+        match validate_token(&token, &jwks, &validation) {
+            Err(JwtError::MissingClaim { claim }) => assert_eq!(claim.as_str(), "tenant_id"),
+            other => panic!("expected MissingClaim(tenant_id), got {other:?}"),
+        }
+
+        // The same token WITH the custom claim present is accepted.
+        let mut claims = make_test_claims();
+        claims
+            .extra
+            .insert("tenant_id".to_string(), serde_json::json!("acme"));
+        let token = create_test_jwt(
+            jsonwebtoken::Algorithm::ES256,
+            &encoding_key,
+            Some("ec-1"),
+            &claims,
+        );
+        assert!(
+            validate_token(&token, &jwks, &validation).is_ok(),
+            "token with the required custom claim should validate"
+        );
+
+        // Configuring a custom required claim must NOT drop the default
+        // exp-presence requirement: a token with the claim but no `exp` is
+        // still rejected.
+        let mut claims = make_test_claims();
+        claims
+            .extra
+            .insert("tenant_id".to_string(), serde_json::json!("acme"));
+        claims.exp = None;
+        let token = create_test_jwt(
+            jsonwebtoken::Algorithm::ES256,
+            &encoding_key,
+            Some("ec-1"),
+            &claims,
+        );
+        assert!(
+            validate_token(&token, &jwks, &validation).is_err(),
+            "missing exp must still be rejected when required_claims is set"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #10.

## Problem
`build_jwt_validation` set required claims in a loop:

```rust
for claim in &validation.required_claims {
    jwt_validation.set_required_spec_claims(&[claim.as_str()]);
}
```

`set_required_spec_claims` **replaces** the required set rather than extending it, and jsonwebtoken only enforces presence of the five **registered** claims. Two defects in the signature-verifying path (`validate_token`):
1. Only the **last** claim survived the loop, and it overwrote the default `{"exp"}` — so configuring any `required_claims` silently **dropped the exp-presence requirement**.
2. Custom claims (e.g. `tenant_id`) hit jsonwebtoken's `_ => continue` and were **never enforced**.

(The separate `validate_claims` helper already checked these correctly, but `validate_token` doesn't use it.)

## Fix
- Extract the correct presence check into a shared `check_required_claims` helper (covers custom `extra` claims and the registered claims), used by both `validate_claims` and `validate_token`.
- Call it in `validate_token` after signature verification.
- Drop the broken `set_required_spec_claims` loop from `build_jwt_validation`, which restores jsonwebtoken's default `exp`-presence requirement.

## Test
`test_validate_token_enforces_custom_required_claims` (ES256, signature path):
- token without the required custom claim → `MissingClaim("tenant_id")`,
- same token with the claim present → validates,
- with `required_claims` set, a token missing `exp` is still rejected (the default guard isn't dropped).

Local gate (1.96): `mcpkit-core` suite green, clippy `-D warnings` + fmt clean.