### PR TITLE
fix(macros): emit tool schema properties in deterministic order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leak them into logs or traces; the secret fields now render as `<redacted>`
   while non-secret metadata and `Some`/`None` presence stay visible.
 
+### Fixed
+
+- Generated tool input schemas now emit their `properties` in a deterministic
+  order. The `#[mcp_server]` macro previously collected properties through a
+  `HashMap`, so `tools/list` returned schemas whose property order varied per
+  run — breaking response caching and snapshot tests. Properties are now
+  inserted in declaration order.
+
 ## [0.6.0] - 2026-06-18
 
 ### Added

--- a/crates/mcpkit-macros-tests/tests/schema_ordering.rs
+++ b/crates/mcpkit-macros-tests/tests/schema_ordering.rs
@@ -1,0 +1,68 @@
+//! Regression test: generated tool input-schema property order is deterministic.
+//!
+//! The macro previously collected schema `properties` through a `HashMap`, whose
+//! iteration order is randomized per instance, so `tools/list` emitted
+//! differently-ordered schemas across runs (breaking caching / snapshot tests).
+
+use mcpkit::mcp_server;
+use mcpkit::server::{Context, NoOpPeer, ToolHandler};
+use mcpkit::types::ToolOutput;
+use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+use mcpkit_core::protocol::RequestId;
+use mcpkit_core::protocol_version::ProtocolVersion;
+
+struct S;
+
+#[mcp_server(name = "s", version = "1.0.0")]
+impl S {
+    #[tool(description = "many params in a fixed declaration order")]
+    async fn many(
+        &self,
+        zebra: String,
+        alpha: i64,
+        mike: bool,
+        bravo: f64,
+        yankee: String,
+        charlie: i64,
+    ) -> ToolOutput {
+        let _ = (zebra, alpha, mike, bravo, yankee, charlie);
+        ToolOutput::text("ok")
+    }
+}
+
+async fn property_order(handler: &S) -> Vec<String> {
+    let request_id = RequestId::Number(1);
+    let client_caps = ClientCapabilities::default();
+    let server_caps = ServerCapabilities::default();
+    let peer = NoOpPeer;
+    let ctx = Context::new(
+        &request_id,
+        None,
+        &client_caps,
+        &server_caps,
+        ProtocolVersion::LATEST,
+        &peer,
+    );
+    let tools = <S as ToolHandler>::list_tools(handler, &ctx)
+        .await
+        .expect("list_tools");
+    let tool = tools.iter().find(|t| t.name == "many").expect("many tool");
+    tool.input_schema["properties"]
+        .as_object()
+        .expect("properties object")
+        .keys()
+        .cloned()
+        .collect()
+}
+
+#[tokio::test]
+async fn tool_schema_property_order_is_deterministic() {
+    let handler = S;
+    let first = property_order(&handler).await;
+    let second = property_order(&handler).await;
+    assert_eq!(
+        first, second,
+        "tool input-schema property order must be deterministic across calls"
+    );
+    assert_eq!(first.len(), 6, "all six parameters should be present");
+}

--- a/crates/mcpkit-macros/src/codegen.rs
+++ b/crates/mcpkit-macros/src/codegen.rs
@@ -112,11 +112,14 @@ impl ToolMethod {
                     "properties": {},
                 });
                 if let ::serde_json::Value::Object(ref mut obj) = schema {
-                    let properties: std::collections::HashMap<String, ::serde_json::Value> =
-                        vec![#(#properties),*].into_iter().collect();
-                    obj.insert("properties".to_string(), ::serde_json::Value::Object(
-                        properties.into_iter().collect()
-                    ));
+                    // Insert in declaration order rather than collecting through a
+                    // HashMap, whose iteration order is randomized per run and would
+                    // make tools/list emit non-deterministically ordered schemas.
+                    let mut properties = ::serde_json::Map::new();
+                    for (name, value) in vec![#(#properties),*] {
+                        properties.insert(name, value);
+                    }
+                    obj.insert("properties".to_string(), ::serde_json::Value::Object(properties));
                     let required: Vec<String> = vec![#(#required.to_string()),*];
                     if !required.is_empty() {
                         obj.insert("required".to_string(), ::serde_json::Value::Array(


### PR DESCRIPTION
`generate_input_schema` collected a tool's schema `properties` into a `HashMap` before inserting them, and `HashMap` iteration order is randomized per instance. As a result `tools/list` returned the same tool with differently-ordered `properties` across runs, which breaks HTTP response caching, snapshot/golden tests, and anything that hashes or diffs the schema.

Properties are now inserted into a `serde_json::Map` in declaration order — deterministic regardless of serde_json's `preserve_order` feature.

Adds a regression test asserting the property order is stable across repeated `list_tools` calls.