### PR TITLE
fix(adapters): reap expired sessions and bound un-initialized ones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   methods may now return any type that converts into `ToolOutput`.
 - A `#[tool]` returning `Json<T>` now also advertises the tool's `outputSchema`,
   derived from `T` (which should derive `ToolInput` in addition to `Serialize`).
+- `SessionStore::with_init_timeout` and `Session::is_reapable` in the
+  `mcpkit-axum` and `mcpkit-actix` adapters, plus a `DEFAULT_INIT_TIMEOUT`
+  constant, to bound how long a session created but never initialized is kept.
 
 ### Security
 
@@ -59,6 +62,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   header, assuming `2025-03-26` for backwards compatibility per the MCP
   Streamable HTTP specification. Previously a missing header was rejected with
   `400 Bad Request`; a present-but-unsupported value is still rejected.
+- The `mcpkit-axum` and `mcpkit-actix` session stores now reap expired sessions
+  when a new one is created, so the store stays bounded without a background
+  cleanup task; previously sessions accumulated indefinitely because the
+  cleanup routines were never invoked on the default request path. Sessions are
+  also reaped if created but not initialized within the initialization timeout,
+  and the `initialize` request now marks its session initialized.
 
 ## [0.6.0] - 2026-06-18
 

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -87,6 +87,14 @@ where
                 "Handling MCP request"
             );
 
+            // Mark the session initialized so it is no longer subject to the
+            // initialization timeout.
+            if request.method.as_ref() == "initialize" {
+                state
+                    .sessions
+                    .update(&session_id, |s| s.mark_initialized(None));
+            }
+
             // Create a basic response using the handler's capabilities
             let response = create_response_for_request(&state, &request).await;
 

--- a/crates/mcpkit-actix/src/lib.rs
+++ b/crates/mcpkit-actix/src/lib.rs
@@ -92,7 +92,8 @@ pub use error::ExtensionError;
 pub use handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
 pub use router::McpRouter;
 pub use session::{
-    EventStore, EventStoreConfig, Session, SessionManager, SessionStore, StoredEvent,
+    DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionManager, SessionStore,
+    StoredEvent,
 };
 pub use state::{McpState, OAuthState};
 
@@ -108,7 +109,8 @@ pub mod prelude {
     pub use crate::handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
     pub use crate::router::McpRouter;
     pub use crate::session::{
-        EventStore, EventStoreConfig, Session, SessionManager, SessionStore, StoredEvent,
+        DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionManager, SessionStore,
+        StoredEvent,
     };
     pub use crate::state::{McpState, OAuthState};
 }

--- a/crates/mcpkit-actix/src/session.rs
+++ b/crates/mcpkit-actix/src/session.rs
@@ -12,6 +12,10 @@ use tokio::sync::broadcast;
 /// Default session timeout duration (1 hour).
 pub const DEFAULT_SESSION_TIMEOUT: Duration = Duration::from_secs(3600);
 
+/// Default timeout after which a session created but never initialized is
+/// reaped.
+pub const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Default SSE broadcast channel capacity.
 pub const DEFAULT_SSE_CAPACITY: usize = 100;
 
@@ -48,6 +52,19 @@ impl Session {
     #[must_use]
     pub fn is_expired(&self, timeout: Duration) -> bool {
         self.last_active.elapsed() >= timeout
+    }
+
+    /// Check whether the session should be reaped, given idle and
+    /// initialization timeouts.
+    ///
+    /// A session is reaped when it has been idle longer than `idle_timeout`, or
+    /// when it has not completed initialization within `init_timeout` of being
+    /// created. The latter bounds resources held by half-open sessions that are
+    /// created but never initialized.
+    #[must_use]
+    pub fn is_reapable(&self, idle_timeout: Duration, init_timeout: Duration) -> bool {
+        self.is_expired(idle_timeout)
+            || (!self.initialized && self.created_at.elapsed() >= init_timeout)
     }
 
     /// Mark the session as active.
@@ -456,27 +473,44 @@ impl SessionManager {
 pub struct SessionStore {
     sessions: DashMap<String, Session>,
     timeout: Duration,
+    init_timeout: Duration,
 }
 
 impl SessionStore {
-    /// Create a new session store with the given timeout.
+    /// Create a new session store with the given idle timeout.
+    ///
+    /// The initialization timeout defaults to [`DEFAULT_INIT_TIMEOUT`]; use
+    /// [`Self::with_init_timeout`] to change it.
     #[must_use]
     pub fn new(timeout: Duration) -> Self {
         Self {
             sessions: DashMap::new(),
             timeout,
+            init_timeout: DEFAULT_INIT_TIMEOUT,
         }
     }
 
-    /// Create a new session store with a default 1-hour timeout.
+    /// Create a new session store with a default 1-hour idle timeout.
     #[must_use]
     pub fn with_default_timeout() -> Self {
         Self::new(DEFAULT_SESSION_TIMEOUT)
     }
 
+    /// Set the timeout after which a session that never completed
+    /// initialization is reaped.
+    #[must_use]
+    pub const fn with_init_timeout(mut self, init_timeout: Duration) -> Self {
+        self.init_timeout = init_timeout;
+        self
+    }
+
     /// Create a new session and return its ID.
+    ///
+    /// Expired sessions are reaped first, so the store stays bounded without a
+    /// background cleanup task.
     #[must_use]
     pub fn create(&self) -> String {
+        self.cleanup_expired();
         let id = uuid::Uuid::new_v4().to_string();
         self.sessions.insert(id.clone(), Session::new(id.clone()));
         id
@@ -505,10 +539,13 @@ impl SessionStore {
         }
     }
 
-    /// Remove expired sessions.
+    /// Remove expired sessions (idle past the timeout, or never initialized
+    /// past the initialization timeout).
     pub fn cleanup_expired(&self) {
         let timeout = self.timeout;
-        self.sessions.retain(|_, s| !s.is_expired(timeout));
+        let init_timeout = self.init_timeout;
+        self.sessions
+            .retain(|_, s| !s.is_reapable(timeout, init_timeout));
     }
 
     /// Remove a session.
@@ -569,6 +606,52 @@ mod tests {
 
         let _ = store.remove(&id);
         assert!(store.get(&id).is_none());
+    }
+
+    #[test]
+    fn uninitialized_session_is_reapable_after_init_timeout()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut session = Session::new("s".to_string());
+        let idle = Duration::from_secs(3600);
+        let init = Duration::from_secs(30);
+
+        // A fresh, uninitialized session is not yet reapable.
+        assert!(!session.is_reapable(idle, init));
+
+        // Once it has existed longer than the init timeout without
+        // initializing, it becomes reapable.
+        session.created_at = Instant::now()
+            .checked_sub(Duration::from_secs(60))
+            .ok_or("Failed to subtract duration")?;
+        assert!(session.is_reapable(idle, init));
+
+        // After initialization, the init timeout no longer applies.
+        session.mark_initialized(None);
+        assert!(!session.is_reapable(idle, init));
+        Ok(())
+    }
+
+    #[test]
+    fn create_reaps_uninitialized_sessions_past_init_timeout() {
+        let store = SessionStore::new(Duration::from_secs(3600)).with_init_timeout(Duration::ZERO);
+        let id = store.create();
+
+        // A zero init timeout makes the uninitialized session reapable, so the
+        // next create() sweeps it away.
+        let _other = store.create();
+        assert!(store.get(&id).is_none());
+    }
+
+    #[test]
+    fn create_keeps_initialized_sessions() {
+        let store = SessionStore::new(Duration::from_secs(3600)).with_init_timeout(Duration::ZERO);
+        let id = store.create();
+        store.update(&id, |s| s.mark_initialized(None));
+
+        // An initialized session is not subject to the init timeout and is well
+        // within the idle timeout, so it survives create-time reaping.
+        let _other = store.create();
+        assert!(store.get(&id).is_some());
     }
 
     #[tokio::test]

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -96,6 +96,14 @@ where
                 "Handling MCP request"
             );
 
+            // Mark the session initialized so it is no longer subject to the
+            // initialization timeout.
+            if request.method.as_ref() == "initialize" {
+                state
+                    .sessions
+                    .update(&session_id, |s| s.mark_initialized(None));
+            }
+
             // Create a basic response using the handler's capabilities
             // In a full implementation, this would route to the handler's methods
             let response = create_response_for_request(&state, &request).await;

--- a/crates/mcpkit-axum/src/lib.rs
+++ b/crates/mcpkit-axum/src/lib.rs
@@ -103,7 +103,8 @@ pub use error::ExtensionError;
 pub use handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
 pub use router::McpRouter;
 pub use session::{
-    EventStore, EventStoreConfig, Session, SessionManager, SessionStore, StoredEvent,
+    DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionManager, SessionStore,
+    StoredEvent,
 };
 pub use state::{McpState, OAuthState};
 
@@ -119,7 +120,8 @@ pub mod prelude {
     pub use crate::handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
     pub use crate::router::McpRouter;
     pub use crate::session::{
-        EventStore, EventStoreConfig, Session, SessionManager, SessionStore, StoredEvent,
+        DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionManager, SessionStore,
+        StoredEvent,
     };
     pub use crate::state::{McpState, OAuthState};
 }

--- a/crates/mcpkit-axum/src/session.rs
+++ b/crates/mcpkit-axum/src/session.rs
@@ -44,6 +44,19 @@ impl Session {
         self.last_active.elapsed() >= timeout
     }
 
+    /// Check whether the session should be reaped, given idle and
+    /// initialization timeouts.
+    ///
+    /// A session is reaped when it has been idle longer than `idle_timeout`, or
+    /// when it has not completed initialization within `init_timeout` of being
+    /// created. The latter bounds resources held by half-open sessions that are
+    /// created but never initialized.
+    #[must_use]
+    pub fn is_reapable(&self, idle_timeout: Duration, init_timeout: Duration) -> bool {
+        self.is_expired(idle_timeout)
+            || (!self.initialized && self.created_at.elapsed() >= init_timeout)
+    }
+
     /// Mark the session as active.
     pub fn touch(&mut self) {
         self.last_active = Instant::now();
@@ -468,6 +481,10 @@ impl SessionManager {
     }
 }
 
+/// Default timeout after which a session created but never initialized is
+/// reaped.
+pub const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// Thread-safe session store with automatic cleanup.
 ///
 /// Stores session metadata for HTTP request handling.
@@ -475,27 +492,44 @@ impl SessionManager {
 pub struct SessionStore {
     sessions: DashMap<String, Session>,
     timeout: Duration,
+    init_timeout: Duration,
 }
 
 impl SessionStore {
-    /// Create a new session store with the given timeout.
+    /// Create a new session store with the given idle timeout.
+    ///
+    /// The initialization timeout defaults to [`DEFAULT_INIT_TIMEOUT`]; use
+    /// [`Self::with_init_timeout`] to change it.
     #[must_use]
     pub fn new(timeout: Duration) -> Self {
         Self {
             sessions: DashMap::new(),
             timeout,
+            init_timeout: DEFAULT_INIT_TIMEOUT,
         }
     }
 
-    /// Create a new session store with a default 1-hour timeout.
+    /// Create a new session store with a default 1-hour idle timeout.
     #[must_use]
     pub fn with_default_timeout() -> Self {
         Self::new(Duration::from_secs(3600))
     }
 
+    /// Set the timeout after which a session that never completed
+    /// initialization is reaped.
+    #[must_use]
+    pub const fn with_init_timeout(mut self, init_timeout: Duration) -> Self {
+        self.init_timeout = init_timeout;
+        self
+    }
+
     /// Create a new session and return its ID.
+    ///
+    /// Expired sessions are reaped first, so the store stays bounded without a
+    /// background cleanup task.
     #[must_use]
     pub fn create(&self) -> String {
+        self.cleanup_expired();
         let id = uuid::Uuid::new_v4().to_string();
         self.sessions.insert(id.clone(), Session::new(id.clone()));
         id
@@ -524,10 +558,13 @@ impl SessionStore {
         }
     }
 
-    /// Remove expired sessions.
+    /// Remove expired sessions (idle past the timeout, or never initialized
+    /// past the initialization timeout).
     pub fn cleanup_expired(&self) {
         let timeout = self.timeout;
-        self.sessions.retain(|_, s| !s.is_expired(timeout));
+        let init_timeout = self.init_timeout;
+        self.sessions
+            .retain(|_, s| !s.is_reapable(timeout, init_timeout));
     }
 
     /// Remove a session.
@@ -589,6 +626,52 @@ mod tests {
 
         let _ = store.remove(&id);
         assert!(store.get(&id).is_none());
+    }
+
+    #[test]
+    fn uninitialized_session_is_reapable_after_init_timeout()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let mut session = Session::new("s".to_string());
+        let idle = Duration::from_secs(3600);
+        let init = Duration::from_secs(30);
+
+        // A fresh, uninitialized session is not yet reapable.
+        assert!(!session.is_reapable(idle, init));
+
+        // Once it has existed longer than the init timeout without
+        // initializing, it becomes reapable.
+        session.created_at = Instant::now()
+            .checked_sub(Duration::from_secs(60))
+            .ok_or("Failed to subtract duration")?;
+        assert!(session.is_reapable(idle, init));
+
+        // After initialization, the init timeout no longer applies.
+        session.mark_initialized(None);
+        assert!(!session.is_reapable(idle, init));
+        Ok(())
+    }
+
+    #[test]
+    fn create_reaps_uninitialized_sessions_past_init_timeout() {
+        let store = SessionStore::new(Duration::from_secs(3600)).with_init_timeout(Duration::ZERO);
+        let id = store.create();
+
+        // A zero init timeout makes the uninitialized session reapable, so the
+        // next create() sweeps it away.
+        let _other = store.create();
+        assert!(store.get(&id).is_none());
+    }
+
+    #[test]
+    fn create_keeps_initialized_sessions() {
+        let store = SessionStore::new(Duration::from_secs(3600)).with_init_timeout(Duration::ZERO);
+        let id = store.create();
+        store.update(&id, |s| s.mark_initialized(None));
+
+        // An initialized session is not subject to the init timeout and is well
+        // within the idle timeout, so it survives create-time reaping.
+        let _other = store.create();
+        assert!(store.get(&id).is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The `mcpkit-axum` and `mcpkit-actix` session stores exposed `cleanup_expired` / `start_cleanup_task`, but nothing on the default request path ever invoked them, so sessions created per request accumulated indefinitely — unbounded memory growth in long-running servers. Separately, the `initialized` flag was never set, so a session created but never initialized was indistinguishable from an active one.

## Fix

- `SessionStore::create` now reaps expired sessions before inserting a new one, keeping the store bounded without requiring a background cleanup task.
- A session is reaped when idle past the idle timeout, **or** when created but never initialized within a new initialization timeout (`DEFAULT_INIT_TIMEOUT` = 30s, configurable via `SessionStore::with_init_timeout`).
- The `initialize` request now marks its session initialized, exempting legitimate sessions from the initialization timeout.

## Scope

Applies to `mcpkit-axum` and `mcpkit-actix`, which already have the timeout-aware session model. The `mcpkit-warp` / `mcpkit-rocket` adapters use a simpler session store with no initialization/idle-timeout concept; bringing them to parity is tracked as a separate follow-up.

## Tests

Adds `Session::is_reapable` with tests for init-timeout reaping, create-time sweeping, and that initialized sessions survive.