### PR TITLE
ci: workflow hygiene — silence ENOENT noise, fix dead fuzz trigger, speed up semver, widen matrix coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --all-features
+      # trybuild spins up a throwaway cargo project under target/tests; remove it
+      # so the rust-cache save step doesn't trip over its torn-down scratch dirs
+      # (harmless ENOENT annotations otherwise).
+      - name: Remove trybuild scratch before cache save
+        if: always()
+        shell: bash
+        run: rm -rf target/tests
 
   # ==========================================================================
   # Code Coverage - PRs only (to save CI minutes)
@@ -146,6 +153,10 @@ jobs:
           verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      - name: Remove trybuild scratch before cache save
+        if: always()
+        shell: bash
+        run: rm -rf target/tests
 
   # ==========================================================================
   # Security & compliance
@@ -213,7 +224,14 @@ jobs:
       # Use --features full instead of --all-features to exclude regenerate-proto
       # (protobuf-src fails to build on Windows due to abseil-cpp linker issues)
       - run: cargo test -p mcpkit-transport --features full
-      - run: cargo test --workspace --exclude mcpkit-transport
+      # --all-features here is safe: regenerate-proto is only reachable through
+      # mcpkit-transport (excluded), so the rest of the workspace gets its
+      # feature-gated code (e.g. jwt) exercised cross-platform.
+      - run: cargo test --workspace --exclude mcpkit-transport --all-features
+      - name: Remove trybuild scratch before cache save
+        if: always()
+        shell: bash
+        run: rm -rf target/tests
 
   # ==========================================================================
   # Semver check - ensure no accidental breaking changes
@@ -230,6 +248,6 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-semver-checks
-        run: cargo install cargo-semver-checks --locked
+        uses: taiki-e/install-action@cargo-semver-checks
       - name: Check semver
         run: cargo semver-checks check-release --package mcpkit

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -19,8 +19,9 @@ on:
   pull_request:
     paths:
       - 'fuzz/**'
-      - 'crates/mcp-core/src/protocol/**'
-      - 'crates/mcp-core/src/types/**'
+      - 'crates/mcpkit-core/src/protocol.rs'
+      - 'crates/mcpkit-core/src/protocol_version.rs'
+      - 'crates/mcpkit-core/src/types/**'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Addresses CI quirks surfaced while working through the issue backlog. No product code changes; `.github/workflows/` only.

### 1. Silence the `rust-cache` ENOENT annotations
Every PR's **Test Suite / Code Coverage / Test (macOS|Windows)** jobs were posting red `failure`-level annotations:
> `ENOENT: no such file or directory, opendir '.../target/tests/target'`

These come from the **`Post Run Swatinem/rust-cache@v2`** (cache-save) step, *not* the tests — it walks `target/` and trips over the throwaway cargo project **trybuild** creates under `target/tests`, which is torn down by the time the walk runs. The jobs go green (it's non-fatal), but the annotations are alarming and constant. Fix: delete `target/tests` (ephemeral test scratch we don't want cached anyway) before the cache-save step, on each affected job.

### 2. Fix the dead `fuzz.yml` path trigger
The `pull_request` path filter pointed at `crates/mcp-core/src/protocol/**` and `.../types/**` — **wrong crate** (`mcp-core` vs `mcpkit-core`) *and* `protocol` is a file (`protocol.rs`), not a directory. So PRs touching the protocol/types code the fuzzers target never triggered fuzzing. Re-pointed at the real files: `protocol.rs`, `protocol_version.rs`, `types/**`.

### 3. Speed up the Semver Check job
Replaced `cargo install cargo-semver-checks --locked` (compiles from source, ~5 min every PR) with `taiki-e/install-action@cargo-semver-checks` (prebuilt binary, seconds) — same approach the Coverage job already uses for `cargo-llvm-cov`.

### 4. Widen cross-platform feature coverage
The matrix ran `cargo test --workspace --exclude mcpkit-transport` with **default features**, so feature-gated code (e.g. everything behind `jwt`) was only ever tested on Linux. Added `--all-features` to that run. Verified safe: `regenerate-proto` (which pulls `protobuf-src` and breaks the Windows linker) is referenced **only** by `mcpkit-transport`, which is excluded from this command — so `--all-features` cannot activate it. Transport itself is still tested separately with `--features full`. This PR's own Windows/macOS run validates the change.