### PR TITLE
ci: exclude shields.io badge URLs from link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
             --exclude "^https://docs.rs"
             --exclude "^https://www.reddit.com"
             --exclude "^https://cliffle.com"
+            --exclude "^https://img.shields.io"
             './docs/**/*.md'
             './README.md'
             './CONTRIBUTING.md'


### PR DESCRIPTION
The README status badges point at `img.shields.io`, which intermittently returns 502 Bad Gateway / timeouts and red-fails the **Link Check** job on unrelated PRs (it just blocked #49 with a 502 on `img.shields.io/crates/l/mcpkit.svg`). Badge image URLs are decorative, not documentation links, so exclude the host from lychee — the same treatment crates.io and docs.rs already get. Makes the link check deterministic.