### PR TITLE
fix(server): answer ping before the initialize handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   connection. `StdioTransport` now replies with a JSON-RPC parse error
   (`-32700`, `id: null`) and keeps serving, instead of returning a transport
   error that ended the server's message loop.
+- `ping` is now answered before the `initialize` handshake completes, instead of
+  being rejected with "Server not initialized". Other requests still require
+  initialization first.
 
 ## [0.6.0] - 2026-06-18
 

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -306,6 +306,9 @@ where
     async fn compute_response(&self, request: &Request) -> Result<serde_json::Value, McpError> {
         match request.method.as_ref() {
             "initialize" => self.handle_initialize(request).await,
+            // `ping` is a liveness check and is valid at any time, including
+            // before the initialize handshake completes.
+            "ping" => self.route_request(request).await,
             _ if !self.state.is_initialized() => {
                 Err(McpError::invalid_request("Server not initialized"))
             }
@@ -1057,6 +1060,27 @@ mod tests {
         }
     }
 
+    /// A router that answers `ping` and nothing else (like the macro-generated
+    /// router's ping handling), for testing pre-initialize behavior.
+    struct PingRouter;
+
+    impl RequestRouter for PingRouter {
+        fn server_info(&self) -> ServerInfo {
+            ServerInfo::new("ping-test", "0.0.0")
+        }
+        async fn route(
+            &self,
+            method: &str,
+            _params: Option<&serde_json::Value>,
+            _ctx: &Context<'_>,
+        ) -> Result<serde_json::Value, McpError> {
+            match method {
+                "ping" => Ok(serde_json::json!({})),
+                other => Err(McpError::method_not_found(other)),
+            }
+        }
+    }
+
     fn req(method: &'static str, id: u64) -> Message {
         Message::Request(Request::new(method, id))
     }
@@ -1104,6 +1128,43 @@ mod tests {
         assert!(
             resp.result.is_some(),
             "expected success after a prior panic"
+        );
+
+        drop(client);
+        let _ = timeout(Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn ping_is_answered_before_initialize() {
+        let (client, server) = MemoryTransport::pair();
+        // Deliberately NOT initialized: the server is mid-handshake.
+        let state = Arc::new(ServerState::new(ServerCapabilities::default()));
+        let runtime = ServerRuntime {
+            server: PingRouter,
+            transport: Arc::new(server),
+            state,
+            config: RuntimeConfig::default(),
+        };
+        let handle = tokio::spawn(async move { runtime.run().await });
+
+        // `ping` must be answered even before `initialize`.
+        client.send(req("ping", 1)).await.expect("send");
+        let resp = next_response(&client).await;
+        assert_eq!(resp.id, RequestId::Number(1));
+        assert!(
+            resp.error.is_none(),
+            "ping before initialize must not error: {:?}",
+            resp.error
+        );
+        assert!(resp.result.is_some(), "ping should return a result");
+
+        // ...but other requests are still rejected until initialized.
+        client.send(req("tools/list", 2)).await.expect("send");
+        let resp = next_response(&client).await;
+        assert_eq!(resp.id, RequestId::Number(2));
+        assert!(
+            resp.error.is_some(),
+            "non-ping requests before initialize must still be rejected"
         );
 
         drop(client);


### PR DESCRIPTION
`compute_response` rejected every method except `initialize` while the server was uninitialized — including `ping`. `ping` is a liveness check that may be sent at any time, so rejecting it with "Server not initialized" is incorrect.

`ping` is now routed regardless of initialization state; all other methods still require `initialize` first. (`logging/setLevel`, which the spec also permits early, has no route handler in mcpkit and is out of scope.)

Adds a test that a pre-`initialize` ping succeeds while a non-ping request is still rejected.