### PR TITLE
feat(core): add outputSchema / structuredContent fields (structured output, part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Structured tool output (MCP `outputSchema` / `structuredContent`): `Tool` gains
+  an `output_schema` field + `Tool::output_schema(..)`, and `CallToolResult` gains
+  a `structured_content` field + `CallToolResult::with_structured_content(..)`.
+  (Ergonomic typed-return `Json<T>` derivation lands in a follow-up.)
+
 ### Security
 
 - OAuth/token types (`TokenResponse`, `TokenRequest`, `AuthorizationConfig`,

--- a/benches/benches/serialization.rs
+++ b/benches/benches/serialization.rs
@@ -111,6 +111,7 @@ fn tool_definition() -> Tool {
             idempotent_hint: Some(true),
             open_world_hint: None,
         }),
+        output_schema: None,
     }
 }
 

--- a/benches/benches/tool_invocation.rs
+++ b/benches/benches/tool_invocation.rs
@@ -28,6 +28,7 @@ impl ToolHandler {
                 description: Some("Echo back the input".to_string()),
                 input_schema: json!({"type": "object", "properties": {"message": {"type": "string"}}}),
                 annotations: None,
+                output_schema: None,
             },
         );
 
@@ -46,6 +47,7 @@ impl ToolHandler {
                     "required": ["a", "b", "op"]
                 }),
                 annotations: None,
+                output_schema: None,
             },
         );
 

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -40,6 +40,12 @@ pub struct Tool {
     /// Optional annotations providing hints about tool behavior.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ToolAnnotations>,
+    /// JSON Schema describing the tool's structured output, if it produces any.
+    ///
+    /// When set, a successful result's `structuredContent` is expected to
+    /// conform to this schema (MCP structured output).
+    #[serde(rename = "outputSchema", skip_serializing_if = "Option::is_none")]
+    pub output_schema: Option<serde_json::Value>,
 }
 
 impl Tool {
@@ -54,7 +60,15 @@ impl Tool {
                 "properties": {}
             }),
             annotations: None,
+            output_schema: None,
         }
+    }
+
+    /// Set the tool's output schema (`outputSchema`).
+    #[must_use]
+    pub fn output_schema(mut self, schema: serde_json::Value) -> Self {
+        self.output_schema = Some(schema);
+        self
     }
 
     /// Set the tool's description.
@@ -280,6 +294,13 @@ pub struct CallToolResult {
     /// If true, this result represents an error.
     #[serde(rename = "isError", skip_serializing_if = "Option::is_none")]
     pub is_error: Option<bool>,
+    /// Structured result conforming to the tool's `outputSchema`, if any.
+    #[serde(
+        rename = "structuredContent",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub structured_content: Option<serde_json::Value>,
 }
 
 impl CallToolResult {
@@ -289,6 +310,7 @@ impl CallToolResult {
         Self {
             content: vec![Content::text(text)],
             is_error: None,
+            structured_content: None,
         }
     }
 
@@ -298,6 +320,7 @@ impl CallToolResult {
         Self {
             content,
             is_error: None,
+            structured_content: None,
         }
     }
 
@@ -307,7 +330,15 @@ impl CallToolResult {
         Self {
             content: vec![Content::text(message)],
             is_error: Some(true),
+            structured_content: None,
         }
+    }
+
+    /// Attach structured content (matching the tool's `outputSchema`).
+    #[must_use]
+    pub fn with_structured_content(mut self, value: serde_json::Value) -> Self {
+        self.structured_content = Some(value);
+        self
     }
 
     /// Check if this result indicates an error.
@@ -508,6 +539,27 @@ mod tests {
 
         let error = CallToolResult::error("Query failed");
         assert!(error.is_error());
+    }
+
+    #[test]
+    fn test_output_schema_and_structured_content_serde() {
+        // Omitted by default.
+        let tool = Tool::new("t");
+        let j = serde_json::to_value(&tool).unwrap();
+        assert!(j.get("outputSchema").is_none());
+
+        // Present + camelCase when set.
+        let tool = Tool::new("t").output_schema(serde_json::json!({"type": "object"}));
+        let j = serde_json::to_value(&tool).unwrap();
+        assert_eq!(j["outputSchema"], serde_json::json!({"type": "object"}));
+
+        let res =
+            CallToolResult::text("ok").with_structured_content(serde_json::json!({"answer": 42}));
+        let j = serde_json::to_value(&res).unwrap();
+        assert_eq!(j["structuredContent"], serde_json::json!({"answer": 42}));
+        // Round-trips and stays absent when unset.
+        let plain: CallToolResult = serde_json::from_str(r#"{"content":[]}"#).expect("deserialize");
+        assert!(plain.structured_content.is_none());
     }
 
     #[test]

--- a/crates/mcpkit-macros/src/server.rs
+++ b/crates/mcpkit-macros/src/server.rs
@@ -540,6 +540,7 @@ fn generate_tool_handler(tools: &[ToolMethod], self_ty: &syn::Type) -> TokenStre
                         idempotent_hint: Some(#idempotent),
                         open_world_hint: None,
                     }),
+                    output_schema: None,
                 }
             }
         })

--- a/crates/mcpkit-server/src/capability/tools.rs
+++ b/crates/mcpkit-server/src/capability/tools.rs
@@ -246,6 +246,7 @@ impl ToolBuilder {
             description: self.description,
             input_schema: self.input_schema,
             annotations,
+            output_schema: None,
         }
     }
 }

--- a/crates/mcpkit-testing/src/mock.rs
+++ b/crates/mcpkit-testing/src/mock.rs
@@ -113,6 +113,7 @@ impl MockTool {
             description: self.description.clone(),
             input_schema: self.input_schema.clone(),
             annotations: self.annotations.clone(),
+            output_schema: None,
         }
     }
 

--- a/mcpkit/tests/tool_schema_compatibility.rs
+++ b/mcpkit/tests/tool_schema_compatibility.rs
@@ -233,6 +233,7 @@ fn test_call_tool_result_is_error_field_casing() -> Result<(), Box<dyn std::erro
     let error_result = CallToolResult {
         content: vec![Content::text("Error message")],
         is_error: Some(true),
+        structured_content: None,
     };
 
     let json_str = serde_json::to_string(&error_result)?;


### PR DESCRIPTION
Adds the MCP structured-output fields, which mcpkit did not previously support:
- `Tool.output_schema` (serialized as `outputSchema`) + `Tool::output_schema(schema)`.
- `CallToolResult.structured_content` (serialized as `structuredContent`) + `CallToolResult::with_structured_content(value)`.

Both fields are `Option` and skip-serialized when `None`, so the change is additive (no wire change for existing results). All `Tool`/`CallToolResult` constructions in the workspace are updated; the `#[mcp_server]` macro emits `output_schema: None`.

A follow-up will add a `Json<T>` return wrapper so the macro can derive `outputSchema` from the return type and serialize the value into `structuredContent`, plus optional validation.

Adds a serde test (camelCase field names, omitted-when-`None`, round-trip).