### PR TITLE
fix(auth): redact secrets in Debug output for OAuth/token types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- OAuth/token types (`TokenResponse`, `TokenRequest`, `AuthorizationConfig`,
+  `PkceChallenge`, `ClientRegistrationResponse`) now redact their secret fields
+  in `Debug` output. Previously deriving `Debug` printed access/refresh tokens,
+  client secrets, authorization codes, and PKCE verifiers verbatim, which could
+  leak them into logs or traces; the secret fields now render as `<redacted>`
+  while non-secret metadata and `Some`/`None` presence stay visible.
+
 ## [0.6.0] - 2026-06-18
 
 ### Added

--- a/crates/mcpkit-core/src/auth/oauth.rs
+++ b/crates/mcpkit-core/src/auth/oauth.rs
@@ -357,7 +357,7 @@ impl std::fmt::Display for CodeChallengeMethod {
 }
 
 /// PKCE code verifier and challenge.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct PkceChallenge {
     /// The code verifier (random string).
     pub verifier: String,
@@ -537,7 +537,7 @@ impl AuthorizationRequest {
 }
 
 /// Token request for authorization code exchange.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TokenRequest {
     /// The grant type.
     pub grant_type: String,
@@ -640,7 +640,7 @@ impl TokenRequest {
 }
 
 /// Token response from the authorization server.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct TokenResponse {
     /// The access token.
     pub access_token: String,
@@ -826,7 +826,7 @@ impl WwwAuthenticate {
 }
 
 /// Client authorization configuration.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct AuthorizationConfig {
     /// The authorization server URL.
     pub authorization_server: String,
@@ -972,7 +972,7 @@ impl Default for ClientRegistrationRequest {
 }
 
 /// Dynamic Client Registration response per RFC 7591.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct ClientRegistrationResponse {
     /// The assigned client identifier.
     pub client_id: String,
@@ -990,9 +990,132 @@ pub struct ClientRegistrationResponse {
     pub metadata: HashMap<String, serde_json::Value>,
 }
 
+// Redacted `Debug` impls for the secret-bearing OAuth types. Deriving `Debug`
+// would write bearer tokens, client secrets, authorization codes, and PKCE
+// verifiers verbatim into logs/traces; these redact the secret fields while
+// preserving presence (`Some`/`None`) for diagnostics.
+
+impl std::fmt::Debug for TokenResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenResponse")
+            .field("access_token", &"<redacted>")
+            .field("token_type", &self.token_type)
+            .field("expires_in", &self.expires_in)
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("scope", &self.scope)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for TokenRequest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TokenRequest")
+            .field("grant_type", &self.grant_type)
+            .field("code", &self.code.as_ref().map(|_| "<redacted>"))
+            .field("redirect_uri", &self.redirect_uri)
+            .field("client_id", &self.client_id)
+            .field(
+                "client_secret",
+                &self.client_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .field(
+                "code_verifier",
+                &self.code_verifier.as_ref().map(|_| "<redacted>"),
+            )
+            .field("resource", &self.resource)
+            .field(
+                "refresh_token",
+                &self.refresh_token.as_ref().map(|_| "<redacted>"),
+            )
+            .field("scope", &self.scope)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for AuthorizationConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthorizationConfig")
+            .field("authorization_server", &self.authorization_server)
+            .field("client_id", &self.client_id)
+            .field(
+                "client_secret",
+                &self.client_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .field("redirect_uri", &self.redirect_uri)
+            .field("resource", &self.resource)
+            .field("scopes", &self.scopes)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for PkceChallenge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PkceChallenge")
+            .field("verifier", &"<redacted>")
+            .field("challenge", &self.challenge)
+            .field("method", &self.method)
+            .finish()
+    }
+}
+
+impl std::fmt::Debug for ClientRegistrationResponse {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ClientRegistrationResponse")
+            .field("client_id", &self.client_id)
+            .field(
+                "client_secret",
+                &self.client_secret.as_ref().map(|_| "<redacted>"),
+            )
+            .field("client_secret_expires_at", &self.client_secret_expires_at)
+            .field("client_id_issued_at", &self.client_id_issued_at)
+            .field("metadata", &self.metadata)
+            .finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_secret_bearing_debug_is_redacted() {
+        let token = TokenResponse {
+            access_token: "super-secret-access".to_string(),
+            token_type: "Bearer".to_string(),
+            expires_in: Some(3600),
+            refresh_token: Some("super-secret-refresh".to_string()),
+            scope: Some("mcp:read".to_string()),
+        };
+        let dbg = format!("{token:?}");
+        assert!(
+            !dbg.contains("super-secret-access"),
+            "access_token leaked: {dbg}"
+        );
+        assert!(
+            !dbg.contains("super-secret-refresh"),
+            "refresh_token leaked: {dbg}"
+        );
+        assert!(dbg.contains("<redacted>"));
+        // Non-secret metadata is still visible.
+        assert!(dbg.contains("Bearer"));
+
+        let pkce = PkceChallenge::new();
+        let pkce_dbg = format!("{pkce:?}");
+        assert!(
+            !pkce_dbg.contains(&pkce.verifier),
+            "PKCE verifier leaked: {pkce_dbg}"
+        );
+
+        let cfg = AuthorizationConfig::new("https://auth.example.com");
+        let cfg2 = AuthorizationConfig {
+            client_secret: Some("super-secret-client".to_string()),
+            ..cfg
+        };
+        assert!(!format!("{cfg2:?}").contains("super-secret-client"));
+    }
 
     #[test]
     fn test_protected_resource_metadata() {


### PR DESCRIPTION
`TokenResponse`, `TokenRequest`, `AuthorizationConfig`, `PkceChallenge`, and `ClientRegistrationResponse` derived `Debug` over plaintext secret fields — `access_token`, `refresh_token`, `client_secret`, the authorization `code`, and the PKCE `code_verifier`/`verifier`. Any `{:?}` or `tracing` of these values (or of types embedding them, e.g. `StoredToken`) writes live credentials into logs/traces.

This replaces the derives with hand-written `Debug` impls that render secret fields as `<redacted>` while keeping non-secret metadata and `Some`/`None` presence. `StoredToken` keeps its derive — it only holds a `TokenResponse`, so it's covered transitively.

Adds a test asserting secrets do not appear in `Debug` output.