### PR TITLE
feat: Json<T> tool-return wrapper for structured output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Structured tool output (MCP `outputSchema` / `structuredContent`): `Tool` gains
   an `output_schema` field + `Tool::output_schema(..)`, and `CallToolResult` gains
   a `structured_content` field + `CallToolResult::with_structured_content(..)`.
-  (Ergonomic typed-return `Json<T>` derivation lands in a follow-up.)
+- `Json<T>` tool-return wrapper: a `#[tool]` method may return `Json(value)` (or
+  `Result<Json<T>, McpError>`) to populate the result's `structuredContent` from
+  a serializable `T`, with a pretty-printed JSON text fallback in `content`. Tool
+  methods may now return any type that converts into `ToolOutput`.
 
 ### Security
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2644,6 +2644,7 @@ dependencies = [
  "mcpkit",
  "mcpkit-core",
  "mcpkit-macros",
+ "serde",
  "serde_json",
  "tokio",
  "trybuild",

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -428,6 +428,21 @@ impl From<ToolOutput> for CallToolResult {
     }
 }
 
+/// Typed structured-output wrapper for tool return values.
+///
+/// Returning `Json(value)` from a tool serializes `value` into the result's
+/// `structuredContent`, with a pretty-printed JSON fallback in `content`.
+#[derive(Debug, Clone)]
+pub struct Json<T>(pub T);
+
+impl<T: Serialize> From<Json<T>> for ToolOutput {
+    fn from(json: Json<T>) -> Self {
+        let structured = serde_json::to_value(&json.0).unwrap_or(serde_json::Value::Null);
+        let text = serde_json::to_string_pretty(&json.0).unwrap_or_default();
+        Self::Success(CallToolResult::text(text).with_structured_content(structured))
+    }
+}
+
 impl From<String> for ToolOutput {
     /// Convert a string into a text `ToolOutput`.
     ///

--- a/crates/mcpkit-macros-tests/Cargo.toml
+++ b/crates/mcpkit-macros-tests/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 mcpkit = { path = "../../mcpkit" }
 mcpkit-macros = { path = "../mcpkit-macros" }
 mcpkit-core = { path = "../mcpkit-core" }
+serde.workspace = true
 serde_json.workspace = true
 trybuild = "1.0"
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/mcpkit-macros-tests/tests/structured_output.rs
+++ b/crates/mcpkit-macros-tests/tests/structured_output.rs
@@ -1,0 +1,63 @@
+//! A `#[tool]` returning `Json<T>` populates the result's `structuredContent`.
+
+use mcpkit::mcp_server;
+use mcpkit::server::{Context, NoOpPeer, ToolHandler};
+use mcpkit::types::{CallToolResult, Json};
+use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+use mcpkit_core::protocol::RequestId;
+use mcpkit_core::protocol_version::ProtocolVersion;
+use serde::Serialize;
+
+#[derive(Serialize)]
+struct Sum {
+    total: i64,
+}
+
+struct Calc;
+
+#[mcp_server(name = "calc", version = "1.0.0")]
+impl Calc {
+    /// Add two numbers and return structured output.
+    #[tool(description = "add")]
+    async fn add(&self, a: i64, b: i64) -> Json<Sum> {
+        Json(Sum { total: a + b })
+    }
+}
+
+#[tokio::test]
+async fn json_return_populates_structured_content() {
+    let handler = Calc;
+    let request_id = RequestId::Number(1);
+    let client_caps = ClientCapabilities::default();
+    let server_caps = ServerCapabilities::default();
+    let peer = NoOpPeer;
+    let ctx = Context::new(
+        &request_id,
+        None,
+        &client_caps,
+        &server_caps,
+        ProtocolVersion::LATEST,
+        &peer,
+    );
+
+    let output = <Calc as ToolHandler>::call_tool(
+        &handler,
+        "add",
+        serde_json::json!({"a": 2, "b": 3}),
+        &ctx,
+    )
+    .await
+    .expect("call_tool");
+
+    let result: CallToolResult = output.into();
+    assert_eq!(
+        result.structured_content,
+        Some(serde_json::json!({"total": 5})),
+        "Json<T> return should populate structuredContent"
+    );
+    // A human-readable JSON fallback is still present in content.
+    assert!(
+        !result.content.is_empty(),
+        "expected a text content fallback"
+    );
+}

--- a/crates/mcpkit-macros/src/codegen.rs
+++ b/crates/mcpkit-macros/src/codegen.rs
@@ -179,10 +179,14 @@ impl ToolMethod {
             quote!(self.#method_name(#(#param_names),*))
         };
 
+        // Convert the return value into `ToolOutput` via `Into`, so a tool may
+        // return `ToolOutput` directly or any type that converts into it (e.g.
+        // `Json<T>` for structured output). `ToolOutput -> ToolOutput` is the
+        // identity conversion, so existing tools are unaffected.
         let call_with_conversion = if self.returns_result {
-            quote!(#call)
+            quote!(#call.map(::core::convert::Into::into))
         } else {
-            quote!(Ok(#call))
+            quote!(Ok(::core::convert::Into::into(#call)))
         };
 
         quote! {


### PR DESCRIPTION
Adds `Json<T>`, a tool-return wrapper that serializes its value into a result's `structuredContent`, with a pretty-printed JSON fallback in `content`:

```rust
#[tool(description = "add")]
async fn add(&self, a: i64, b: i64) -> Json<Sum> {
    Json(Sum { total: a + b })
}
```

The `#[mcp_server]` macro now converts a tool's return value into `ToolOutput` via `Into`, so a `#[tool]` may return `ToolOutput` directly or any type that converts into it (including `Json<T>`). `ToolOutput -> ToolOutput` is the identity conversion, so existing tools are unaffected.

Adds a macro integration test asserting a tool returning `Json<T>` populates `structuredContent` and still includes a text fallback.

Follow-up: derive the tool's `outputSchema` from `T` (so `tools/list` advertises the schema) — the `ToolInput` derive already provides the schema method this will reuse.