### PR TITLE
fix(macros): implement #[mcp(default/min/max)] parameter attributes (#14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   server build a `tungstenite::WebSocketConfig` from the configured limit and
   pass it via `connect_async_with_config` / `accept_hdr_async_with_config`;
   previously the value was dropped and tungstenite's default was always used.
+- The `#[mcp(default = ..., min = ..., max = ...)]` parameter attribute is now
+  functional ([#14](https://github.com/praxiomlabs/mcpkit/issues/14)). It was
+  documented but a no-op — the parsed attributes were never emitted, so
+  generated tool schemas omitted `default`/`minimum`/`maximum`. The macro now
+  parses these (and strips the helper attribute, along with parameter doc
+  comments, so the impl still compiles) and emits them into the JSON Schema.
 - The default in-memory rate limiter now isolates clients per key
   ([#11](https://github.com/praxiomlabs/mcpkit/issues/11)). `InMemoryStore`
   previously used a single global bucket and ignored the key, so one noisy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2615,6 +2615,7 @@ name = "mcpkit-macros-tests"
 version = "0.0.0"
 dependencies = [
  "mcpkit",
+ "mcpkit-core",
  "mcpkit-macros",
  "serde_json",
  "tokio",

--- a/crates/mcpkit-macros-tests/Cargo.toml
+++ b/crates/mcpkit-macros-tests/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 [dev-dependencies]
 mcpkit = { path = "../../mcpkit" }
 mcpkit-macros = { path = "../mcpkit-macros" }
+mcpkit-core = { path = "../mcpkit-core" }
 serde_json.workspace = true
 trybuild = "1.0"
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/mcpkit-macros-tests/tests/param_defaults.rs
+++ b/crates/mcpkit-macros-tests/tests/param_defaults.rs
@@ -1,0 +1,66 @@
+//! Regression test for #14: `#[mcp(default = ..., min = ..., max = ...)]` on a
+//! tool parameter must be emitted into the generated JSON Schema (and the
+//! helper attribute must be stripped so the impl still compiles).
+
+use mcpkit::mcp_server;
+use mcpkit::server::{Context, NoOpPeer, ToolHandler};
+use mcpkit::types::ToolOutput;
+use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+use mcpkit_core::protocol::RequestId;
+use mcpkit_core::protocol_version::ProtocolVersion;
+
+struct Search;
+
+#[mcp_server(name = "search", version = "1.0.0")]
+impl Search {
+    /// Search for things.
+    #[tool(description = "Search")]
+    async fn search(
+        &self,
+        /// The query string
+        query: String,
+        /// Maximum results to return
+        #[mcp(default = 10, min = 1, max = 100)]
+        limit: i64,
+    ) -> ToolOutput {
+        let _ = (query, limit);
+        ToolOutput::text("ok")
+    }
+}
+
+#[tokio::test]
+async fn mcp_param_attrs_are_emitted_into_input_schema() {
+    let handler = Search;
+    let request_id = RequestId::Number(1);
+    let client_caps = ClientCapabilities::default();
+    let server_caps = ServerCapabilities::default();
+    let peer = NoOpPeer;
+    let ctx = Context::new(
+        &request_id,
+        None,
+        &client_caps,
+        &server_caps,
+        ProtocolVersion::LATEST,
+        &peer,
+    );
+
+    let tools = <Search as ToolHandler>::list_tools(&handler, &ctx)
+        .await
+        .expect("list_tools");
+    let tool = tools
+        .iter()
+        .find(|t| t.name == "search")
+        .expect("search tool present");
+
+    let limit = &tool.input_schema["properties"]["limit"];
+    assert_eq!(limit["default"], serde_json::json!(10), "schema: {limit}");
+    assert_eq!(limit["minimum"], serde_json::json!(1), "schema: {limit}");
+    assert_eq!(limit["maximum"], serde_json::json!(100), "schema: {limit}");
+
+    // The plain parameter has no default/min/max, but its doc comment becomes
+    // the schema description (and the doc attribute is stripped so it compiles).
+    let query = &tool.input_schema["properties"]["query"];
+    assert!(query.get("default").is_none());
+    assert!(query.get("minimum").is_none());
+    assert_eq!(query["description"], serde_json::json!("The query string"));
+}

--- a/crates/mcpkit-macros/src/codegen.rs
+++ b/crates/mcpkit-macros/src/codegen.rs
@@ -4,9 +4,12 @@
 
 #![allow(dead_code)]
 
+use darling::FromMeta;
 use proc_macro2::TokenStream;
 use quote::{format_ident, quote};
 use syn::{FnArg, Ident, Pat, PatIdent, PatType, ReturnType, Type};
+
+use crate::attrs::ParamAttrs;
 
 /// Information about a tool method extracted from the AST.
 #[derive(Debug)]
@@ -42,8 +45,12 @@ pub struct ToolParam {
     pub doc: Option<String>,
     /// Whether the parameter is optional (Option<T>)
     pub is_optional: bool,
-    /// Default value if specified
+    /// Default value, from `#[mcp(default = ...)]`.
     pub default: Option<syn::Lit>,
+    /// Minimum value, from `#[mcp(min = ...)]`.
+    pub min: Option<i64>,
+    /// Maximum value, from `#[mcp(max = ...)]`.
+    pub max: Option<i64>,
 }
 
 impl ToolMethod {
@@ -63,6 +70,21 @@ impl ToolMethod {
                 |d| quote!(::serde_json::Value::String(#d.to_string())),
             );
 
+            // `#[mcp(default = ..., min = ..., max = ...)]` -> JSON Schema
+            // `default` / `minimum` / `maximum`.
+            let default_insert = param.default.as_ref().map_or_else(
+                || quote!(),
+                |lit| quote!(obj.insert("default".to_string(), ::serde_json::json!(#lit));),
+            );
+            let min_insert = param.min.map_or_else(
+                || quote!(),
+                |m| quote!(obj.insert("minimum".to_string(), ::serde_json::json!(#m));),
+            );
+            let max_insert = param.max.map_or_else(
+                || quote!(),
+                |m| quote!(obj.insert("maximum".to_string(), ::serde_json::json!(#m));),
+            );
+
             properties.push(quote! {
                 (#name.to_string(), {
                     let mut prop = #type_schema;
@@ -70,6 +92,9 @@ impl ToolMethod {
                         if #description != ::serde_json::Value::Null {
                             obj.insert("description".to_string(), #description);
                         }
+                        #default_insert
+                        #min_insert
+                        #max_insert
                     }
                     prop
                 })
@@ -244,13 +269,17 @@ fn type_to_json_schema(ty: &Type) -> TokenStream {
 }
 
 /// Extract parameter information from a function argument.
-pub fn extract_param(arg: &FnArg) -> Option<ToolParam> {
+///
+/// Parses (and strips) the `#[mcp(default = ..., min = ..., max = ...)]` helper
+/// attribute so it does not leak into the re-emitted impl block. Returns an
+/// error for a malformed `#[mcp(...)]` attribute instead of silently ignoring it.
+pub fn extract_param(arg: &mut FnArg) -> syn::Result<Option<ToolParam>> {
     match arg {
         FnArg::Typed(PatType { pat, ty, attrs, .. }) => {
             // Get the parameter name
             let name = match pat.as_ref() {
                 Pat::Ident(PatIdent { ident, .. }) => ident.clone(),
-                _ => return None,
+                _ => return Ok(None),
             };
 
             // Extract doc comment
@@ -273,18 +302,33 @@ pub fn extract_param(arg: &FnArg) -> Option<ToolParam> {
 
             let doc = if doc.is_empty() { None } else { Some(doc) };
 
+            // Parse the `#[mcp(...)]` helper attribute, if present.
+            let mut param_attrs = ParamAttrs::default();
+            for attr in attrs.iter() {
+                if attr.path().is_ident("mcp") {
+                    param_attrs = ParamAttrs::from_meta(&attr.meta)
+                        .map_err(|e| syn::Error::new_spanned(attr, e.to_string()))?;
+                }
+            }
+            // Strip the attributes the macro consumes (`#[mcp(...)]` and the doc
+            // comments read above) so they aren't re-emitted onto the parameter,
+            // where the compiler rejects all but a few built-in attributes.
+            attrs.retain(|attr| !attr.path().is_ident("mcp") && !attr.path().is_ident("doc"));
+
             // Check if optional
             let is_optional = is_option_type(ty);
 
-            Some(ToolParam {
+            Ok(Some(ToolParam {
                 name,
                 ty: (**ty).clone(),
                 doc,
                 is_optional,
-                default: None,
-            })
+                default: param_attrs.default,
+                min: param_attrs.min,
+                max: param_attrs.max,
+            }))
         }
-        FnArg::Receiver(_) => None,
+        FnArg::Receiver(_) => Ok(None),
     }
 }
 

--- a/crates/mcpkit-macros/src/lib.rs
+++ b/crates/mcpkit-macros/src/lib.rs
@@ -305,7 +305,7 @@ pub fn prompt(attr: TokenStream, item: TokenStream) -> TokenStream {
 ///     /// The search query
 ///     query: String,
 ///     /// Maximum results (1-100)
-///     #[mcp(default = 10, range(1, 100))]
+///     #[mcp(default = 10, min = 1, max = 100)]
 ///     limit: usize,
 ///     /// Optional filters
 ///     filters: Option<Vec<String>>,

--- a/crates/mcpkit-macros/src/server.rs
+++ b/crates/mcpkit-macros/src/server.rs
@@ -196,20 +196,18 @@ fn find_tool_attr(attrs: &[Attribute]) -> Result<Option<(usize, ToolAttrs)>> {
 
 /// Extract tool information from a method.
 #[allow(clippy::unnecessary_wraps)] // Returns Result for future validation extensibility
-fn extract_tool_info(method: &ImplItemFn, attrs: ToolAttrs) -> Result<ToolMethod> {
+fn extract_tool_info(method: &mut ImplItemFn, attrs: ToolAttrs) -> Result<ToolMethod> {
     let name = method.sig.ident.clone();
     let tool_name = attrs.name.unwrap_or_else(|| name.to_string());
 
-    // Extract parameters (skip &self)
-    let params: Vec<ToolParam> = method
-        .sig
-        .inputs
-        .iter()
-        .filter_map(|arg| match arg {
-            FnArg::Receiver(_) => None,
-            FnArg::Typed(_) => extract_param(arg),
-        })
-        .collect();
+    // Extract parameters (skip &self). `extract_param` also strips the
+    // `#[mcp(...)]` helper attribute from each parameter so it isn't re-emitted.
+    let mut params: Vec<ToolParam> = Vec::new();
+    for arg in &mut method.sig.inputs {
+        if let Some(param) = extract_param(arg)? {
+            params.push(param);
+        }
+    }
 
     let is_async = method.sig.asyncness.is_some();
     let returns_result = is_result_type(&method.sig.output);


### PR DESCRIPTION
Closes #14.

## Problem
The macro rustdoc advertised `#[mcp(default = 10)]` / `#[mcp(default = 10, range(1, 100))]` on tool parameters, but the parsing struct `ParamAttrs` was **never referenced** and codegen **hardcoded `default: None`**. So those attributes were silently ignored and generated JSON Schemas omitted the requested `default`/`minimum`/`maximum`.

## Fix
- Parse `#[mcp(...)]` per parameter via the existing `ParamAttrs` (`default`/`min`/`max` fields) and emit `default`, `minimum`, `maximum` into the property schema. The doc example is updated from `range(1, 100)` to `min = 1, max = 100` to match the struct (lowest-friction faithful syntax; the schema output is the same).
- `extract_param` now takes `&mut FnArg` and **strips** the `#[mcp(...)]` helper attribute from the re-emitted impl — the compiler rejects unknown attributes on parameters, so leaving it would fail to compile.
- It also strips the **parameter doc comments** the macro already consumes for descriptions. These were *also* never stripped, so the documented "param doc comment becomes the schema description" feature would itself fail to compile if used — this fixes that latent issue as a necessary part of the change.
- A malformed `#[mcp(...)]` is now a compile error instead of being silently ignored.

## Test
New integration test (`param_defaults.rs`): a tool with `#[mcp(default = 10, min = 1, max = 100)] limit: i64` and a doc-commented `query` param. Asserts the generated `inputSchema` has `default: 10`, `minimum: 1`, `maximum: 100` on `limit`, and the doc-derived `description` on `query`.

Verified the existing macro `trybuild`/expand tests still pass (params without `#[mcp]` produce identical output — the inserts are empty).

Local gate (1.96): `mcpkit-macros` + `mcpkit-macros-tests` green, clippy `-D warnings` + fmt + doc clean.