### PR TITLE
fix(macros): schema fidelity — qualified paths, Option, generics (#19)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#18](https://github.com/praxiomlabs/mcpkit/issues/18)). `with_*_param`
   previously indexed a non-object `properties` (or `input_schema`) and panicked;
   it now coerces non-object values to a fresh object.
+- Macro schema fidelity ([#19](https://github.com/praxiomlabs/mcpkit/issues/19)):
+  tool parameter types are now resolved by their last path segment, so qualified
+  paths like `std::string::String` and `core::option::Option<T>` map to the
+  correct schema instead of a confusing compile error; the dead `Option`
+  "nullable" code was removed (optionality is conveyed by omitting the parameter
+  from `required`); and `#[mcp_server]` on a generic impl block now fails with a
+  clear error rather than emitting malformed impls.
 - `McpError::ResourceAccessDenied` now has a distinct JSON-RPC error code
   ([#17](https://github.com/praxiomlabs/mcpkit/issues/17)); it previously
   collided with `ResourceNotFound` at `-32002`, so clients couldn't tell the two

--- a/crates/mcpkit-macros-tests/tests/compile_fail/generic_impl.rs
+++ b/crates/mcpkit-macros-tests/tests/compile_fail/generic_impl.rs
@@ -1,0 +1,16 @@
+//! #19: `#[mcp_server]` must reject a generic impl block with a clear error
+//! instead of generating malformed trait impls referencing undefined `T`.
+
+use mcpkit::mcp_server;
+
+struct Handler<T>(T);
+
+#[mcp_server(name = "h", version = "1.0.0")]
+impl<T> Handler<T> {
+    #[tool(description = "noop")]
+    async fn noop(&self) -> mcpkit::types::ToolOutput {
+        mcpkit::types::ToolOutput::text("ok")
+    }
+}
+
+fn main() {}

--- a/crates/mcpkit-macros-tests/tests/compile_fail/generic_impl.stderr
+++ b/crates/mcpkit-macros-tests/tests/compile_fail/generic_impl.stderr
@@ -1,0 +1,5 @@
+error: #[mcp_server] does not support generic impl blocks; implement it on a concrete type
+ --> tests/compile_fail/generic_impl.rs:9:5
+  |
+9 | impl<T> Handler<T> {
+  |     ^^^

--- a/crates/mcpkit-macros-tests/tests/expand.rs
+++ b/crates/mcpkit-macros-tests/tests/expand.rs
@@ -8,4 +8,6 @@
 fn expand_tests() {
     let t = trybuild::TestCases::new();
     t.pass("tests/expand/*.rs");
+    // #19: generic impl blocks must be rejected with a clear error.
+    t.compile_fail("tests/compile_fail/*.rs");
 }

--- a/crates/mcpkit-macros-tests/tests/schema_fidelity.rs
+++ b/crates/mcpkit-macros-tests/tests/schema_fidelity.rs
@@ -1,0 +1,73 @@
+//! Regression tests for #19: macro schema fidelity.
+//!
+//! - Qualified type paths (`std::string::String`) resolve to the right schema
+//!   (previously only bare `String` matched).
+//! - `Option<T>` resolves to the inner type's schema and is omitted from
+//!   `required`.
+
+use mcpkit::mcp_server;
+use mcpkit::server::{Context, NoOpPeer, ToolHandler};
+use mcpkit::types::ToolOutput;
+use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+use mcpkit_core::protocol::RequestId;
+use mcpkit_core::protocol_version::ProtocolVersion;
+
+struct Q;
+
+#[mcp_server(name = "q", version = "1.0.0")]
+impl Q {
+    /// Echo back.
+    #[tool(description = "echo")]
+    async fn echo(
+        &self,
+        /// A qualified-path string parameter.
+        text: std::string::String,
+        /// An optional integer parameter.
+        limit: Option<i64>,
+    ) -> ToolOutput {
+        let _ = (text, limit);
+        ToolOutput::text("ok")
+    }
+}
+
+#[tokio::test]
+async fn qualified_paths_and_option_resolve_in_schema() {
+    let handler = Q;
+    let request_id = RequestId::Number(1);
+    let client_caps = ClientCapabilities::default();
+    let server_caps = ServerCapabilities::default();
+    let peer = NoOpPeer;
+    let ctx = Context::new(
+        &request_id,
+        None,
+        &client_caps,
+        &server_caps,
+        ProtocolVersion::LATEST,
+        &peer,
+    );
+
+    let tools = <Q as ToolHandler>::list_tools(&handler, &ctx)
+        .await
+        .expect("list_tools");
+    let tool = tools.iter().find(|t| t.name == "echo").expect("echo tool");
+
+    // `std::string::String` resolves to a string schema (a confusing compile
+    // error before this fix).
+    assert_eq!(tool.input_schema["properties"]["text"]["type"], "string");
+    // `Option<i64>` resolves to the inner integer schema...
+    assert_eq!(tool.input_schema["properties"]["limit"]["type"], "integer");
+
+    // ...and the optional parameter is not in `required`, while the plain one is.
+    let required = tool.input_schema["required"]
+        .as_array()
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        required.iter().any(|v| v == "text"),
+        "text must be required"
+    );
+    assert!(
+        !required.iter().any(|v| v == "limit"),
+        "Option<i64> must not be required"
+    );
+}

--- a/crates/mcpkit-macros/src/codegen.rs
+++ b/crates/mcpkit-macros/src/codegen.rs
@@ -200,72 +200,60 @@ impl ToolMethod {
 /// compilation will fail with a clear error message.
 fn type_to_json_schema(ty: &Type) -> TokenStream {
     if let Type::Path(path) = ty {
-        let path_str = quote!(#path).to_string().replace(' ', "");
+        // Match on the *last* path segment ident so qualified paths such as
+        // `std::string::String` or `core::option::Option<T>` resolve correctly,
+        // rather than stringifying the whole path (which only matched bare names).
+        let Some(segment) = path.path.segments.last() else {
+            return quote!(::serde_json::json!({}));
+        };
 
-        // Handle common types
-        match path_str.as_str() {
-            "String" | "&str" | "str" => quote!(::serde_json::json!({"type": "string"})),
+        match segment.ident.to_string().as_str() {
+            "String" | "str" => quote!(::serde_json::json!({"type": "string"})),
             "i8" | "i16" | "i32" | "i64" | "i128" | "isize" | "u8" | "u16" | "u32" | "u64"
             | "u128" | "usize" => {
                 quote!(::serde_json::json!({"type": "integer"}))
             }
             "f32" | "f64" => quote!(::serde_json::json!({"type": "number"})),
             "bool" => quote!(::serde_json::json!({"type": "boolean"})),
-            _ if path_str.starts_with("Option<") => {
-                // Extract inner type and make it nullable
-                if let Some(segment) = path.path.segments.last() {
-                    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-                        if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                            let inner_schema = type_to_json_schema(inner);
-                            return quote! {
-                                {
-                                    let mut schema = #inner_schema;
-                                    // Option types are nullable
-                                    schema
-                                }
-                            };
-                        }
-                    }
-                }
-                quote!(::serde_json::json!({}))
+            "Option" => {
+                // Optionality is conveyed by omitting the parameter from the
+                // schema's `required` array (see `generate_input_schema`); the
+                // value schema is just the inner type's schema.
+                first_type_arg(segment)
+                    .map_or_else(|| quote!(::serde_json::json!({})), type_to_json_schema)
             }
-            _ if path_str.starts_with("Vec<") => {
-                // Handle Vec<T>
-                if let Some(segment) = path.path.segments.last() {
-                    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-                        if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                            let inner_schema = type_to_json_schema(inner);
-                            return quote! {
-                                ::serde_json::json!({
-                                    "type": "array",
-                                    "items": #inner_schema
-                                })
-                            };
-                        }
-                    }
-                }
-                quote!(::serde_json::json!({"type": "array"}))
+            "Vec" => first_type_arg(segment).map_or_else(
+                || quote!(::serde_json::json!({"type": "array"})),
+                |inner| {
+                    let inner_schema = type_to_json_schema(inner);
+                    quote!(::serde_json::json!({"type": "array", "items": #inner_schema}))
+                },
+            ),
+            "HashMap" | "BTreeMap" => {
+                quote!(::serde_json::json!({"type": "object", "additionalProperties": true}))
             }
-            _ if path_str.starts_with("HashMap<") || path_str.starts_with("BTreeMap<") => {
-                quote!(::serde_json::json!({
-                    "type": "object",
-                    "additionalProperties": true
-                }))
-            }
-            "serde_json::Value" | "Value" => {
-                // JSON Value can be any type
-                quote!(::serde_json::json!({}))
-            }
+            "Value" => quote!(::serde_json::json!({})),
             _ => {
                 // For custom struct types, call their tool_input_schema() method.
-                // This requires the type to derive ToolInput.
-                // If it doesn't, the user gets a compile error with a helpful message.
+                // This requires the type to derive ToolInput; otherwise the user
+                // gets a compile error pointing at the type.
                 quote!(#path::tool_input_schema())
             }
         }
     } else {
         quote!(::serde_json::json!({}))
     }
+}
+
+/// Return the first generic type argument of a path segment (e.g. `T` in
+/// `Option<T>` or `Vec<T>`), if present.
+fn first_type_arg(segment: &syn::PathSegment) -> Option<&Type> {
+    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
+        if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
+            return Some(inner);
+        }
+    }
+    None
 }
 
 /// Extract parameter information from a function argument.

--- a/crates/mcpkit-macros/src/server.rs
+++ b/crates/mcpkit-macros/src/server.rs
@@ -67,6 +67,17 @@ pub fn expand_mcp_server(attr: TokenStream, item: TokenStream) -> Result<TokenSt
     // Parse the impl block
     let mut impl_block: ItemImpl = parse2(item)?;
 
+    // Generic impl blocks aren't supported: the generated trait impls reference
+    // the concrete self type and would otherwise produce confusing "undefined
+    // type parameter" errors. Fail with a clear message instead.
+    if !impl_block.generics.params.is_empty() {
+        return Err(Error::new_spanned(
+            &impl_block.generics,
+            "#[mcp_server] does not support generic impl blocks; \
+             implement it on a concrete type",
+        ));
+    }
+
     // Find all tool methods
     let tool_methods = extract_tool_methods(&mut impl_block)?;
 


### PR DESCRIPTION
Closes #19. Three macro schema-fidelity gaps (non-breaking codegen changes).

## 1. Fragile type matching → last-segment resolution
Parameter type matching stringified the whole path (`quote!(#path).to_string()`), so `std::string::String`, `core::option::Option<T>`, etc. fell through to `#path::tool_input_schema()` → confusing compile error. Now matches on the **last path segment ident**, so qualified paths resolve correctly.

## 2. `Option<T>` no-op cleanup
The `Option` arm wrapped the inner schema in `{ let mut schema = ...; /* Option types are nullable */ schema }` — a no-op that emitted no nullability. Optionality is already conveyed by **omitting the parameter from `required`** (handled in `generate_input_schema` via `is_optional`), so the arm now just returns the inner type's schema.

## 3. Generic impl blocks → clear error
`#[mcp_server]` used `impl_block.self_ty` but ignored `generics`, so `impl<T> Handler<T>` generated impls referencing an undefined `T` (poor diagnostic). Now rejected with a clear `compile_error!`.

## Tests
- Runtime: `std::string::String` → `{"type":"string"}`, `Option<i64>` → `{"type":"integer"}` and excluded from `required`.
- trybuild **compile-fail**: a generic `#[mcp_server] impl<T>` fails with the new error message.

Existing `pass` expand tests unchanged. Local gate (1.96): `mcpkit-macros` + `mcpkit-macros-tests` green, clippy `-D warnings` + fmt clean.