### PR TITLE
test(core): fix flaky notification_has_no_id property test

### DIFF
--- a/crates/mcpkit-core/tests/property_serialization.rs
+++ b/crates/mcpkit-core/tests/property_serialization.rs
@@ -326,9 +326,14 @@ proptest! {
     #[test]
     fn notification_has_no_id(notification in arb_notification()) {
         let json = serde_json::to_string(&notification)?;
-        // Notifications must not have an id field
-        // Note: We check that there's no "id": pattern (with colon)
-        prop_assert!(!json.contains(r#""id":"#));
+        // Notifications must not have a top-level `id` field. Check the parsed
+        // structure rather than a substring: a substring check false-positives
+        // when the (arbitrary) params happen to contain an "id" key.
+        let value: serde_json::Value = serde_json::from_str(&json)?;
+        prop_assert!(
+            value.get("id").is_none(),
+            "notification must not serialize a top-level id: {json}"
+        );
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
`notification_has_no_id` (in `crates/mcpkit-core/tests/property_serialization.rs`) asserted `!json.contains(r#""id":"#)` over the full serialized `Notification`. Because `arb_notification()` generates **arbitrary `params`**, a generated param with an `"id"` key (e.g. `{"id": 1}`) makes the substring appear and the test fails — a latent **flake** that can block any PR. It surfaced on a Windows run of an unrelated PR (#40).

## Fix
Parse the JSON and assert the **top-level** object has no `id` field (params may legitimately contain a nested `"id"`):

```rust
let value: serde_json::Value = serde_json::from_str(&json)?;
prop_assert!(value.get("id").is_none(), ...);
```

Verified by running the test with `PROPTEST_CASES=4096` (16× the default) — passes consistently.

Test-only; no CHANGELOG entry.