### PR TITLE
fix(transport): accept all supported MCP-Protocol-Version values on the HTTP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   status as responses to the awaiting request, instead of failing the whole
   transport with "unexpected status code"; and it clears the session on
   `401 Unauthorized` so a retry re-establishes one.
+- The HTTP server now accepts any supported `MCP-Protocol-Version` header value
+  (and a request that omits the header, assumed to be `2025-03-26` for
+  backwards compatibility), rejecting only unsupported versions with
+  `400 Bad Request`. Previously it rejected every request whose header was not
+  the single latest version, breaking older but supported clients.
 
 ## [0.6.0] - 2026-06-18
 

--- a/crates/mcpkit-transport/src/http/server.rs
+++ b/crates/mcpkit-transport/src/http/server.rs
@@ -5,6 +5,7 @@
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
+use mcpkit_core::ProtocolVersion;
 use mcpkit_core::protocol::Message;
 
 use crate::error::TransportError;
@@ -652,17 +653,25 @@ async fn handle_mcp_post_with_state(
             .into_response();
     }
 
-    // Check protocol version
-    let version = headers
-        .get(MCP_PROTOCOL_VERSION_HEADER)
-        .and_then(|v| v.to_str().ok());
-
-    if version != Some(MCP_PROTOCOL_VERSION) {
-        return (
-            StatusCode::BAD_REQUEST,
-            format!("Missing or invalid {MCP_PROTOCOL_VERSION_HEADER} header"),
-        )
-            .into_response();
+    // Validate the protocol version header.
+    //
+    // A request that omits the header is assumed to use protocol version
+    // `2025-03-26` (the header was introduced in `2025-06-18`), so a missing
+    // header is accepted for backwards compatibility. A header that is present
+    // but names an unsupported version is rejected with `400 Bad Request`.
+    if let Some(raw) = headers.get(MCP_PROTOCOL_VERSION_HEADER) {
+        let supported = raw
+            .to_str()
+            .ok()
+            .and_then(|v| v.parse::<ProtocolVersion>().ok())
+            .is_some();
+        if !supported {
+            return (
+                StatusCode::BAD_REQUEST,
+                format!("Unsupported {MCP_PROTOCOL_VERSION_HEADER} header"),
+            )
+                .into_response();
+        }
     }
 
     // Parse message
@@ -976,5 +985,54 @@ mod tests {
         // Strict mode with no configured origins rejects all
         assert!(!config.is_origin_allowed(Some("https://anything.com")));
         assert!(!config.is_origin_allowed(None));
+    }
+
+    // Protocol version header validation (POST handler)
+
+    fn post_request(
+        headers: axum::http::HeaderMap,
+    ) -> impl std::future::Future<Output = axum::http::StatusCode> {
+        let config = std::sync::Arc::new(HttpServerConfig::new());
+        let body = r#"{"jsonrpc":"2.0","method":"ping","id":1}"#.to_string();
+        async move {
+            handle_mcp_post_with_state(axum::extract::State(config), headers, body)
+                .await
+                .status()
+        }
+    }
+
+    #[tokio::test]
+    async fn post_accepts_missing_protocol_version_header() {
+        // The header was introduced in 2025-06-18; an absent header is assumed
+        // to mean 2025-03-26 and must be accepted for backwards compatibility.
+        let status = post_request(axum::http::HeaderMap::new()).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_accepts_supported_older_protocol_version() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(MCP_PROTOCOL_VERSION_HEADER, "2025-06-18".parse().unwrap());
+        let status = post_request(headers).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_accepts_current_protocol_version() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(
+            MCP_PROTOCOL_VERSION_HEADER,
+            MCP_PROTOCOL_VERSION.parse().unwrap(),
+        );
+        let status = post_request(headers).await;
+        assert_eq!(status, axum::http::StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn post_rejects_unsupported_protocol_version() {
+        let mut headers = axum::http::HeaderMap::new();
+        headers.insert(MCP_PROTOCOL_VERSION_HEADER, "1999-01-01".parse().unwrap());
+        let status = post_request(headers).await;
+        assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
     }
 }


### PR DESCRIPTION
## Problem

The HTTP server's POST handler rejected every request whose `MCP-Protocol-Version` header was not the single latest version, and rejected requests that omitted the header entirely. This breaks clients negotiating an older but still-supported protocol version, and clients predating the header (it was introduced in `2025-06-18`).

## Fix

Validate the header rather than exact-matching it:

- A header that is present must parse to a supported `ProtocolVersion`, otherwise the request is rejected with `400 Bad Request`.
- A missing header is accepted and assumed to be `2025-03-26` for backwards compatibility.

## Tests

Handler-level tests cover a missing header, a supported older version, the current version, and an unsupported version (calling the POST handler directly).