### PR TITLE
chore: bump in-development version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,7 +2481,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcpkit"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "axum 0.8.8",
  "futures",
@@ -2499,7 +2499,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-actix"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -2520,7 +2520,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-axum"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-stream",
  "axum 0.8.8",
@@ -2555,7 +2555,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-client"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-lock",
  "futures",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-core"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2600,7 +2600,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-macros"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "darling 0.20.11",
  "mcpkit-core",
@@ -2624,7 +2624,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-rocket"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "dashmap",
  "mcpkit-core",
@@ -2642,7 +2642,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "chrono",
  "event-listener",
@@ -2658,7 +2658,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-testing"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "futures",
  "mcpkit-core",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-transport"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-io",
  "async-lock",
@@ -2710,7 +2710,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-warp"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "bytes",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -115,12 +115,12 @@ proptest = "1.6"
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 
 # Internal crates - path takes precedence locally, version used for publishing
-mcpkit-core = { version = "0.5.0", path = "crates/mcpkit-core" }
-mcpkit-transport = { version = "0.5.0", path = "crates/mcpkit-transport" }
-mcpkit-server = { version = "0.5.0", path = "crates/mcpkit-server" }
-mcpkit-client = { version = "0.5.0", path = "crates/mcpkit-client" }
-mcpkit-macros = { version = "0.5.0", path = "crates/mcpkit-macros" }
-mcpkit-testing = { version = "0.5.0", path = "crates/mcpkit-testing" }
+mcpkit-core = { version = "0.6.0", path = "crates/mcpkit-core" }
+mcpkit-transport = { version = "0.6.0", path = "crates/mcpkit-transport" }
+mcpkit-server = { version = "0.6.0", path = "crates/mcpkit-server" }
+mcpkit-client = { version = "0.6.0", path = "crates/mcpkit-client" }
+mcpkit-macros = { version = "0.6.0", path = "crates/mcpkit-macros" }
+mcpkit-testing = { version = "0.6.0", path = "crates/mcpkit-testing" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcpkit = "0.5"
+mcpkit = "0.6"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/crates/mcpkit-actix/Cargo.toml
+++ b/crates/mcpkit-actix/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["web-programming::http-server", "asynchronous"]
 
 [dependencies]
 # Internal crates
-mcpkit-core = { version = "0.5.0", path = "../mcpkit-core" }
-mcpkit-server = { version = "0.5.0", path = "../mcpkit-server" }
-mcpkit-transport = { version = "0.5.0", path = "../mcpkit-transport", features = ["http"] }
+mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
+mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
+mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport", features = ["http"] }
 
 # Web framework
 actix-web = "4"

--- a/crates/mcpkit-axum/Cargo.toml
+++ b/crates/mcpkit-axum/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["web-programming::http-server", "asynchronous"]
 
 [dependencies]
 # Internal crates
-mcpkit-core = { version = "0.5.0", path = "../mcpkit-core" }
-mcpkit-server = { version = "0.5.0", path = "../mcpkit-server" }
-mcpkit-transport = { version = "0.5.0", path = "../mcpkit-transport", features = ["http"] }
+mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
+mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
+mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport", features = ["http"] }
 
 # Web framework
 axum = { workspace = true }

--- a/crates/mcpkit-client/Cargo.toml
+++ b/crates/mcpkit-client/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 
 [dependencies]
 # Internal crates - path takes precedence locally, version used for publishing
-mcpkit-core = { version = "0.5.0", path = "../mcpkit-core" }
-mcpkit-transport = { version = "0.5.0", path = "../mcpkit-transport" }
+mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
+mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport" }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/mcpkit-macros/Cargo.toml
+++ b/crates/mcpkit-macros/Cargo.toml
@@ -28,5 +28,5 @@ darling = "0.20"
 
 [dev-dependencies]
 # Only mcpkit-core needed for compile-fail tests (no circular dependency)
-mcpkit-core = { version = "0.5", path = "../mcpkit-core" }
+mcpkit-core = { version = "0.6", path = "../mcpkit-core" }
 trybuild = "1.0"

--- a/crates/mcpkit-rocket/Cargo.toml
+++ b/crates/mcpkit-rocket/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["web-programming::http-server", "asynchronous"]
 
 [dependencies]
 # Internal crates
-mcpkit-core = { version = "0.5.0", path = "../mcpkit-core" }
-mcpkit-server = { version = "0.5.0", path = "../mcpkit-server" }
-mcpkit-transport = { version = "0.5.0", path = "../mcpkit-transport", features = ["http"] }
+mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
+mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
+mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport", features = ["http"] }
 
 # Web framework
 rocket = { version = "0.5", features = ["json"] }

--- a/crates/mcpkit-server/Cargo.toml
+++ b/crates/mcpkit-server/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-mcpkit-core = { version = "0.5.0", path = "../mcpkit-core" }
-mcpkit-transport = { version = "0.5.0", path = "../mcpkit-transport" }
+mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
+mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/mcpkit-testing/Cargo.toml
+++ b/crates/mcpkit-testing/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 # Internal crates - path takes precedence locally, version used for publishing
-mcpkit-core = { version = "0.5.0", path = "../mcpkit-core" }
-mcpkit-transport = { version = "0.5.0", path = "../mcpkit-transport" }
-mcpkit-server = { version = "0.5.0", path = "../mcpkit-server" }
+mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
+mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport" }
+mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/mcpkit-transport/Cargo.toml
+++ b/crates/mcpkit-transport/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-mcpkit-core = { version = "0.5.0", path = "../mcpkit-core" }
+mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/mcpkit-warp/Cargo.toml
+++ b/crates/mcpkit-warp/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["web-programming::http-server", "asynchronous"]
 
 [dependencies]
 # Internal crates
-mcpkit-core = { version = "0.5.0", path = "../mcpkit-core" }
-mcpkit-server = { version = "0.5.0", path = "../mcpkit-server" }
-mcpkit-transport = { version = "0.5.0", path = "../mcpkit-transport", features = ["http"] }
+mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
+mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
+mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport", features = ["http"] }
 
 # Web framework
 warp = "0.3"

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcpkit = "0.5"
+mcpkit = "0.6"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/mcpkit/Cargo.toml
+++ b/mcpkit/Cargo.toml
@@ -14,11 +14,11 @@ readme = "../README.md"
 
 [dependencies]
 # Internal crates - path takes precedence locally, version used for publishing
-mcpkit-core = { version = "0.5.0", path = "../crates/mcpkit-core" }
-mcpkit-transport = { version = "0.5.0", path = "../crates/mcpkit-transport" }
-mcpkit-server = { version = "0.5.0", path = "../crates/mcpkit-server" }
-mcpkit-client = { version = "0.5.0", path = "../crates/mcpkit-client" }
-mcpkit-macros = { version = "0.5.0", path = "../crates/mcpkit-macros" }
+mcpkit-core = { version = "0.6.0", path = "../crates/mcpkit-core" }
+mcpkit-transport = { version = "0.6.0", path = "../crates/mcpkit-transport" }
+mcpkit-server = { version = "0.6.0", path = "../crates/mcpkit-server" }
+mcpkit-client = { version = "0.6.0", path = "../crates/mcpkit-client" }
+mcpkit-macros = { version = "0.6.0", path = "../crates/mcpkit-macros" }
 
 [features]
 default = ["server", "client", "tokio-runtime"]


### PR DESCRIPTION
Declares the next version as **0.6.0** across the workspace.

## Why
The changes accumulated since 0.5.0 include breaking API changes (concurrent request processing #9, retry default change #15) and more are queued (#17 protocol-type fidelity, #18/#19 builder & macro fixes). For a 0.x crate, Cargo's semver rules require a **minor** bump to carry breaking changes, and the `cargo semver-checks` PR gate enforces this against the published 0.5.0 — so those fixes can't land at 0.5.0.

## What
- Workspace `package.version` 0.5.0 → 0.6.0, and all inter-crate dependency requirements (`mcpkit-core = "0.5"`/`"0.5.0"` → `"0.6"`/`"0.6.0"`, etc.).
- `README.md` and `docs/getting-started.md` version references (checked by the Version Sync job).
- `Cargo.lock` updated.

**This is a development-version declaration only** — nothing is published, no tag is cut, and the CHANGELOG `[Unreleased]` section is left to be finalized at actual release time (per your decision to defer the release).

`cargo check --workspace --all-features` passes; this PR has no API changes itself, so Semver Check is clean.