### PR TITLE
docs: refresh stale rmcp version and competitive framing (#22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ A Rust SDK for the Model Context Protocol (MCP) that simplifies server developme
 
 ## Why mcpkit?
 
-mcpkit implements **MCP 2025-11-25** — the latest protocol specification. As of December 2025, the official `rmcp` SDK documentation references protocol version 2024-11-05 (always [verify current status](https://github.com/modelcontextprotocol/rust-sdk)). mcpkit supports the newest MCP features:
+mcpkit implements **MCP 2025-11-25** — the latest protocol specification — and negotiates all four published protocol versions. The official `rmcp` SDK now ships the same latest version, so protocol coverage is at parity; mcpkit's differentiation is its developer experience: a single unified `#[mcp_server]` macro, a runtime-agnostic core (Tokio or smol), and a broader built-in transport list (stdio, WebSocket, HTTP, Unix sockets, in-memory). mcpkit supports the newest MCP features:
 
 | Feature | Added In | Description |
 |---------|----------|-------------|

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -2,17 +2,17 @@
 
 This document provides an honest, transparent comparison between `mcpkit` and `rmcp` (the official Rust MCP SDK) to help you choose the right tool for your project.
 
-> **Last verified**: December 2025. SDK ecosystems evolve rapidly—always check the respective repositories for the latest information.
+> **Last verified**: June 2026 (rmcp 1.7.0). SDK ecosystems evolve rapidly—always check the respective repositories for the latest information.
 
 ## Executive Summary
 
 | Aspect | mcpkit | rmcp |
 |--------|--------|------|
 | **Macro Approach** | Single `#[mcp_server]` macro | Multiple macros (`#[tool_router]`, etc.) |
-| **Transport Options** | 5 built-in (stdio, WebSocket, HTTP, Unix, Memory) | 2 (stdio, SSE) |
+| **Transport Options** | 5 built-in (stdio, WebSocket, HTTP, Unix, Memory) | 4 (stdio, Streamable HTTP, SSE [legacy], child-process) |
 | **Error Handling** | `McpError` + `ToolOutput::error()` | `Result<CallToolResult, Error>` |
-| **Maturity** | Pre-1.0 | Established (0.11.x) |
-| **Protocol Version** | 2025-11-25 (per docs) | 2024-11-05 (per docs) |
+| **Maturity** | Pre-1.0 | Established (1.7.x) |
+| **Protocol Version** | 2025-11-25 (all 4 versions) | 2025-11-25 (all 4 versions) |
 
 ## Code Size Comparison
 
@@ -150,7 +150,7 @@ Both SDKs use Rust's ownership system, ensuring no memory leaks by design. mcpki
 
 mcpkit includes automatic version negotiation and capability negotiation.
 
-**rmcp protocol support:** Check [rmcp's repository](https://github.com/modelcontextprotocol/rust-sdk) for current protocol version support. As of December 2025, their README references version 2024-11-05.
+**rmcp protocol support:** As of June 2026 (rmcp 1.7.0), rmcp ships the same four protocol versions and defaults to the latest, `2025-11-25` — the two SDKs are at protocol parity. Check [rmcp's repository](https://github.com/modelcontextprotocol/rust-sdk) for the current status.
 
 ### mcpkit-Specific Features
 
@@ -210,7 +210,7 @@ The Rust MCP ecosystem includes several implementations beyond mcpkit and rmcp. 
 
 | SDK | Protocol Versions | Key Differentiators |
 |-----|-------------------|---------------------|
-| **[rmcp](https://github.com/modelcontextprotocol/rust-sdk)** | 2024-11-05 (per docs) | Official SDK, wide adoption |
+| **[rmcp](https://github.com/modelcontextprotocol/rust-sdk)** | All versions (default: 2025-11-25) | Official SDK, wide adoption |
 | **[rust-mcp-sdk](https://github.com/rust-mcp-stack/rust-mcp-sdk)** | All versions (default: 2025-06-18) | DNS rebinding protection, OAuth providers, batch messages |
 | **[mcp-protocol-sdk](https://docs.rs/mcp-protocol-sdk)** | 2025-06-18 | Audio support, annotations, autocompletion |
 | **mcpkit** | All versions (default: 2025-11-25) | Unified macro, runtime-agnostic, Tasks support |

--- a/docs/migration-from-rmcp.md
+++ b/docs/migration-from-rmcp.md
@@ -2,7 +2,7 @@
 
 This guide helps you migrate from the `rmcp` crate (the official Rust MCP SDK) to `mcpkit`. Both SDKs implement the same MCP protocol and are wire-compatible.
 
-> **Note**: This guide reflects rmcp's API as of December 2025. Check [rmcp's documentation](https://github.com/modelcontextprotocol/rust-sdk) for the latest API details.
+> **Note**: This guide reflects rmcp's API as of June 2026 (rmcp 1.7.0). Check [rmcp's documentation](https://github.com/modelcontextprotocol/rust-sdk) for the latest API details.
 
 ## Quick Comparison
 
@@ -12,8 +12,8 @@ This guide helps you migrate from the `rmcp` crate (the official Rust MCP SDK) t
 | Schema generation | `schemars` crate | Built-in JSON Schema |
 | Server builder | Custom builder | Typestate builder |
 | Error handling | `CallToolResult` | `ToolOutput` + `McpError` |
-| Protocol versions | 2024-11-05 | 2024-11-05, 2025-11-25 |
-| Transport | stdio, SSE | stdio, WebSocket, HTTP, Unix, Memory |
+| Protocol versions | All 4 (2024-11-05 … 2025-11-25) | All 4 (2024-11-05 … 2025-11-25) |
+| Transport | stdio, Streamable HTTP, SSE, child-process | stdio, WebSocket, HTTP, Unix, Memory |
 
 ## Dependency Changes
 
@@ -21,7 +21,7 @@ This guide helps you migrate from the `rmcp` crate (the official Rust MCP SDK) t
 
 ```toml
 [dependencies]
-rmcp = "0.1"
+rmcp = "1.7"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 schemars = "1"
@@ -303,10 +303,11 @@ let caps = ServerCapabilities {
 
 ## Protocol Version Compatibility
 
-Both SDKs are wire-compatible. mcpkit supports:
+Both SDKs are wire-compatible and support all four protocol versions, defaulting to the latest:
 
-- `2024-11-05` (rmcp's version)
-- `2025-11-25` (latest)
+- `2024-11-05` (original spec)
+- `2025-03-26`, `2025-06-18`
+- `2025-11-25` (latest; default for both SDKs)
 
 Version negotiation happens automatically during initialization.
 
@@ -334,8 +335,8 @@ Replace `rmcp` with `mcpkit`:
 
 ```toml
 [dependencies]
-- rmcp = "0.1"
-+ mcpkit = "0.5"
+- rmcp = "1.7"
++ mcpkit = "0.6"
 ```
 
 Remove `schemars` if only used for tool schemas.


### PR DESCRIPTION
Closes #22.

rmcp is at **1.7.0** (June 2026) and ships the **same four protocol versions** as mcpkit, defaulting to `2025-11-25`. So the docs' framing — that mcpkit leads on protocol version while rmcp sits at `2024-11-05` — is no longer true, and several version pins are stale.

### Changes
- **README** — Removed the false "the official rmcp SDK references protocol version 2024-11-05" claim. Reframed mcpkit's differentiation honestly: protocol coverage is at parity; the real edges are the single unified `#[mcp_server]` macro, a runtime-agnostic core (Tokio or smol), and a broader built-in transport list.
- **docs/comparison.md** — rmcp maturity `0.11.x` → `1.7.x`; protocol-version row now shows parity at `2025-11-25 (all 4 versions)`; rmcp transport list corrected from "2 (stdio, SSE)" to "4 (stdio, Streamable HTTP, SSE [legacy], child-process)"; "last verified" → June 2026.
- **docs/migration-from-rmcp.md** — `rmcp = "0.1"` → `"1.7"`, `mcpkit = "0.5"` → `"0.6"`; protocol/transport comparison rows updated to reflect parity and rmcp's real transports.

### Verification
- rmcp 1.7.0 / May 2026 confirmed via crates.io.
- rmcp transports (stdio, Streamable HTTP, SSE-legacy, child-process) confirmed via the rust-sdk repo/docs.
- mcpkit `ProtocolVersion::LATEST == 2025-11-25` and all-four support confirmed in `crates/mcpkit-core/src/protocol_version.rs`.

Docs-only; no CHANGELOG entry (consistent with how CI/dev-doc changes were handled).