### PR TITLE
fix(transport): per-key buckets in the default rate limiter (#11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The default in-memory rate limiter now isolates clients per key
+  ([#11](https://github.com/praxiomlabs/mcpkit/issues/11)). `InMemoryStore`
+  previously used a single global bucket and ignored the key, so one noisy
+  client throttled everyone. It now keeps an independent bucket per key, bounded
+  by an LRU-evicted map (default 10,000 keys) to cap memory.
 - JWT `required_claims` are now actually enforced by the signature-verifying
   validator ([#10](https://github.com/praxiomlabs/mcpkit/issues/10)). Previously
   custom claims were silently ignored and configuring any `required_claims`

--- a/crates/mcpkit-transport/src/middleware/rate_limit/store.rs
+++ b/crates/mcpkit-transport/src/middleware/rate_limit/store.rs
@@ -45,6 +45,7 @@
 use super::{RateLimitAlgorithm, RateLimitConfig};
 use async_lock::Mutex;
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
@@ -164,37 +165,63 @@ pub trait RateLimitStore: Send + Sync {
     async fn reset(&self, key: &str) -> Result<(), RateLimitStoreError>;
 }
 
-/// In-memory rate limit store using atomic operations.
+/// Default maximum number of distinct keys tracked before the
+/// least-recently-used bucket is evicted, bounding memory under many clients.
+const DEFAULT_MAX_KEYS: usize = 10_000;
+
+/// Per-key rate-limit state.
+struct Bucket {
+    /// Token bucket: current token count (scaled by 1000 for precision).
+    tokens: u64,
+    /// Token bucket: last refill time.
+    last_refill: Instant,
+    /// Sliding window: request timestamps.
+    request_times: Vec<Instant>,
+    /// Fixed window: request count in the current window.
+    window_count: u64,
+    /// Fixed window: window start time.
+    window_start: Instant,
+    /// When this bucket was last accessed (for LRU eviction).
+    last_seen: Instant,
+}
+
+impl Bucket {
+    fn new(config: &RateLimitConfig, now: Instant) -> Self {
+        Self {
+            // Start with a full bucket (scaled by 1000 for sub-token precision).
+            tokens: config.burst_size * 1000,
+            last_refill: now,
+            request_times: Vec::new(),
+            window_count: 0,
+            window_start: now,
+            last_seen: now,
+        }
+    }
+}
+
+/// In-memory rate limit store with independent per-key buckets.
 ///
 /// This is the default store implementation, suitable for single-process
-/// deployments. For distributed systems, implement a custom store using
-/// Redis or similar.
-///
-/// # Thread Safety
-///
-/// Uses atomic operations and async mutexes for thread-safe access.
+/// deployments. Each key (e.g. client IP) gets its own bucket, so one client
+/// cannot exhaust another's budget. For distributed systems, implement a custom
+/// store using Redis or similar.
 ///
 /// # Memory Usage
 ///
-/// Currently uses a single global bucket. For per-client rate limiting,
-/// consider using a distributed store or extending this implementation.
+/// Buckets are tracked in a map bounded to `max_keys` (default 10,000); once
+/// full, the least-recently-used bucket is evicted when a new key arrives, so
+/// the map cannot grow without bound.
 pub struct InMemoryStore {
-    /// Token bucket: current token count (scaled by 1000 for precision).
-    tokens: AtomicU64,
-    /// Last refill time.
-    last_refill: Mutex<Instant>,
-    /// Sliding window: request timestamps.
-    request_times: Mutex<Vec<Instant>>,
-    /// Fixed window: request count in current window.
-    window_count: AtomicU64,
-    /// Fixed window: window start time.
-    window_start: Mutex<Instant>,
-    /// Total requests tracked (for metrics).
-    total_requests: AtomicU64,
-    /// Total rejected requests (for metrics).
-    total_rejected: AtomicU64,
-    /// Configuration snapshot for token bucket sizing.
+    /// Per-key buckets, guarded by a single async mutex.
+    buckets: Mutex<HashMap<String, Bucket>>,
+    /// Maximum number of keys retained before LRU eviction.
+    max_keys: usize,
+    /// Burst size, used to report stats for keys without a live bucket.
     burst_size: u64,
+    /// Total requests tracked across all keys (for metrics).
+    total_requests: AtomicU64,
+    /// Total rejected requests across all keys (for metrics).
+    total_rejected: AtomicU64,
 }
 
 impl InMemoryStore {
@@ -202,54 +229,49 @@ impl InMemoryStore {
     #[must_use]
     pub fn new(config: &RateLimitConfig) -> Self {
         Self {
-            // Start with full bucket (scaled by 1000 for sub-token precision)
-            tokens: AtomicU64::new(config.burst_size * 1000),
-            last_refill: Mutex::new(Instant::now()),
-            request_times: Mutex::new(Vec::with_capacity(config.max_requests as usize)),
-            window_count: AtomicU64::new(0),
-            window_start: Mutex::new(Instant::now()),
+            buckets: Mutex::new(HashMap::new()),
+            max_keys: DEFAULT_MAX_KEYS,
+            burst_size: config.burst_size,
             total_requests: AtomicU64::new(0),
             total_rejected: AtomicU64::new(0),
-            burst_size: config.burst_size,
         }
     }
 
-    /// Token bucket algorithm implementation.
-    async fn check_token_bucket(&self, config: &RateLimitConfig) -> RateLimitDecision {
-        let now = Instant::now();
+    /// Evict the least-recently-used bucket to stay within `max_keys`.
+    fn evict_lru(buckets: &mut HashMap<String, Bucket>) {
+        if let Some(key) = buckets
+            .iter()
+            .min_by_key(|(_, b)| b.last_seen)
+            .map(|(k, _)| k.clone())
+        {
+            buckets.remove(&key);
+        }
+    }
 
-        // Refill tokens based on elapsed time
-        let mut last_refill = self.last_refill.lock().await;
-
-        let elapsed = now.duration_since(*last_refill);
+    /// Token bucket algorithm, operating on a single key's bucket.
+    fn check_token_bucket(
+        bucket: &mut Bucket,
+        config: &RateLimitConfig,
+        now: Instant,
+    ) -> RateLimitDecision {
+        // Refill tokens based on elapsed time.
+        let elapsed = now.duration_since(bucket.last_refill);
         let refill_rate = config.max_requests as f64 / config.window.as_millis() as f64;
         let tokens_to_add = (elapsed.as_millis() as f64 * refill_rate * 1000.0) as u64;
 
         if tokens_to_add > 0 {
-            let current = self.tokens.load(Ordering::Relaxed);
             let max_tokens = config.burst_size * 1000;
-            let new_tokens = (current + tokens_to_add).min(max_tokens);
-            self.tokens.store(new_tokens, Ordering::Relaxed);
-            *last_refill = now;
+            bucket.tokens = (bucket.tokens + tokens_to_add).min(max_tokens);
+            bucket.last_refill = now;
         }
 
-        // Try to consume a token (1000 units = 1 token)
-        let result = self
-            .tokens
-            .fetch_update(Ordering::SeqCst, Ordering::Relaxed, |current| {
-                if current >= 1000 {
-                    Some(current - 1000)
-                } else {
-                    None
-                }
-            });
-
-        if let Ok(new_value) = result {
+        // Try to consume a token (1000 units = 1 token).
+        if bucket.tokens >= 1000 {
+            bucket.tokens -= 1000;
             RateLimitDecision::Allowed {
-                remaining: new_value / 1000,
+                remaining: bucket.tokens / 1000,
             }
         } else {
-            // Calculate retry_after based on refill rate
             let wait_ms = (1000.0 / refill_rate).max(1.0) as u64;
             RateLimitDecision::Denied {
                 retry_after: Duration::from_millis(wait_ms),
@@ -257,25 +279,26 @@ impl InMemoryStore {
         }
     }
 
-    /// Sliding window algorithm implementation.
-    async fn check_sliding_window(&self, config: &RateLimitConfig) -> RateLimitDecision {
-        let now = Instant::now();
+    /// Sliding window algorithm, operating on a single key's bucket.
+    fn check_sliding_window(
+        bucket: &mut Bucket,
+        config: &RateLimitConfig,
+        now: Instant,
+    ) -> RateLimitDecision {
         let window_start = now.checked_sub(config.window);
 
-        let mut times = self.request_times.lock().await;
+        // Remove requests outside the window.
+        bucket
+            .request_times
+            .retain(|&t| window_start.is_none_or(|start| t > start));
 
-        // Remove requests outside the window
-        times.retain(|&t| window_start.is_none_or(|start| t > start));
-
-        // Check if we're under the limit
-        if times.len() < config.max_requests as usize {
-            times.push(now);
+        if bucket.request_times.len() < config.max_requests as usize {
+            bucket.request_times.push(now);
             RateLimitDecision::Allowed {
-                remaining: config.max_requests - times.len() as u64,
+                remaining: config.max_requests - bucket.request_times.len() as u64,
             }
         } else {
-            // Estimate when the oldest request will expire
-            let oldest = times.first().copied();
+            let oldest = bucket.request_times.first().copied();
             let retry_after = oldest
                 .and_then(|t| (t + config.window).checked_duration_since(now))
                 .unwrap_or(config.window);
@@ -283,30 +306,29 @@ impl InMemoryStore {
         }
     }
 
-    /// Fixed window algorithm implementation.
-    async fn check_fixed_window(&self, config: &RateLimitConfig) -> RateLimitDecision {
-        let now = Instant::now();
-
-        let mut window_start = self.window_start.lock().await;
-
-        // Check if we need to start a new window
-        if now.duration_since(*window_start) >= config.window {
-            *window_start = now;
-            self.window_count.store(1, Ordering::Relaxed);
+    /// Fixed window algorithm, operating on a single key's bucket.
+    fn check_fixed_window(
+        bucket: &mut Bucket,
+        config: &RateLimitConfig,
+        now: Instant,
+    ) -> RateLimitDecision {
+        // Start a new window if the current one has elapsed.
+        if now.duration_since(bucket.window_start) >= config.window {
+            bucket.window_start = now;
+            bucket.window_count = 1;
             return RateLimitDecision::Allowed {
                 remaining: config.max_requests - 1,
             };
         }
 
-        // Increment count and check limit
-        let count = self.window_count.fetch_add(1, Ordering::Relaxed) + 1;
+        bucket.window_count += 1;
+        let count = bucket.window_count;
         if count <= config.max_requests {
             RateLimitDecision::Allowed {
                 remaining: config.max_requests - count,
             }
         } else {
-            // Calculate time until window resets
-            let elapsed = now.duration_since(*window_start);
+            let elapsed = now.duration_since(bucket.window_start);
             let retry_after = config.window.saturating_sub(elapsed);
             RateLimitDecision::Denied { retry_after }
         }
@@ -317,16 +339,30 @@ impl InMemoryStore {
 impl RateLimitStore for InMemoryStore {
     async fn check_and_consume(
         &self,
-        _key: &str, // In-memory store uses global bucket
+        key: &str,
         config: &RateLimitConfig,
     ) -> Result<RateLimitDecision, RateLimitStoreError> {
         self.total_requests.fetch_add(1, Ordering::Relaxed);
+        let now = Instant::now();
+
+        let mut buckets = self.buckets.lock().await;
+
+        // Bound the key map: evict the LRU bucket before adding a new key.
+        if buckets.len() >= self.max_keys && !buckets.contains_key(key) {
+            Self::evict_lru(&mut buckets);
+        }
+
+        let bucket = buckets
+            .entry(key.to_string())
+            .or_insert_with(|| Bucket::new(config, now));
+        bucket.last_seen = now;
 
         let decision = match config.algorithm {
-            RateLimitAlgorithm::TokenBucket => self.check_token_bucket(config).await,
-            RateLimitAlgorithm::SlidingWindow => self.check_sliding_window(config).await,
-            RateLimitAlgorithm::FixedWindow => self.check_fixed_window(config).await,
+            RateLimitAlgorithm::TokenBucket => Self::check_token_bucket(bucket, config, now),
+            RateLimitAlgorithm::SlidingWindow => Self::check_sliding_window(bucket, config, now),
+            RateLimitAlgorithm::FixedWindow => Self::check_fixed_window(bucket, config, now),
         };
+        drop(buckets);
 
         if decision.is_denied() {
             self.total_rejected.fetch_add(1, Ordering::Relaxed);
@@ -335,24 +371,22 @@ impl RateLimitStore for InMemoryStore {
         Ok(decision)
     }
 
-    async fn get_stats(&self, _key: &str) -> Result<StoreStats, RateLimitStoreError> {
+    async fn get_stats(&self, key: &str) -> Result<StoreStats, RateLimitStoreError> {
+        let buckets = self.buckets.lock().await;
+        // A key with no live bucket behaves as a full bucket.
+        let current_tokens = buckets
+            .get(key)
+            .map_or(self.burst_size, |b| b.tokens / 1000);
         Ok(StoreStats {
-            current_tokens: self.tokens.load(Ordering::Relaxed) / 1000,
+            current_tokens,
             total_requests: self.total_requests.load(Ordering::Relaxed),
             total_rejected: self.total_rejected.load(Ordering::Relaxed),
         })
     }
 
-    async fn reset(&self, _key: &str) -> Result<(), RateLimitStoreError> {
-        self.tokens.store(self.burst_size * 1000, Ordering::Relaxed);
-        self.window_count.store(0, Ordering::Relaxed);
-        self.total_requests.store(0, Ordering::Relaxed);
-        self.total_rejected.store(0, Ordering::Relaxed);
-
-        *self.last_refill.lock().await = Instant::now();
-        *self.window_start.lock().await = Instant::now();
-        self.request_times.lock().await.clear();
-
+    async fn reset(&self, key: &str) -> Result<(), RateLimitStoreError> {
+        // Drop the key's bucket; the next request recreates a full one.
+        self.buckets.lock().await.remove(key);
         Ok(())
     }
 }
@@ -378,6 +412,83 @@ mod tests {
         // 11th request should be denied
         let decision = store.check_and_consume("", &config).await.unwrap();
         assert!(decision.is_denied(), "11th request should be denied");
+    }
+
+    /// Regression test for #11: distinct keys must have independent buckets, so
+    /// one client exhausting its budget does not throttle another.
+    #[tokio::test]
+    async fn check_and_consume_is_per_key() {
+        let config = RateLimitConfig::new(2, Duration::from_secs(60));
+        let store = InMemoryStore::new(&config);
+
+        // Exhaust "alice".
+        assert!(
+            store
+                .check_and_consume("alice", &config)
+                .await
+                .unwrap()
+                .is_allowed()
+        );
+        assert!(
+            store
+                .check_and_consume("alice", &config)
+                .await
+                .unwrap()
+                .is_allowed()
+        );
+        assert!(
+            store
+                .check_and_consume("alice", &config)
+                .await
+                .unwrap()
+                .is_denied()
+        );
+
+        // "bob" has its own full bucket and is unaffected by "alice".
+        assert!(
+            store
+                .check_and_consume("bob", &config)
+                .await
+                .unwrap()
+                .is_allowed()
+        );
+        assert!(
+            store
+                .check_and_consume("bob", &config)
+                .await
+                .unwrap()
+                .is_allowed()
+        );
+        assert!(
+            store
+                .check_and_consume("bob", &config)
+                .await
+                .unwrap()
+                .is_denied()
+        );
+    }
+
+    /// The key map is bounded: once at capacity, the least-recently-used bucket
+    /// is evicted when a new key arrives.
+    #[tokio::test]
+    async fn evicts_least_recently_used_key_when_over_capacity() {
+        let config = RateLimitConfig::new(5, Duration::from_secs(60));
+        let mut store = InMemoryStore::new(&config);
+        store.max_keys = 2;
+
+        store.check_and_consume("alice", &config).await.unwrap();
+        store.check_and_consume("bob", &config).await.unwrap();
+        // "carol" pushes past max_keys=2, evicting the LRU bucket ("alice").
+        store.check_and_consume("carol", &config).await.unwrap();
+
+        let buckets = store.buckets.lock().await;
+        assert_eq!(buckets.len(), 2);
+        assert!(
+            !buckets.contains_key("alice"),
+            "alice (least recently used) should have been evicted"
+        );
+        assert!(buckets.contains_key("bob"));
+        assert!(buckets.contains_key("carol"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #11.

## Problem
`InMemoryStore::check_and_consume(_key, …)` ignored the key and operated on a single global token bucket. So the per-key contract the trait documents — and the `with_key` middleware API — silently did nothing: **one noisy client throttled everyone**, the opposite of per-client rate limiting.

## Fix
Move the per-bucket state (tokens, refill time, sliding-window timestamps, fixed-window counters) into a `Bucket` struct and keep one per key in a `HashMap<String, Bucket>` behind a single async mutex. `check_and_consume` looks up (or creates) the key's bucket and runs the configured algorithm on it.

To keep memory bounded under many distinct keys, the map is capped at `max_keys` (default **10,000**) with **least-recently-used eviction** when a new key arrives at capacity.

- `get_stats(key)` / `reset(key)` now operate on the specific key.
- An empty key `""` still maps to one shared bucket → global limiting, matching the documented "empty key = global" behavior (and why the existing single-key tests still pass).
- The token-bucket consume is now a plain check-and-subtract under the map lock (no more atomic `fetch_update`), which is correct since the lock serializes access.

## Tests
- `check_and_consume_is_per_key` — exhausting `"alice"` (limit 2) leaves `"bob"` with a full, independent bucket. (Fails on the old global-bucket code: `bob`'s first request would be denied.)
- `evicts_least_recently_used_key_when_over_capacity` — with `max_keys = 2`, adding a third key evicts the LRU bucket.
- All pre-existing store tests (token bucket / sliding / fixed window / stats / reset) still pass.

Local gate (1.96): full `mcpkit-transport` suite (239) green, clippy `-D warnings` + fmt + doc clean.