### PR TITLE
fix(transport): apply configured WebSocket max_message_size (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The WebSocket `max_message_size` setting is now actually applied
+  ([#13](https://github.com/praxiomlabs/mcpkit/issues/13)). Both the client and
+  server build a `tungstenite::WebSocketConfig` from the configured limit and
+  pass it via `connect_async_with_config` / `accept_hdr_async_with_config`;
+  previously the value was dropped and tungstenite's default was always used.
 - The default in-memory rate limiter now isolates clients per key
   ([#11](https://github.com/praxiomlabs/mcpkit/issues/11)). `InMemoryStore`
   previously used a single global bucket and ignored the key, so one noisy

--- a/crates/mcpkit-transport/src/websocket/client.rs
+++ b/crates/mcpkit-transport/src/websocket/client.rs
@@ -17,7 +17,8 @@ use {
     futures::{SinkExt, StreamExt},
     tokio::net::TcpStream,
     tokio_tungstenite::{
-        MaybeTlsStream, WebSocketStream, connect_async, tungstenite::protocol::Message as WsMessage,
+        MaybeTlsStream, WebSocketStream, connect_async_with_config,
+        tungstenite::protocol::{Message as WsMessage, WebSocketConfig as TungsteniteConfig},
     },
 };
 
@@ -102,8 +103,16 @@ impl WebSocketTransport {
             message: format!("Invalid WebSocket URL: {e}"),
         })?;
 
+        // Apply the configured message-size limit to tungstenite (it is
+        // otherwise ignored, leaving tungstenite's own default in effect).
+        let ws_config = TungsteniteConfig {
+            max_message_size: Some(self.config.max_message_size),
+            max_frame_size: Some(self.config.max_message_size),
+            ..Default::default()
+        };
+
         // Connect with timeout
-        let connect_future = connect_async(url.as_str());
+        let connect_future = connect_async_with_config(url.as_str(), Some(ws_config), false);
         let result = tokio::time::timeout(self.config.connect_timeout, connect_future)
             .await
             .map_err(|_| TransportError::Timeout {

--- a/crates/mcpkit-transport/src/websocket/server.rs
+++ b/crates/mcpkit-transport/src/websocket/server.rs
@@ -343,6 +343,7 @@ impl WebSocketListener {
                             tracing::debug!(peer = %addr, "Accepting WebSocket connection");
 
                             let allowed_origins = self.config.allowed_origins.clone();
+                            let max_message_size = self.config.max_message_size;
                             let tx = self.connection_tx.clone();
                             let conn_id = connection_id.fetch_add(1, Ordering::Relaxed);
                             let active_conns_counter = Arc::clone(&self.active_connections);
@@ -392,7 +393,21 @@ impl WebSocketListener {
                                     Ok(response)
                                 };
 
-                                match tokio_tungstenite::accept_hdr_async(stream, callback).await {
+                                // Apply the configured message-size limit to
+                                // tungstenite (otherwise its own default is used
+                                // and our setting is ignored).
+                                let ws_config = tokio_tungstenite::tungstenite::protocol::WebSocketConfig {
+                                    max_message_size: Some(max_message_size),
+                                    max_frame_size: Some(max_message_size),
+                                    ..Default::default()
+                                };
+                                match tokio_tungstenite::accept_hdr_async_with_config(
+                                    stream,
+                                    callback,
+                                    Some(ws_config),
+                                )
+                                .await
+                                {
                                     Ok(ws_stream) => {
                                         tracing::info!(
                                             peer = %addr,


### PR DESCRIPTION
Closes #13.

## Problem
The WebSocket client (`connect_async`) and server (`accept_hdr_async`) never passed the configured `max_message_size` to tungstenite. Both sides expose `with_max_message_size(...)` (and test that the field is stored), but the value was dropped on the floor — tungstenite's own default was always in effect, so tightening the limit for hardening (or raising it) silently did nothing.

## Fix
On each side, build a `tungstenite::protocol::WebSocketConfig` from the configured limit (setting both `max_message_size` and `max_frame_size`) and pass it through:
- client: `connect_async_with_config(url, Some(ws_config), false)`
- server: `accept_hdr_async_with_config(stream, callback, Some(ws_config))` (capturing `max_message_size` before the per-connection spawn, like the existing `allowed_origins`)

Enforcement itself is tungstenite's; this just wires the already-validated value into the handshake so it takes effect.

## Testing
Compilation guarantees the configured value now flows into the `*_with_config` calls, and the existing 42 WebSocket tests pass. I did **not** add an end-to-end "oversized message rejected" test: the listener doesn't expose its ephemeral bound port, so a non-flaky client↔server roundtrip test isn't cheap to write, and the actual size enforcement is tungstenite's (well-covered upstream). Happy to add `local_addr()` + a roundtrip test as a follow-up if you'd like that coverage.

Local gate (1.96): `mcpkit-transport` suite green, clippy `-D warnings` + fmt + doc clean.