### PR TITLE
fix(adapters): reap idle sessions on create in the warp and rocket stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `SessionStore::with_init_timeout` and `Session::is_reapable` in the
   `mcpkit-axum` and `mcpkit-actix` adapters, plus a `DEFAULT_INIT_TIMEOUT`
   constant, to bound how long a session created but never initialized is kept.
+- `SessionStore::with_idle_timeout` and a `DEFAULT_SESSION_TIMEOUT` constant in
+  the `mcpkit-warp` and `mcpkit-rocket` adapters, to configure the idle timeout
+  used when reaping inactive sessions.
 
 ### Security
 
@@ -68,6 +71,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cleanup routines were never invoked on the default request path. Sessions are
   also reaped if created but not initialized within the initialization timeout,
   and the `initialize` request now marks its session initialized.
+- The `mcpkit-warp` and `mcpkit-rocket` session stores now reap sessions idle
+  past the idle timeout when a new one is created, so the store stays bounded;
+  previously their cleanup routine was never invoked on the default request
+  path and sessions accumulated indefinitely.
 
 ## [0.6.0] - 2026-06-18
 

--- a/crates/mcpkit-rocket/src/lib.rs
+++ b/crates/mcpkit-rocket/src/lib.rs
@@ -103,7 +103,7 @@ pub use handler::{
     handle_sse,
 };
 pub use router::{Cors, McpRouter};
-pub use session::{SessionManager, SessionStore};
+pub use session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};
 pub use state::McpState;
 
 /// Prelude module for convenient imports.
@@ -117,7 +117,7 @@ pub mod prelude {
     pub use crate::error::RocketError;
     pub use crate::handler::{handle_mcp_post, handle_sse};
     pub use crate::router::McpRouter;
-    pub use crate::session::{SessionManager, SessionStore};
+    pub use crate::session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};
     pub use crate::state::McpState;
 }
 

--- a/crates/mcpkit-rocket/src/session.rs
+++ b/crates/mcpkit-rocket/src/session.rs
@@ -6,11 +6,15 @@ use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
+/// Default idle timeout after which an inactive session is reaped.
+pub const DEFAULT_SESSION_TIMEOUT: Duration = Duration::from_secs(3600);
+
 /// Session manager for tracking MCP client sessions.
 #[derive(Clone)]
 pub struct SessionStore {
     sessions: Arc<DashMap<String, SessionState>>,
     sse_channels: Arc<DashMap<String, broadcast::Sender<String>>>,
+    idle_timeout: Duration,
 }
 
 struct SessionState {
@@ -32,12 +36,25 @@ impl SessionStore {
         Self {
             sessions: Arc::new(DashMap::new()),
             sse_channels: Arc::new(DashMap::new()),
+            idle_timeout: DEFAULT_SESSION_TIMEOUT,
         }
     }
 
+    /// Set the idle timeout after which an inactive session is reaped on the
+    /// next [`create`](Self::create).
+    #[must_use]
+    pub const fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
+        self.idle_timeout = idle_timeout;
+        self
+    }
+
     /// Create a new session and return its ID.
+    ///
+    /// Sessions idle past the idle timeout are reaped first, so the store stays
+    /// bounded without a background cleanup task.
     #[must_use]
     pub fn create(&self) -> String {
+        self.cleanup(self.idle_timeout);
         let id = Uuid::new_v4().to_string();
         let now = Instant::now();
         self.sessions.insert(
@@ -178,6 +195,28 @@ mod tests {
         // Cleanup with 0 duration should remove all sessions
         store.cleanup(Duration::from_secs(0));
         assert!(!store.exists(&id));
+    }
+
+    #[test]
+    fn create_reaps_idle_sessions() {
+        let store = SessionStore::new().with_idle_timeout(Duration::ZERO);
+        let id = store.create();
+
+        // A zero idle timeout makes the previous session reapable, so the next
+        // create() sweeps it away.
+        let _other = store.create();
+        assert!(!store.exists(&id));
+    }
+
+    #[test]
+    fn create_keeps_recent_sessions() {
+        // The default idle timeout is an hour, so a freshly created session
+        // survives create-time reaping.
+        let store = SessionStore::new();
+        let id = store.create();
+
+        let _other = store.create();
+        assert!(store.exists(&id));
     }
 
     #[tokio::test]

--- a/crates/mcpkit-warp/src/lib.rs
+++ b/crates/mcpkit-warp/src/lib.rs
@@ -46,7 +46,7 @@ mod state;
 pub use error::WarpError;
 pub use handler::{handle_mcp_post, handle_sse};
 pub use router::McpRouter;
-pub use session::{SessionManager, SessionStore};
+pub use session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};
 pub use state::McpState;
 
 /// Prelude module for convenient imports.
@@ -54,7 +54,7 @@ pub mod prelude {
     pub use crate::error::WarpError;
     pub use crate::handler::{handle_mcp_post, handle_sse};
     pub use crate::router::McpRouter;
-    pub use crate::session::{SessionManager, SessionStore};
+    pub use crate::session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};
     pub use crate::state::McpState;
 }
 

--- a/crates/mcpkit-warp/src/session.rs
+++ b/crates/mcpkit-warp/src/session.rs
@@ -6,11 +6,15 @@ use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use uuid::Uuid;
 
+/// Default idle timeout after which an inactive session is reaped.
+pub const DEFAULT_SESSION_TIMEOUT: Duration = Duration::from_secs(3600);
+
 /// Session manager for tracking MCP client sessions.
 #[derive(Clone)]
 pub struct SessionStore {
     sessions: Arc<DashMap<String, SessionState>>,
     sse_channels: Arc<DashMap<String, broadcast::Sender<String>>>,
+    idle_timeout: Duration,
 }
 
 struct SessionState {
@@ -30,12 +34,25 @@ impl SessionStore {
         Self {
             sessions: Arc::new(DashMap::new()),
             sse_channels: Arc::new(DashMap::new()),
+            idle_timeout: DEFAULT_SESSION_TIMEOUT,
         }
     }
 
+    /// Set the idle timeout after which an inactive session is reaped on the
+    /// next [`create`](Self::create).
+    #[must_use]
+    pub const fn with_idle_timeout(mut self, idle_timeout: Duration) -> Self {
+        self.idle_timeout = idle_timeout;
+        self
+    }
+
     /// Create a new session and return its ID.
+    ///
+    /// Sessions idle past the idle timeout are reaped first, so the store stays
+    /// bounded without a background cleanup task.
     #[must_use]
     pub fn create(&self) -> String {
+        self.cleanup(self.idle_timeout);
         let id = Uuid::new_v4().to_string();
         let now = Instant::now();
         self.sessions
@@ -159,6 +176,28 @@ mod tests {
         // Cleanup with 0 duration should remove all sessions
         store.cleanup(Duration::from_secs(0));
         assert!(!store.exists(&id));
+    }
+
+    #[test]
+    fn create_reaps_idle_sessions() {
+        let store = SessionStore::new().with_idle_timeout(Duration::ZERO);
+        let id = store.create();
+
+        // A zero idle timeout makes the previous session reapable, so the next
+        // create() sweeps it away.
+        let _other = store.create();
+        assert!(!store.exists(&id));
+    }
+
+    #[test]
+    fn create_keeps_recent_sessions() {
+        // The default idle timeout is an hour, so a freshly created session
+        // survives create-time reaping.
+        let store = SessionStore::new();
+        let id = store.create();
+
+        let _other = store.create();
+        assert!(store.exists(&id));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Problem

The `mcpkit-warp` and `mcpkit-rocket` session stores exposed a `cleanup` method, but nothing on the default request path ever called it, so sessions created per request accumulated indefinitely — unbounded memory growth in long-running servers. This is the same leak already fixed for the `mcpkit-axum` and `mcpkit-actix` adapters.

## Fix

`SessionStore::create` now reaps sessions idle past the store's idle timeout before inserting a new one, keeping the store bounded without a background cleanup task. The idle timeout defaults to `DEFAULT_SESSION_TIMEOUT` (one hour) and is configurable via `SessionStore::with_idle_timeout`.

## Scope

These adapters use a simpler session model with no initialization flag, so the initialization-timeout reaping available in the axum/actix adapters is not part of this change (tracked as a separate parity follow-up).

## Tests

Adds tests covering create-time reaping and that recent sessions survive.