### PR TITLE
fix(core): protocol-type fidelity — RequestId::Null, distinct access-denied code, plain completion total (#17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `RequestId::Null` variant so error responses to an unparseable request can use
+  `"id": null` as required by JSON-RPC 2.0
+  ([#17](https://github.com/praxiomlabs/mcpkit/issues/17)).
 - `ClientBuilder::request_timeout` to configure the per-request response timeout
   (`mcpkit-client`). Defaults to 60 seconds.
 
@@ -29,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **(Breaking)** `Completion.total` is now `Option<usize>` and the broken
+  `CompletionTotal` enum was removed
+  ([#17](https://github.com/praxiomlabs/mcpkit/issues/17)). Its `Approximate`
+  variant was unreachable on round-trip (both variants serialized to a bare
+  integer); the MCP spec models `total` as a plain count with a separate
+  `hasMore` flag.
 - **The server now processes requests concurrently** instead of strictly one at
   a time ([#9](https://github.com/praxiomlabs/mcpkit/issues/9)). Requests are
   interleaved on the connection task up to `RuntimeConfig::max_concurrent_requests`
@@ -48,6 +57,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - See llmtk for LLM provider abstractions, RAG pipelines, agents, and related functionality
 
 ### Fixed
+
+- `McpError::ResourceAccessDenied` now has a distinct JSON-RPC error code
+  ([#17](https://github.com/praxiomlabs/mcpkit/issues/17)); it previously
+  collided with `ResourceNotFound` at `-32002`, so clients couldn't tell the two
+  apart.
 
 - Retry middleware: jitter is now actually randomized, and timeouts are no
   longer retried by default ([#15](https://github.com/praxiomlabs/mcpkit/issues/15)).

--- a/crates/mcpkit-core/src/error/types.rs
+++ b/crates/mcpkit-core/src/error/types.rs
@@ -463,7 +463,9 @@ impl McpError {
             Self::Transport(_) => codes::SERVER_ERROR_START,
             Self::ToolExecution(_) => codes::SERVER_ERROR_START - 1,
             Self::ResourceNotFound { .. } => codes::RESOURCE_NOT_FOUND,
-            Self::ResourceAccessDenied { .. } => codes::SERVER_ERROR_START - 2,
+            // -2 would be -32002, which collides with RESOURCE_NOT_FOUND; use a
+            // distinct code so clients can tell access-denied from not-found.
+            Self::ResourceAccessDenied { .. } => codes::SERVER_ERROR_START - 9,
             Self::ConnectionFailed { .. } => codes::SERVER_ERROR_START - 3,
             Self::SessionExpired { .. } => codes::SERVER_ERROR_START - 4,
             Self::HandshakeFailed(_) => codes::SERVER_ERROR_START - 5,
@@ -520,5 +522,28 @@ impl From<std::io::Error> for McpError {
             context: TransportContext::default(),
             source: Some(Box::new(err)),
         }))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resource_errors_have_distinct_codes() {
+        // Regression for #17: access-denied must not share -32002 with not-found.
+        let not_found = McpError::ResourceNotFound {
+            uri: "file:///x".to_string(),
+        };
+        let denied = McpError::ResourceAccessDenied {
+            uri: "file:///x".to_string(),
+            reason: None,
+        };
+        assert_eq!(not_found.code(), codes::RESOURCE_NOT_FOUND);
+        assert_ne!(
+            denied.code(),
+            not_found.code(),
+            "access-denied and not-found must have distinct JSON-RPC codes"
+        );
     }
 }

--- a/crates/mcpkit-core/src/protocol.rs
+++ b/crates/mcpkit-core/src/protocol.rs
@@ -43,6 +43,11 @@ pub enum RequestId {
     Number(u64),
     /// String request ID.
     String(String),
+    /// A `null` request ID.
+    ///
+    /// JSON-RPC 2.0 requires error responses to a request that could not be
+    /// parsed (so its id is unknown) to use `"id": null`.
+    Null,
 }
 
 impl RequestId {
@@ -82,6 +87,7 @@ impl std::fmt::Display for RequestId {
         match self {
             Self::Number(n) => write!(f, "{n}"),
             Self::String(s) => write!(f, "{s}"),
+            Self::Null => write!(f, "null"),
         }
     }
 }
@@ -422,6 +428,25 @@ impl From<&str> for Cursor {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn request_id_null_round_trips() {
+        // #17: JSON-RPC error responses to unparseable requests use `"id": null`.
+        assert_eq!(serde_json::to_string(&RequestId::Null).unwrap(), "null");
+        assert_eq!(
+            serde_json::from_str::<RequestId>("null").unwrap(),
+            RequestId::Null
+        );
+        // Numbers and strings still take precedence over null.
+        assert_eq!(
+            serde_json::from_str::<RequestId>("7").unwrap(),
+            RequestId::Number(7)
+        );
+        assert_eq!(
+            serde_json::from_str::<RequestId>("\"abc\"").unwrap(),
+            RequestId::String("abc".to_string())
+        );
+    }
 
     #[test]
     fn test_request_serialization() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/mcpkit-core/src/types/completion.rs
+++ b/crates/mcpkit-core/src/types/completion.rs
@@ -78,20 +78,13 @@ pub struct Completion {
     /// Suggested values.
     pub values: Vec<String>,
     /// Total number of available completions (if known).
-    pub total: Option<CompletionTotal>,
+    ///
+    /// Per the MCP spec this is a plain count; whether more are available beyond
+    /// what was returned is conveyed separately by [`has_more`](Self::has_more).
+    pub total: Option<usize>,
     /// Whether there are more completions available.
     #[serde(rename = "hasMore")]
     pub has_more: Option<bool>,
-}
-
-/// Total completion count.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(untagged)]
-pub enum CompletionTotal {
-    /// Exact count.
-    Exact(usize),
-    /// Approximate count (with "+" suffix when serialized).
-    Approximate(usize),
 }
 
 /// Result of a completion request.
@@ -104,6 +97,23 @@ pub struct CompleteResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn completion_total_is_a_plain_number() {
+        // #17: total serializes as a bare integer and round-trips (the old
+        // CompletionTotal enum made the "approximate" variant unreachable).
+        let completion = Completion {
+            values: vec!["a".to_string()],
+            total: Some(42),
+            has_more: Some(true),
+        };
+        let json = serde_json::to_value(&completion).unwrap();
+        assert_eq!(json["total"], serde_json::json!(42));
+        assert_eq!(json["hasMore"], serde_json::json!(true));
+
+        let parsed: Completion = serde_json::from_value(json).unwrap();
+        assert_eq!(parsed.total, Some(42));
+    }
 
     #[test]
     fn test_completion_ref() {

--- a/crates/mcpkit-core/tests/property_serialization.rs
+++ b/crates/mcpkit-core/tests/property_serialization.rs
@@ -228,6 +228,7 @@ proptest! {
         match &id {
             RequestId::Number(n) => prop_assert_eq!(display, n.to_string()),
             RequestId::String(s) => prop_assert_eq!(display, s.clone()),
+            RequestId::Null => prop_assert_eq!(display, "null".to_string()),
         }
     }
 

--- a/crates/mcpkit-server/src/capability/completions.rs
+++ b/crates/mcpkit-server/src/capability/completions.rs
@@ -7,7 +7,7 @@ use crate::context::Context;
 use crate::handler::CompletionHandler;
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::completion::{
-    CompleteRequest, CompleteResult, Completion, CompletionArgument, CompletionRef, CompletionTotal,
+    CompleteRequest, CompleteResult, Completion, CompletionArgument, CompletionRef,
 };
 use std::collections::HashMap;
 use std::future::Future;
@@ -135,7 +135,7 @@ impl CompletionService {
             Ok(CompleteResult {
                 completion: Completion {
                     values,
-                    total: Some(CompletionTotal::Exact(total)),
+                    total: Some(total),
                     has_more: Some(false),
                 },
             })
@@ -144,7 +144,7 @@ impl CompletionService {
             Ok(CompleteResult {
                 completion: Completion {
                     values: Vec::new(),
-                    total: Some(CompletionTotal::Exact(0)),
+                    total: Some(0),
                     has_more: Some(false),
                 },
             })


### PR DESCRIPTION
Closes #17. Three small core protocol-type fidelity fixes (grouped). Includes breaking changes, hence requires 0.6.0 (#43).

## 1. `RequestId::Null` (Added)
JSON-RPC 2.0 requires error responses to an unparseable request to use `"id": null`. Added a `Null` variant (untagged → serializes to/from JSON `null`); numbers/strings still take precedence on deserialize.

## 2. Distinct error code for access-denied (Fixed)
`ResourceAccessDenied` mapped to `SERVER_ERROR_START - 2 = -32002`, which **collides** with `RESOURCE_NOT_FOUND`. Reassigned to `SERVER_ERROR_START - 9` (-32009) so clients can distinguish them.

## 3. `CompletionTotal` → `Option<usize>` (Breaking)
The `#[serde(untagged)] CompletionTotal { Exact, Approximate }` enum serialized both variants to a bare integer, so `Approximate` was unreachable on round-trip and the documented "+" suffix was never produced. The MCP spec models completion `total` as a plain count (with a separate `hasMore` flag), so `Completion.total` is now `Option<usize>` and `CompletionTotal` is removed.

## Tests
- `request_id_null_round_trips` — null serializes/parses correctly; numbers/strings unaffected.
- `resource_errors_have_distinct_codes` — access-denied ≠ not-found code.
- `completion_total_is_a_plain_number` — `total` serializes as a bare integer and round-trips.
- Updated the `RequestId` Display + property-test matches for the new variant.

Local gate (1.96): `mcpkit-core` + `mcpkit-server` green, clippy `-D warnings` + fmt clean. Semver Check now passes under 0.6.0.