### PR TITLE
feat(macros): derive tool outputSchema from a Json<T> return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Result<Json<T>, McpError>`) to populate the result's `structuredContent` from
   a serializable `T`, with a pretty-printed JSON text fallback in `content`. Tool
   methods may now return any type that converts into `ToolOutput`.
+- A `#[tool]` returning `Json<T>` now also advertises the tool's `outputSchema`,
+  derived from `T` (which should derive `ToolInput` in addition to `Serialize`).
 
 ### Security
 

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -432,6 +432,10 @@ impl From<ToolOutput> for CallToolResult {
 ///
 /// Returning `Json(value)` from a tool serializes `value` into the result's
 /// `structuredContent`, with a pretty-printed JSON fallback in `content`.
+///
+/// When a `#[tool]` method returns `Json<T>`, the `#[mcp_server]` macro also
+/// derives the tool's `outputSchema` from `T`, so `T` should derive `ToolInput`
+/// in addition to `serde::Serialize`.
 #[derive(Debug, Clone)]
 pub struct Json<T>(pub T);
 

--- a/crates/mcpkit-macros-tests/tests/structured_output.rs
+++ b/crates/mcpkit-macros-tests/tests/structured_output.rs
@@ -1,5 +1,6 @@
 //! A `#[tool]` returning `Json<T>` populates the result's `structuredContent`.
 
+use mcpkit::ToolInput;
 use mcpkit::mcp_server;
 use mcpkit::server::{Context, NoOpPeer, ToolHandler};
 use mcpkit::types::{CallToolResult, Json};
@@ -8,8 +9,9 @@ use mcpkit_core::protocol::RequestId;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use serde::Serialize;
 
-#[derive(Serialize)]
+#[derive(Serialize, ToolInput)]
 struct Sum {
+    /// The sum of the two operands.
     total: i64,
 }
 
@@ -60,4 +62,31 @@ async fn json_return_populates_structured_content() {
         !result.content.is_empty(),
         "expected a text content fallback"
     );
+}
+
+#[tokio::test]
+async fn json_return_advertises_output_schema() {
+    let handler = Calc;
+    let request_id = RequestId::Number(1);
+    let client_caps = ClientCapabilities::default();
+    let server_caps = ServerCapabilities::default();
+    let peer = NoOpPeer;
+    let ctx = Context::new(
+        &request_id,
+        None,
+        &client_caps,
+        &server_caps,
+        ProtocolVersion::LATEST,
+        &peer,
+    );
+
+    let tools = <Calc as ToolHandler>::list_tools(&handler, &ctx)
+        .await
+        .expect("list_tools");
+    let add = tools.iter().find(|t| t.name == "add").expect("add tool");
+    let schema = add
+        .output_schema
+        .as_ref()
+        .expect("output_schema should be derived from the Json<Sum> return");
+    assert_eq!(schema["properties"]["total"]["type"], "integer");
 }

--- a/crates/mcpkit-macros/src/codegen.rs
+++ b/crates/mcpkit-macros/src/codegen.rs
@@ -32,6 +32,8 @@ pub struct ToolMethod {
     pub is_async: bool,
     /// Whether the return type is Result
     pub returns_result: bool,
+    /// The `T` of a `Json<T>` return, whose schema is the tool's `outputSchema`.
+    pub output_type: Option<Type>,
 }
 
 /// Information about a tool parameter.
@@ -350,6 +352,34 @@ pub fn is_result_type(ret: &ReturnType) -> bool {
         }
         ReturnType::Default => false,
     }
+}
+
+/// If a tool returns `Json<T>` (optionally wrapped in `Result<_, E>`), return
+/// the inner `T`. Its schema becomes the tool's `outputSchema`.
+pub fn output_schema_type(ret: &ReturnType) -> Option<Type> {
+    let ReturnType::Type(_, ty) = ret else {
+        return None;
+    };
+    // Unwrap `Result<X, _>` to `X`, otherwise use the type directly.
+    let inner = match ty.as_ref() {
+        Type::Path(path) => {
+            let seg = path.path.segments.last()?;
+            if seg.ident == "Result" {
+                first_type_arg(seg)?
+            } else {
+                ty.as_ref()
+            }
+        }
+        _ => return None,
+    };
+    // `inner` must be `Json<T>`.
+    if let Type::Path(path) = inner {
+        let seg = path.path.segments.last()?;
+        if seg.ident == "Json" {
+            return first_type_arg(seg).cloned();
+        }
+    }
+    None
 }
 
 /// Generate a unique identifier.

--- a/crates/mcpkit-macros/src/server.rs
+++ b/crates/mcpkit-macros/src/server.rs
@@ -7,7 +7,7 @@ use quote::quote;
 use syn::{Attribute, Error, FnArg, ImplItem, ImplItemFn, ItemImpl, Result, parse2};
 
 use crate::attrs::{PromptAttrs, ResourceAttrs, ServerAttrs, ToolAttrs};
-use crate::codegen::{ToolMethod, ToolParam, extract_param, is_result_type};
+use crate::codegen::{ToolMethod, ToolParam, extract_param, is_result_type, output_schema_type};
 
 /// Information about a resource method extracted from the AST.
 #[derive(Debug)]
@@ -222,6 +222,7 @@ fn extract_tool_info(method: &mut ImplItemFn, attrs: ToolAttrs) -> Result<ToolMe
 
     let is_async = method.sig.asyncness.is_some();
     let returns_result = is_result_type(&method.sig.output);
+    let output_type = output_schema_type(&method.sig.output);
 
     Ok(ToolMethod {
         name,
@@ -233,6 +234,7 @@ fn extract_tool_info(method: &mut ImplItemFn, attrs: ToolAttrs) -> Result<ToolMe
         params,
         is_async,
         returns_result,
+        output_type,
     })
 }
 
@@ -528,6 +530,13 @@ fn generate_tool_handler(tools: &[ToolMethod], self_ty: &syn::Type) -> TokenStre
             let idempotent = tool.idempotent;
             let read_only = tool.read_only;
 
+            // Derive the output schema from a `Json<T>` return type, if present.
+            let output_schema = if let Some(ty) = &tool.output_type {
+                quote!(Some(<#ty>::tool_input_schema()))
+            } else {
+                quote!(None)
+            };
+
             quote! {
                 ::mcpkit::types::Tool {
                     name: #name.to_string(),
@@ -540,7 +549,7 @@ fn generate_tool_handler(tools: &[ToolMethod], self_ty: &syn::Type) -> TokenStre
                         idempotent_hint: Some(#idempotent),
                         open_world_hint: None,
                     }),
-                    output_schema: None,
+                    output_schema: #output_schema,
                 }
             }
         })


### PR DESCRIPTION
Completes structured-output support: a `#[tool]` returning `Json<T>` now advertises the tool's `outputSchema` (so `tools/list` describes the structured result), in addition to populating `structuredContent`.

The macro extracts `T` from a `Json<T>` (or `Result<Json<T>, _>`) return type and emits `output_schema: Some(<T>::tool_input_schema())` in the generated `Tool`. `T` should therefore derive `ToolInput` (which provides the schema method) in addition to `Serialize`. Tools that don't return `Json<T>` are unaffected — `outputSchema` stays `None`.

```rust
#[derive(Serialize, ToolInput)]
struct Sum { total: i64 }

#[tool(description = "add")]
async fn add(&self, a: i64, b: i64) -> Json<Sum> { Json(Sum { total: a + b }) }
// tools/list now reports add.outputSchema describing { total: integer }
```

Extends the structured-output test to assert the derived `outputSchema`. `cargo test`, `--all-features` clippy `-D warnings`, fmt all pass.