### PR TITLE
fix(core): default CallToolResult.content to empty when absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ping` is now answered before the `initialize` handshake completes, instead of
   being rejected with "Server not initialized". Other requests still require
   initialization first.
+- `CallToolResult` now deserializes when the `content` field is absent (defaults
+  to empty), so results carrying only `isError` (or `{}`) from other peers parse
+  instead of failing.
 
 ## [0.6.0] - 2026-06-18
 

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -271,6 +271,11 @@ impl ToolAnnotations {
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CallToolResult {
     /// The content returned by the tool.
+    ///
+    /// Defaults to empty when omitted, so a result that carries only `isError`
+    /// (or is `{}`) still deserializes — some peers send empty results without a
+    /// `content` field.
+    #[serde(default)]
     pub content: Vec<Content>,
     /// If true, this result represents an error.
     #[serde(rename = "isError", skip_serializing_if = "Option::is_none")]
@@ -503,6 +508,19 @@ mod tests {
 
         let error = CallToolResult::error("Query failed");
         assert!(error.is_error());
+    }
+
+    #[test]
+    fn test_tool_result_deserializes_without_content() {
+        // A peer may send an empty result with no `content` field.
+        let empty: CallToolResult = serde_json::from_str("{}").expect("empty object");
+        assert!(empty.content.is_empty());
+        assert_eq!(empty.is_error, None);
+
+        let only_flag: CallToolResult =
+            serde_json::from_str(r#"{"isError":true}"#).expect("isError only");
+        assert!(only_flag.content.is_empty());
+        assert_eq!(only_flag.is_error, Some(true));
     }
 
     #[test]


### PR DESCRIPTION
`CallToolResult.content` (`Vec<Content>`) had no serde default, so deserializing a result that omits `content` failed with a missing-field error. Empty results are valid and are sent by other peers without a `content` field (e.g. `{"isError":true}` or `{}`), so those responses failed to parse.

Adds `#[serde(default)]` so a missing `content` deserializes to an empty vec.

Adds a deserialization test covering `{}` and `{"isError":true}`.