### PR TITLE
fix(transport): reply -32700 on stdio parse errors instead of closing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `HashMap`, so `tools/list` returned schemas whose property order varied per
   run — breaking response caching and snapshot tests. Properties are now
   inserted in declaration order.
+- A malformed message on the stdio transport no longer tears down the
+  connection. `StdioTransport` now replies with a JSON-RPC parse error
+  (`-32700`, `id: null`) and keeps serving, instead of returning a transport
+  error that ended the server's message loop.
 
 ## [0.6.0] - 2026-06-18
 

--- a/crates/mcpkit-transport/src/stdio.rs
+++ b/crates/mcpkit-transport/src/stdio.rs
@@ -35,7 +35,8 @@ use crate::error::TransportError;
 use crate::runtime::{AsyncMutex, BufReader};
 use crate::traits::{Transport, TransportMetadata};
 use futures::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
-use mcpkit_core::protocol::Message;
+use mcpkit_core::error::JsonRpcError;
+use mcpkit_core::protocol::{Message, RequestId, Response};
 use std::io::{BufRead, Write};
 use std::sync::atomic::{AtomicBool, Ordering};
 
@@ -148,6 +149,24 @@ where
                 .connected_now(),
         }
     }
+
+    /// Write a JSON-RPC parse error (`-32700`) with a null id to stdout.
+    ///
+    /// Used when an incoming line cannot be parsed, so the connection stays
+    /// open and keeps serving instead of being torn down by one malformed
+    /// message.
+    async fn send_parse_error(&self) -> Result<(), TransportError> {
+        let response = Message::Response(Response::error(
+            RequestId::Null,
+            JsonRpcError::parse_error("failed to parse message as JSON-RPC"),
+        ));
+        let json = serde_json::to_string(&response)?;
+        let mut stdout = self.stdout.lock().await;
+        stdout.write_all(json.as_bytes()).await?;
+        stdout.write_all(b"\n").await?;
+        stdout.flush().await?;
+        Ok(())
+    }
 }
 
 #[cfg(any(feature = "tokio-runtime", feature = "smol-runtime"))]
@@ -223,8 +242,14 @@ where
                 continue;
             }
 
-            // Parse JSON directly from bytes - avoids String allocation
-            let msg: Message = serde_json::from_slice(trimmed)?;
+            // Parse JSON directly from bytes - avoids String allocation. A
+            // malformed line is a JSON-RPC parse error: reply -32700 with a null
+            // id and keep reading, rather than tearing down the connection on a
+            // single bad message.
+            let Ok(msg) = serde_json::from_slice::<Message>(trimmed) else {
+                self.send_parse_error().await?;
+                continue;
+            };
             return Ok(Some(msg));
         }
     }
@@ -394,5 +419,26 @@ mod tests {
     #[test]
     fn test_max_message_size() {
         assert_eq!(MAX_MESSAGE_SIZE, 16 * 1024 * 1024);
+    }
+
+    #[cfg(feature = "tokio-runtime")]
+    #[tokio::test]
+    async fn malformed_line_does_not_close_connection() {
+        use futures::io::Cursor;
+        // A malformed line followed by a valid request on the next line.
+        let input =
+            b"this is not json\n{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"ping\"}\n".to_vec();
+        let transport = StdioTransport::with_streams(Cursor::new(input), Cursor::new(Vec::new()));
+
+        // The malformed line must not tear down the connection: recv replies
+        // -32700 to stdout, skips it, and returns the following valid request.
+        let msg = transport
+            .recv()
+            .await
+            .expect("a malformed line must not error out the connection");
+        match msg {
+            Some(Message::Request(req)) => assert_eq!(req.method, "ping"),
+            other => panic!("expected the ping request after the bad line, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
The server message loop breaks on any `transport.recv()` error. On stdio a single malformed line is a JSON parse error surfaced as a transport error, so one bad message tore down the entire connection instead of being rejected per-message.

`StdioTransport::recv` now replies with a JSON-RPC parse error (`-32700`, `id: null`) on a parse failure and continues reading the next message, matching the JSON-RPC spec for unparsable input.

Adds a test that a malformed line is skipped (with a `-32700` reply) and the following valid request is still delivered. `SyncStdioTransport` is not on the async server path and has no stream injection for testing; tracked as a follow-up.