### PR TITLE
fix(release): make publish step errexit-safe (surface real errors, tolerate already-published)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,17 +61,21 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
+          # NB: the step shell runs with `bash -e`. Capture the publish output
+          # via an `if` condition so a non-zero cargo exit does NOT trip errexit
+          # before we can print the error and check for "already uploaded".
           set -uo pipefail
 
           publish() {
             echo "::group::publish $1"
-            local out status
-            out=$(cargo publish -p "$1" 2>&1); status=$?
-            echo "$out"
-            echo "::endgroup::"
-            if [ "$status" -eq 0 ]; then
+            local out
+            if out=$(cargo publish -p "$1" 2>&1); then
+              echo "$out"
+              echo "::endgroup::"
               return 0
             fi
+            echo "$out"
+            echo "::endgroup::"
             if echo "$out" | grep -qiE "already (exists|uploaded)"; then
               echo "::notice::$1 already published at this version — skipping"
               return 0


### PR DESCRIPTION
The v0.6.0 release reached **publish** (validate passed after the clippy fix) but died on `mcpkit-core` with bare `exit code 101` and **no cargo output**.

**Root cause:** the publish step runs under `bash -e`. The script captured `out=$(cargo publish ... 2>&1); status=$?` — but under errexit a non-zero command substitution aborts the script *at the assignment*, before `echo "$out"` and before the 'already uploaded' tolerance. So cargo's real error was captured into `$out` and never printed, and the tolerance never ran. (My local test used `set -uo pipefail` without `-e`, so it passed locally — my miss.)

**Fix:** capture via `if out=$(cargo publish ...); then ...` so errexit is suppressed for that command; on failure we print the output, skip on `already (exists|uploaded)`, and abort with a visible `::error::` otherwise. Verified under `bash -e` across success / already-published / real-error paths.

This makes the *next* publish run show the actual reason `mcpkit-core` failed (most likely `CARGO_REGISTRY_TOKEN` or a crates.io-side rejection, since `publish-dry` packaging/verify passed).