### PR TITLE
fix(transport): surface JSON-RPC error bodies on non-2xx HTTP, handle 401, add HTTP test harness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CallToolResult` now deserializes when the `content` field is absent (defaults
   to empty), so results carrying only `isError` (or `{}`) from other peers parse
   instead of failing.
+- The HTTP client now delivers JSON-RPC error bodies returned with a non-2xx
+  status as responses to the awaiting request, instead of failing the whole
+  transport with "unexpected status code"; and it clears the session on
+  `401 Unauthorized` so a retry re-establishes one.
 
 ## [0.6.0] - 2026-06-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,6 +279,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,6 +1211,24 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "der"
@@ -2705,6 +2733,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]
@@ -5997,6 +6026,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/crates/mcpkit-transport/Cargo.toml
+++ b/crates/mcpkit-transport/Cargo.toml
@@ -60,6 +60,7 @@ prometheus = { workspace = true, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
+wiremock = "0.6"
 
 [build-dependencies]
 # These are only needed for regenerating proto code (development use)

--- a/crates/mcpkit-transport/src/http/client.rs
+++ b/crates/mcpkit-transport/src/http/client.rs
@@ -230,10 +230,13 @@ impl HttpTransport {
                 // 202 Accepted - no response body (for notifications)
                 Ok(())
             }
-            StatusCode::BAD_REQUEST => {
+            StatusCode::UNAUTHORIZED => {
+                // 401: credentials/session are stale. Clear the session so a
+                // retry re-establishes one, and surface an authorization error.
+                self.state.lock().await.session_id = None;
                 let body = response.text().await.unwrap_or_default();
-                Err(TransportError::Protocol {
-                    message: format!("Bad request: {body}"),
+                Err(TransportError::Connection {
+                    message: format!("Unauthorized (401): {body}"),
                 })
             }
             StatusCode::NOT_FOUND => {
@@ -243,9 +246,22 @@ impl HttpTransport {
                     message: "Session expired or not found".to_string(),
                 })
             }
-            _ => Err(TransportError::Protocol {
-                message: format!("Unexpected status code: {status}"),
-            }),
+            _ => {
+                // Other non-success codes may still carry a JSON-RPC response
+                // (e.g. an error object) in the body. Deliver it to the awaiting
+                // caller instead of tearing down the transport; only a body we
+                // cannot parse as a JSON-RPC message becomes a transport error.
+                let body = response.text().await.unwrap_or_default();
+                if let Ok(msg) = serde_json::from_str::<Message>(&body) {
+                    self.state.lock().await.message_queue.push_back(msg);
+                    self.messages_received.fetch_add(1, Ordering::Relaxed);
+                    Ok(())
+                } else {
+                    Err(TransportError::Protocol {
+                        message: format!("HTTP {status}: {body}"),
+                    })
+                }
+            }
         }
     }
 
@@ -447,5 +463,85 @@ mod tests {
             Some("test-session-123".to_string())
         );
         Ok(())
+    }
+
+    #[cfg(feature = "http")]
+    mod error_handling {
+        use super::super::HttpTransport;
+        use crate::http::config::HttpTransportConfig;
+        use crate::traits::Transport;
+        use mcpkit_core::protocol::{Message, Request, RequestId};
+        use wiremock::matchers::method;
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        async fn connect(uri: String) -> HttpTransport {
+            HttpTransport::connect(HttpTransportConfig::new(uri))
+                .await
+                .expect("connect")
+        }
+
+        #[tokio::test]
+        async fn jsonrpc_error_body_on_4xx_is_delivered_as_response() {
+            let server = MockServer::start().await;
+            let body =
+                r#"{"jsonrpc":"2.0","id":1,"error":{"code":-32601,"message":"method not found"}}"#;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(400).set_body_string(body))
+                .mount(&server)
+                .await;
+
+            let t = connect(server.uri()).await;
+            // A 4xx carrying a JSON-RPC error must be delivered as a response,
+            // not fail the whole transport.
+            t.send(Message::Request(Request::new("tools/list", 1u64)))
+                .await
+                .expect("send should not error when the body is a JSON-RPC error");
+            let msg = t.recv().await.expect("recv ok").expect("a message");
+            match msg {
+                Message::Response(r) => {
+                    assert_eq!(r.id, RequestId::Number(1));
+                    assert!(r.error.is_some(), "expected an error response");
+                }
+                other => panic!("expected response, got {other:?}"),
+            }
+        }
+
+        #[tokio::test]
+        async fn unauthorized_clears_session_and_errors() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(401).set_body_string("nope"))
+                .mount(&server)
+                .await;
+
+            let t = connect(server.uri()).await;
+            t.set_session_id("stale").await;
+            let res = t
+                .send(Message::Request(Request::new("tools/list", 1u64)))
+                .await;
+            assert!(res.is_err(), "401 must surface as an error");
+            assert!(
+                t.session_id().await.is_none(),
+                "session must be cleared on 401"
+            );
+        }
+
+        #[tokio::test]
+        async fn unparseable_non_2xx_body_is_transport_error() {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .respond_with(ResponseTemplate::new(500).set_body_string("boom"))
+                .mount(&server)
+                .await;
+
+            let t = connect(server.uri()).await;
+            let res = t
+                .send(Message::Request(Request::new("tools/list", 1u64)))
+                .await;
+            assert!(
+                res.is_err(),
+                "an unparseable non-2xx body should be a transport error"
+            );
+        }
     }
 }


### PR DESCRIPTION
The HTTP client treated most non-2xx responses as transport errors: a server returning a JSON-RPC error inside a 4xx body would tear down the transport instead of delivering the error to the awaiting request, and `401` fell into a generic "unexpected status code" arm with no session handling.

Changes:
- Non-2xx responses whose body parses as a JSON-RPC message are delivered to the recv queue as a normal response; only an unparseable body becomes a transport error. (Folds in the previous `400`-specific arm.)
- `401 Unauthorized` clears the session id (like `404`) and returns an authorization error so a retry re-establishes a session.
- Adds a `wiremock`-based HTTP test harness (dev-dependency only; does not affect the crate's 1.85 MSRV, since the MSRV job checks `--lib`) with tests for the three paths.

Server-side HTTP items (inbound `MCP-Protocol-Version` validation, session keep-alive/init-timeout, HTTP/2 `:authority`, stateless `json_response`) are tracked as a follow-up.