### PR TITLE
fix(adapters): assume 2025-03-26 when MCP-Protocol-Version header is absent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   backwards compatibility), rejecting only unsupported versions with
   `400 Bad Request`. Previously it rejected every request whose header was not
   the single latest version, breaking older but supported clients.
+- The framework adapters (`mcpkit-axum`, `mcpkit-actix`, `mcpkit-warp`,
+  `mcpkit-rocket`) now accept requests that omit the `MCP-Protocol-Version`
+  header, assuming `2025-03-26` for backwards compatibility per the MCP
+  Streamable HTTP specification. Previously a missing header was rejected with
+  `400 Bad Request`; a present-but-unsupported value is still rejected.
 
 ## [0.6.0] - 2026-06-18
 

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -23,7 +23,9 @@ use tracing::{debug, info, warn};
 ///
 /// # Headers
 ///
-/// - `mcp-protocol-version`: Required. Must be a supported protocol version.
+/// - `mcp-protocol-version`: Optional. If present, must name a supported
+///   protocol version; if absent, `2025-03-26` is assumed for backwards
+///   compatibility.
 /// - `mcp-session-id`: Optional. Used to track sessions.
 /// - `Content-Type`: Should be `application/json`.
 ///

--- a/crates/mcpkit-actix/src/lib.rs
+++ b/crates/mcpkit-actix/src/lib.rs
@@ -116,8 +116,36 @@ pub mod prelude {
 /// Protocol versions supported by this extension.
 pub const SUPPORTED_VERSIONS: &[&str] = &["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
 
-/// Check if a protocol version is supported.
+/// Check whether a request's protocol version is acceptable.
+///
+/// Returns `true` if `version` names a supported protocol version, or if it is
+/// `None`: a request that omits the `MCP-Protocol-Version` header is assumed to
+/// use `2025-03-26` (the version predating the header) for backwards
+/// compatibility, per the MCP Streamable HTTP specification.
 #[must_use]
 pub fn is_supported_version(version: Option<&str>) -> bool {
-    version.is_some_and(|v| SUPPORTED_VERSIONS.contains(&v))
+    version.is_none_or(|v| SUPPORTED_VERSIONS.contains(&v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_supported_version;
+
+    #[test]
+    fn missing_protocol_version_header_is_accepted() {
+        // An absent header is assumed to be 2025-03-26 for backwards compatibility.
+        assert!(is_supported_version(None));
+    }
+
+    #[test]
+    fn supported_protocol_versions_are_accepted() {
+        assert!(is_supported_version(Some("2024-11-05")));
+        assert!(is_supported_version(Some("2025-03-26")));
+        assert!(is_supported_version(Some("2025-11-25")));
+    }
+
+    #[test]
+    fn unsupported_protocol_version_is_rejected() {
+        assert!(!is_supported_version(Some("1999-01-01")));
+    }
 }

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -28,7 +28,9 @@ use tracing::{debug, info, warn};
 ///
 /// # Headers
 ///
-/// - `mcp-protocol-version`: Required. Must be a supported protocol version.
+/// - `mcp-protocol-version`: Optional. If present, must name a supported
+///   protocol version; if absent, `2025-03-26` is assumed for backwards
+///   compatibility.
 /// - `mcp-session-id`: Optional. Used to track sessions.
 /// - `Content-Type`: Should be `application/json`.
 ///

--- a/crates/mcpkit-axum/src/lib.rs
+++ b/crates/mcpkit-axum/src/lib.rs
@@ -127,8 +127,36 @@ pub mod prelude {
 /// Protocol versions supported by this extension.
 pub const SUPPORTED_VERSIONS: &[&str] = &["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
 
-/// Check if a protocol version is supported.
+/// Check whether a request's protocol version is acceptable.
+///
+/// Returns `true` if `version` names a supported protocol version, or if it is
+/// `None`: a request that omits the `MCP-Protocol-Version` header is assumed to
+/// use `2025-03-26` (the version predating the header) for backwards
+/// compatibility, per the MCP Streamable HTTP specification.
 #[must_use]
 pub fn is_supported_version(version: Option<&str>) -> bool {
-    version.is_some_and(|v| SUPPORTED_VERSIONS.contains(&v))
+    version.is_none_or(|v| SUPPORTED_VERSIONS.contains(&v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_supported_version;
+
+    #[test]
+    fn missing_protocol_version_header_is_accepted() {
+        // An absent header is assumed to be 2025-03-26 for backwards compatibility.
+        assert!(is_supported_version(None));
+    }
+
+    #[test]
+    fn supported_protocol_versions_are_accepted() {
+        assert!(is_supported_version(Some("2024-11-05")));
+        assert!(is_supported_version(Some("2025-03-26")));
+        assert!(is_supported_version(Some("2025-11-25")));
+    }
+
+    #[test]
+    fn unsupported_protocol_version_is_rejected() {
+        assert!(!is_supported_version(Some("1999-01-01")));
+    }
 }

--- a/crates/mcpkit-rocket/src/lib.rs
+++ b/crates/mcpkit-rocket/src/lib.rs
@@ -124,8 +124,36 @@ pub mod prelude {
 /// Protocol versions supported by this extension.
 pub const SUPPORTED_VERSIONS: &[&str] = &["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
 
-/// Check if a protocol version is supported.
+/// Check whether a request's protocol version is acceptable.
+///
+/// Returns `true` if `version` names a supported protocol version, or if it is
+/// `None`: a request that omits the `MCP-Protocol-Version` header is assumed to
+/// use `2025-03-26` (the version predating the header) for backwards
+/// compatibility, per the MCP Streamable HTTP specification.
 #[must_use]
 pub fn is_supported_version(version: Option<&str>) -> bool {
-    version.is_some_and(|v| SUPPORTED_VERSIONS.contains(&v))
+    version.is_none_or(|v| SUPPORTED_VERSIONS.contains(&v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_supported_version;
+
+    #[test]
+    fn missing_protocol_version_header_is_accepted() {
+        // An absent header is assumed to be 2025-03-26 for backwards compatibility.
+        assert!(is_supported_version(None));
+    }
+
+    #[test]
+    fn supported_protocol_versions_are_accepted() {
+        assert!(is_supported_version(Some("2024-11-05")));
+        assert!(is_supported_version(Some("2025-03-26")));
+        assert!(is_supported_version(Some("2025-11-25")));
+    }
+
+    #[test]
+    fn unsupported_protocol_version_is_rejected() {
+        assert!(!is_supported_version(Some("1999-01-01")));
+    }
 }

--- a/crates/mcpkit-warp/src/lib.rs
+++ b/crates/mcpkit-warp/src/lib.rs
@@ -61,8 +61,36 @@ pub mod prelude {
 /// Protocol versions supported by this extension.
 pub const SUPPORTED_VERSIONS: &[&str] = &["2024-11-05", "2025-03-26", "2025-06-18", "2025-11-25"];
 
-/// Check if a protocol version is supported.
+/// Check whether a request's protocol version is acceptable.
+///
+/// Returns `true` if `version` names a supported protocol version, or if it is
+/// `None`: a request that omits the `MCP-Protocol-Version` header is assumed to
+/// use `2025-03-26` (the version predating the header) for backwards
+/// compatibility, per the MCP Streamable HTTP specification.
 #[must_use]
 pub fn is_supported_version(version: Option<&str>) -> bool {
-    version.is_some_and(|v| SUPPORTED_VERSIONS.contains(&v))
+    version.is_none_or(|v| SUPPORTED_VERSIONS.contains(&v))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_supported_version;
+
+    #[test]
+    fn missing_protocol_version_header_is_accepted() {
+        // An absent header is assumed to be 2025-03-26 for backwards compatibility.
+        assert!(is_supported_version(None));
+    }
+
+    #[test]
+    fn supported_protocol_versions_are_accepted() {
+        assert!(is_supported_version(Some("2024-11-05")));
+        assert!(is_supported_version(Some("2025-03-26")));
+        assert!(is_supported_version(Some("2025-11-25")));
+    }
+
+    #[test]
+    fn unsupported_protocol_version_is_rejected() {
+        assert!(!is_supported_version(Some("1999-01-01")));
+    }
 }


### PR DESCRIPTION
## Problem

The `mcpkit-axum`, `mcpkit-actix`, `mcpkit-warp`, and `mcpkit-rocket` adapters rejected any request that omitted the `MCP-Protocol-Version` header with `400 Bad Request`. The MCP Streamable HTTP specification says a server should assume protocol version `2025-03-26` when the header is absent (the header was introduced in `2025-06-18`), so clients predating the header — and clients that simply omit it — were turned away.

## Fix

`is_supported_version` now treats a missing version as acceptable (assuming `2025-03-26`) while still rejecting a present-but-unsupported value with `400 Bad Request`. The handler docs that described the header as required are updated to match.

## Tests

Each adapter gains unit tests for the absent, supported, and unsupported cases.