### PR TITLE
ci(release): install clippy component in validate job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
+        with:
+          components: clippy
       - uses: Swatinem/rust-cache@v2
 
       - name: Extract version from tag


### PR DESCRIPTION
The **Validate Release** job in `release.yml` failed the v0.6.0 release with `error: 'cargo-clippy' is not installed for the toolchain '1.96.0'` — it runs `cargo clippy` but requested `dtolnay/rust-toolchain@1.96` without the `clippy` component.

This was latent: pinning the toolchain `@stable` → `@1.96` (#29) dropped the clippy that `@stable` bundled, and no release ran between then and now to surface it. The main `ci.yml` clippy job already specifies `components: clippy`; this mirrors that in the release validate job.

**Impact of the failed release:** validate gates publish, so the **publish** and **github-release** jobs were *skipped* — nothing was published to crates.io and v0.6.0 was not consumed. The tag has been deleted; once this merges I'll re-tag v0.6.0 and re-run the release.

YAML validated; the publish job's toolchain is intentionally left unchanged (it only runs `cargo publish`).