### PR TITLE
feat(adapters): surface the negotiated protocol version and client capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the `mcpkit-warp` and `mcpkit-rocket` adapters, to configure the idle timeout
   used when reaping inactive sessions.
 
+### Changed
+
+- **Breaking:** `Session::mark_initialized` in the `mcpkit-axum` and
+  `mcpkit-actix` adapters now takes the negotiated `ProtocolVersion` in addition
+  to the client capabilities, and `Session` gains a `protocol_version` field.
+
 ### Security
 
 - OAuth/token types (`TokenResponse`, `TokenRequest`, `AuthorizationConfig`,
@@ -75,6 +81,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   past the idle timeout when a new one is created, so the store stays bounded;
   previously their cleanup routine was never invoked on the default request
   path and sessions accumulated indefinitely.
+- The `mcpkit-axum` and `mcpkit-actix` adapters now record the protocol version
+  and client capabilities negotiated at `initialize` and surface them in the
+  `Context` passed to tools, resources, and prompts (and echo the negotiated
+  version in the `initialize` response), instead of always reporting the latest
+  protocol version and empty client capabilities.
 
 ## [0.6.0] - 2026-06-18
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2508,7 +2508,7 @@ checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "mcpkit"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "axum 0.8.8",
  "futures",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-actix"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "actix-cors",
  "actix-rt",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-axum"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-stream",
  "axum 0.8.8",
@@ -2582,7 +2582,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-client"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-lock",
  "futures",
@@ -2599,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-core"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-macros"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "darling 0.20.11",
  "mcpkit-core",
@@ -2652,7 +2652,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-rocket"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "dashmap",
  "mcpkit-core",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-server"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "chrono",
  "event-listener",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-testing"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "futures",
  "mcpkit-core",
@@ -2699,7 +2699,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-transport"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-io",
  "async-lock",
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "mcpkit-warp"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"
@@ -115,12 +115,12 @@ proptest = "1.6"
 criterion = { version = "0.5", features = ["html_reports", "async_tokio"] }
 
 # Internal crates - path takes precedence locally, version used for publishing
-mcpkit-core = { version = "0.6.0", path = "crates/mcpkit-core" }
-mcpkit-transport = { version = "0.6.0", path = "crates/mcpkit-transport" }
-mcpkit-server = { version = "0.6.0", path = "crates/mcpkit-server" }
-mcpkit-client = { version = "0.6.0", path = "crates/mcpkit-client" }
-mcpkit-macros = { version = "0.6.0", path = "crates/mcpkit-macros" }
-mcpkit-testing = { version = "0.6.0", path = "crates/mcpkit-testing" }
+mcpkit-core = { version = "0.7.0", path = "crates/mcpkit-core" }
+mcpkit-transport = { version = "0.7.0", path = "crates/mcpkit-transport" }
+mcpkit-server = { version = "0.7.0", path = "crates/mcpkit-server" }
+mcpkit-client = { version = "0.7.0", path = "crates/mcpkit-client" }
+mcpkit-macros = { version = "0.7.0", path = "crates/mcpkit-macros" }
+mcpkit-testing = { version = "0.7.0", path = "crates/mcpkit-testing" }
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add the dependency to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcpkit = "0.6"
+mcpkit = "0.7"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/crates/mcpkit-actix/Cargo.toml
+++ b/crates/mcpkit-actix/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["web-programming::http-server", "asynchronous"]
 
 [dependencies]
 # Internal crates
-mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
-mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
-mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport", features = ["http"] }
+mcpkit-core = { version = "0.7.0", path = "../mcpkit-core" }
+mcpkit-server = { version = "0.7.0", path = "../mcpkit-server" }
+mcpkit-transport = { version = "0.7.0", path = "../mcpkit-transport", features = ["http"] }
 
 # Web framework
 actix-web = "4"

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -87,16 +87,31 @@ where
                 "Handling MCP request"
             );
 
-            // Mark the session initialized so it is no longer subject to the
-            // initialization timeout.
+            // On initialize, negotiate the protocol version and record it (and
+            // the client's capabilities) on the session, so subsequent requests
+            // observe the negotiated values and the session is no longer subject
+            // to the initialization timeout.
             if request.method.as_ref() == "initialize" {
+                let (version, caps) = negotiate_initialize(request.params.as_ref());
                 state
                     .sessions
-                    .update(&session_id, |s| s.mark_initialized(None));
+                    .update(&session_id, |s| s.mark_initialized(version, caps.clone()));
             }
 
+            // Resolve the session's negotiated values for the request context,
+            // falling back to defaults before initialization completes.
+            let session = state.sessions.get(&session_id);
+            let protocol_version = session
+                .as_ref()
+                .and_then(|s| s.protocol_version)
+                .unwrap_or(ProtocolVersion::LATEST);
+            let client_caps = session
+                .and_then(|s| s.client_capabilities)
+                .unwrap_or_default();
+
             // Create a basic response using the handler's capabilities
-            let response = create_response_for_request(&state, &request).await;
+            let response =
+                create_response_for_request(&state, &request, protocol_version, &client_caps).await;
 
             let body = serde_json::to_string(&Message::Response(response))
                 .map_err(ExtensionError::Serialization)?;
@@ -125,12 +140,35 @@ where
     }
 }
 
+/// Negotiate the protocol version and extract client capabilities from an
+/// `initialize` request's params.
+///
+/// The negotiated version is the highest supported version not exceeding the
+/// client's requested version, falling back to the latest supported version
+/// when the request omits or names an unknown version.
+fn negotiate_initialize(
+    params: Option<&serde_json::Value>,
+) -> (ProtocolVersion, Option<ClientCapabilities>) {
+    let requested = params
+        .and_then(|p| p.get("protocolVersion"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let version = ProtocolVersion::negotiate(requested, ProtocolVersion::ALL)
+        .unwrap_or(ProtocolVersion::LATEST);
+    let capabilities = params
+        .and_then(|p| p.get("capabilities"))
+        .and_then(|c| serde_json::from_value::<ClientCapabilities>(c.clone()).ok());
+    (version, capabilities)
+}
+
 /// Create a response for a request.
 ///
 /// Routes all MCP methods through the appropriate handler traits.
 async fn create_response_for_request<H>(
     state: &McpState<H>,
     request: &mcpkit_core::protocol::Request,
+    protocol_version: ProtocolVersion,
+    client_caps: &ClientCapabilities,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -143,14 +181,12 @@ where
 
     // Create a context for the request
     let req_id = request.id.clone();
-    let client_caps = ClientCapabilities::default();
     let server_caps = state.handler.capabilities();
-    let protocol_version = ProtocolVersion::LATEST;
     let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
         None,
-        &client_caps,
+        client_caps,
         &server_caps,
         protocol_version,
         &peer,
@@ -160,7 +196,7 @@ where
         "ping" => Response::success(request.id.clone(), serde_json::json!({})),
         "initialize" => {
             let init_result = serde_json::json!({
-                "protocolVersion": ProtocolVersion::LATEST.as_str(),
+                "protocolVersion": protocol_version.as_str(),
                 "serverInfo": state.server_info,
                 "capabilities": state.handler.capabilities(),
             });
@@ -336,4 +372,35 @@ pub async fn handle_oauth_protected_resource(
     Ok(HttpResponse::Ok()
         .content_type(ContentType::json())
         .body(body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::negotiate_initialize;
+    use mcpkit_core::protocol_version::ProtocolVersion;
+
+    #[test]
+    fn negotiate_uses_requested_supported_version() {
+        let params = serde_json::json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {}
+        });
+        let (version, caps) = negotiate_initialize(Some(&params));
+        assert_eq!(version, ProtocolVersion::V2025_06_18);
+        assert!(caps.is_some());
+    }
+
+    #[test]
+    fn negotiate_defaults_to_latest_when_absent() {
+        let (version, caps) = negotiate_initialize(None);
+        assert_eq!(version, ProtocolVersion::LATEST);
+        assert!(caps.is_none());
+    }
+
+    #[test]
+    fn negotiate_unknown_version_falls_back_to_latest() {
+        let params = serde_json::json!({ "protocolVersion": "2099-01-01" });
+        let (version, _caps) = negotiate_initialize(Some(&params));
+        assert_eq!(version, ProtocolVersion::LATEST);
+    }
 }

--- a/crates/mcpkit-actix/src/session.rs
+++ b/crates/mcpkit-actix/src/session.rs
@@ -2,6 +2,7 @@
 
 use dashmap::DashMap;
 use mcpkit_core::capability::ClientCapabilities;
+use mcpkit_core::protocol_version::ProtocolVersion;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -32,6 +33,8 @@ pub struct Session {
     pub initialized: bool,
     /// Client capabilities from initialization.
     pub client_capabilities: Option<ClientCapabilities>,
+    /// Protocol version negotiated during initialization.
+    pub protocol_version: Option<ProtocolVersion>,
 }
 
 impl Session {
@@ -45,6 +48,7 @@ impl Session {
             last_active: now,
             initialized: false,
             client_capabilities: None,
+            protocol_version: None,
         }
     }
 
@@ -72,9 +76,15 @@ impl Session {
         self.last_active = Instant::now();
     }
 
-    /// Mark the session as initialized.
-    pub fn mark_initialized(&mut self, capabilities: Option<ClientCapabilities>) {
+    /// Mark the session as initialized, recording the negotiated protocol
+    /// version and the client's capabilities.
+    pub fn mark_initialized(
+        &mut self,
+        protocol_version: ProtocolVersion,
+        capabilities: Option<ClientCapabilities>,
+    ) {
         self.initialized = true;
+        self.protocol_version = Some(protocol_version);
         self.client_capabilities = capabilities;
     }
 }
@@ -626,7 +636,7 @@ mod tests {
         assert!(session.is_reapable(idle, init));
 
         // After initialization, the init timeout no longer applies.
-        session.mark_initialized(None);
+        session.mark_initialized(ProtocolVersion::LATEST, None);
         assert!(!session.is_reapable(idle, init));
         Ok(())
     }
@@ -646,7 +656,7 @@ mod tests {
     fn create_keeps_initialized_sessions() {
         let store = SessionStore::new(Duration::from_secs(3600)).with_init_timeout(Duration::ZERO);
         let id = store.create();
-        store.update(&id, |s| s.mark_initialized(None));
+        store.update(&id, |s| s.mark_initialized(ProtocolVersion::LATEST, None));
 
         // An initialized session is not subject to the init timeout and is well
         // within the idle timeout, so it survives create-time reaping.

--- a/crates/mcpkit-axum/Cargo.toml
+++ b/crates/mcpkit-axum/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["web-programming::http-server", "asynchronous"]
 
 [dependencies]
 # Internal crates
-mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
-mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
-mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport", features = ["http"] }
+mcpkit-core = { version = "0.7.0", path = "../mcpkit-core" }
+mcpkit-server = { version = "0.7.0", path = "../mcpkit-server" }
+mcpkit-transport = { version = "0.7.0", path = "../mcpkit-transport", features = ["http"] }
 
 # Web framework
 axum = { workspace = true }

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -96,17 +96,32 @@ where
                 "Handling MCP request"
             );
 
-            // Mark the session initialized so it is no longer subject to the
-            // initialization timeout.
+            // On initialize, negotiate the protocol version and record it (and
+            // the client's capabilities) on the session, so subsequent requests
+            // observe the negotiated values and the session is no longer subject
+            // to the initialization timeout.
             if request.method.as_ref() == "initialize" {
+                let (version, caps) = negotiate_initialize(request.params.as_ref());
                 state
                     .sessions
-                    .update(&session_id, |s| s.mark_initialized(None));
+                    .update(&session_id, |s| s.mark_initialized(version, caps.clone()));
             }
+
+            // Resolve the session's negotiated values for the request context,
+            // falling back to defaults before initialization completes.
+            let session = state.sessions.get(&session_id);
+            let protocol_version = session
+                .as_ref()
+                .and_then(|s| s.protocol_version)
+                .unwrap_or(ProtocolVersion::LATEST);
+            let client_caps = session
+                .and_then(|s| s.client_capabilities)
+                .unwrap_or_default();
 
             // Create a basic response using the handler's capabilities
             // In a full implementation, this would route to the handler's methods
-            let response = create_response_for_request(&state, &request).await;
+            let response =
+                create_response_for_request(&state, &request, protocol_version, &client_caps).await;
 
             match serde_json::to_string(&Message::Response(response)) {
                 Ok(body) => (
@@ -141,12 +156,35 @@ where
     }
 }
 
+/// Negotiate the protocol version and extract client capabilities from an
+/// `initialize` request's params.
+///
+/// The negotiated version is the highest supported version not exceeding the
+/// client's requested version, falling back to the latest supported version
+/// when the request omits or names an unknown version.
+fn negotiate_initialize(
+    params: Option<&serde_json::Value>,
+) -> (ProtocolVersion, Option<ClientCapabilities>) {
+    let requested = params
+        .and_then(|p| p.get("protocolVersion"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let version = ProtocolVersion::negotiate(requested, ProtocolVersion::ALL)
+        .unwrap_or(ProtocolVersion::LATEST);
+    let capabilities = params
+        .and_then(|p| p.get("capabilities"))
+        .and_then(|c| serde_json::from_value::<ClientCapabilities>(c.clone()).ok());
+    (version, capabilities)
+}
+
 /// Create a response for a request.
 ///
 /// Routes all MCP methods through the appropriate handler traits.
 async fn create_response_for_request<H>(
     state: &McpState<H>,
     request: &mcpkit_core::protocol::Request,
+    protocol_version: ProtocolVersion,
+    client_caps: &ClientCapabilities,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -159,14 +197,12 @@ where
 
     // Create a context for the request
     let req_id = request.id.clone();
-    let client_caps = ClientCapabilities::default();
     let server_caps = state.handler.capabilities();
-    let protocol_version = ProtocolVersion::LATEST;
     let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
         None,
-        &client_caps,
+        client_caps,
         &server_caps,
         protocol_version,
         &peer,
@@ -176,7 +212,7 @@ where
         "ping" => Response::success(request.id.clone(), serde_json::json!({})),
         "initialize" => {
             let init_result = serde_json::json!({
-                "protocolVersion": ProtocolVersion::LATEST.as_str(),
+                "protocolVersion": protocol_version.as_str(),
                 "serverInfo": state.server_info,
                 "capabilities": state.handler.capabilities(),
             });
@@ -394,4 +430,35 @@ pub async fn handle_oauth_protected_resource(State(state): State<OAuthState>) ->
         [("content-type", "application/json")],
         Json(state.metadata),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::negotiate_initialize;
+    use mcpkit_core::protocol_version::ProtocolVersion;
+
+    #[test]
+    fn negotiate_uses_requested_supported_version() {
+        let params = serde_json::json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {}
+        });
+        let (version, caps) = negotiate_initialize(Some(&params));
+        assert_eq!(version, ProtocolVersion::V2025_06_18);
+        assert!(caps.is_some());
+    }
+
+    #[test]
+    fn negotiate_defaults_to_latest_when_absent() {
+        let (version, caps) = negotiate_initialize(None);
+        assert_eq!(version, ProtocolVersion::LATEST);
+        assert!(caps.is_none());
+    }
+
+    #[test]
+    fn negotiate_unknown_version_falls_back_to_latest() {
+        let params = serde_json::json!({ "protocolVersion": "2099-01-01" });
+        let (version, _caps) = negotiate_initialize(Some(&params));
+        assert_eq!(version, ProtocolVersion::LATEST);
+    }
 }

--- a/crates/mcpkit-axum/src/session.rs
+++ b/crates/mcpkit-axum/src/session.rs
@@ -2,6 +2,7 @@
 
 use dashmap::DashMap;
 use mcpkit_core::capability::ClientCapabilities;
+use mcpkit_core::protocol_version::ProtocolVersion;
 use std::collections::VecDeque;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -22,6 +23,8 @@ pub struct Session {
     pub initialized: bool,
     /// Client capabilities from initialization.
     pub client_capabilities: Option<ClientCapabilities>,
+    /// Protocol version negotiated during initialization.
+    pub protocol_version: Option<ProtocolVersion>,
 }
 
 impl Session {
@@ -35,6 +38,7 @@ impl Session {
             last_active: now,
             initialized: false,
             client_capabilities: None,
+            protocol_version: None,
         }
     }
 
@@ -62,9 +66,15 @@ impl Session {
         self.last_active = Instant::now();
     }
 
-    /// Mark the session as initialized.
-    pub fn mark_initialized(&mut self, capabilities: Option<ClientCapabilities>) {
+    /// Mark the session as initialized, recording the negotiated protocol
+    /// version and the client's capabilities.
+    pub fn mark_initialized(
+        &mut self,
+        protocol_version: ProtocolVersion,
+        capabilities: Option<ClientCapabilities>,
+    ) {
         self.initialized = true;
+        self.protocol_version = Some(protocol_version);
         self.client_capabilities = capabilities;
     }
 }
@@ -646,7 +656,7 @@ mod tests {
         assert!(session.is_reapable(idle, init));
 
         // After initialization, the init timeout no longer applies.
-        session.mark_initialized(None);
+        session.mark_initialized(ProtocolVersion::LATEST, None);
         assert!(!session.is_reapable(idle, init));
         Ok(())
     }
@@ -666,7 +676,7 @@ mod tests {
     fn create_keeps_initialized_sessions() {
         let store = SessionStore::new(Duration::from_secs(3600)).with_init_timeout(Duration::ZERO);
         let id = store.create();
-        store.update(&id, |s| s.mark_initialized(None));
+        store.update(&id, |s| s.mark_initialized(ProtocolVersion::LATEST, None));
 
         // An initialized session is not subject to the init timeout and is well
         // within the idle timeout, so it survives create-time reaping.

--- a/crates/mcpkit-client/Cargo.toml
+++ b/crates/mcpkit-client/Cargo.toml
@@ -12,8 +12,8 @@ readme = "README.md"
 
 [dependencies]
 # Internal crates - path takes precedence locally, version used for publishing
-mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
-mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport" }
+mcpkit-core = { version = "0.7.0", path = "../mcpkit-core" }
+mcpkit-transport = { version = "0.7.0", path = "../mcpkit-transport" }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/mcpkit-macros/Cargo.toml
+++ b/crates/mcpkit-macros/Cargo.toml
@@ -28,5 +28,5 @@ darling = "0.20"
 
 [dev-dependencies]
 # Only mcpkit-core needed for compile-fail tests (no circular dependency)
-mcpkit-core = { version = "0.6", path = "../mcpkit-core" }
+mcpkit-core = { version = "0.7", path = "../mcpkit-core" }
 trybuild = "1.0"

--- a/crates/mcpkit-rocket/Cargo.toml
+++ b/crates/mcpkit-rocket/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["web-programming::http-server", "asynchronous"]
 
 [dependencies]
 # Internal crates
-mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
-mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
-mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport", features = ["http"] }
+mcpkit-core = { version = "0.7.0", path = "../mcpkit-core" }
+mcpkit-server = { version = "0.7.0", path = "../mcpkit-server" }
+mcpkit-transport = { version = "0.7.0", path = "../mcpkit-transport", features = ["http"] }
 
 # Web framework
 rocket = { version = "0.5", features = ["json"] }

--- a/crates/mcpkit-server/Cargo.toml
+++ b/crates/mcpkit-server/Cargo.toml
@@ -11,8 +11,8 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
-mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport" }
+mcpkit-core = { version = "0.7.0", path = "../mcpkit-core" }
+mcpkit-transport = { version = "0.7.0", path = "../mcpkit-transport" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/mcpkit-testing/Cargo.toml
+++ b/crates/mcpkit-testing/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["development-tools::testing"]
 
 [dependencies]
 # Internal crates - path takes precedence locally, version used for publishing
-mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
-mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport" }
-mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
+mcpkit-core = { version = "0.7.0", path = "../mcpkit-core" }
+mcpkit-transport = { version = "0.7.0", path = "../mcpkit-transport" }
+mcpkit-server = { version = "0.7.0", path = "../mcpkit-server" }
 
 # Serialization
 serde = { workspace = true }

--- a/crates/mcpkit-transport/Cargo.toml
+++ b/crates/mcpkit-transport/Cargo.toml
@@ -11,7 +11,7 @@ categories.workspace = true
 readme = "README.md"
 
 [dependencies]
-mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
+mcpkit-core = { version = "0.7.0", path = "../mcpkit-core" }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/mcpkit-warp/Cargo.toml
+++ b/crates/mcpkit-warp/Cargo.toml
@@ -12,9 +12,9 @@ categories = ["web-programming::http-server", "asynchronous"]
 
 [dependencies]
 # Internal crates
-mcpkit-core = { version = "0.6.0", path = "../mcpkit-core" }
-mcpkit-server = { version = "0.6.0", path = "../mcpkit-server" }
-mcpkit-transport = { version = "0.6.0", path = "../mcpkit-transport", features = ["http"] }
+mcpkit-core = { version = "0.7.0", path = "../mcpkit-core" }
+mcpkit-server = { version = "0.7.0", path = "../mcpkit-server" }
+mcpkit-transport = { version = "0.7.0", path = "../mcpkit-transport", features = ["http"] }
 
 # Web framework
 warp = "0.3"

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -14,7 +14,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcpkit = "0.6"
+mcpkit = "0.7"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,7 +13,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-mcpkit = "0.6"
+mcpkit = "0.7"
 tokio = { version = "1", features = ["full"] }
 serde_json = "1"
 ```

--- a/docs/migration-from-rmcp.md
+++ b/docs/migration-from-rmcp.md
@@ -31,7 +31,7 @@ schemars = "1"
 
 ```toml
 [dependencies]
-mcpkit = "0.6"
+mcpkit = "0.7"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 # schemars no longer required - schemas are built-in
@@ -336,7 +336,7 @@ Replace `rmcp` with `mcpkit`:
 ```toml
 [dependencies]
 - rmcp = "1.7"
-+ mcpkit = "0.6"
++ mcpkit = "0.7"
 ```
 
 Remove `schemars` if only used for tool schemas.

--- a/docs/migration-to-1.0.md
+++ b/docs/migration-to-1.0.md
@@ -47,7 +47,7 @@ Simply update your dependency:
 
 ```toml
 # Before
-mcpkit = "0.6"
+mcpkit = "0.7"
 
 # After
 mcpkit = "1"
@@ -233,7 +233,7 @@ If migration causes critical issues, you can roll back to your previous version.
 
 ```toml
 # Revert Cargo.toml
-mcpkit = "0.6"
+mcpkit = "0.7"
 ```
 
 ```bash

--- a/mcpkit/Cargo.toml
+++ b/mcpkit/Cargo.toml
@@ -14,11 +14,11 @@ readme = "../README.md"
 
 [dependencies]
 # Internal crates - path takes precedence locally, version used for publishing
-mcpkit-core = { version = "0.6.0", path = "../crates/mcpkit-core" }
-mcpkit-transport = { version = "0.6.0", path = "../crates/mcpkit-transport" }
-mcpkit-server = { version = "0.6.0", path = "../crates/mcpkit-server" }
-mcpkit-client = { version = "0.6.0", path = "../crates/mcpkit-client" }
-mcpkit-macros = { version = "0.6.0", path = "../crates/mcpkit-macros" }
+mcpkit-core = { version = "0.7.0", path = "../crates/mcpkit-core" }
+mcpkit-transport = { version = "0.7.0", path = "../crates/mcpkit-transport" }
+mcpkit-server = { version = "0.7.0", path = "../crates/mcpkit-server" }
+mcpkit-client = { version = "0.7.0", path = "../crates/mcpkit-client" }
+mcpkit-macros = { version = "0.7.0", path = "../crates/mcpkit-macros" }
 
 [features]
 default = ["server", "client", "tokio-runtime"]


### PR DESCRIPTION
## Problem

The `mcpkit-axum` and `mcpkit-actix` adapters built each request's `Context` with `ProtocolVersion::LATEST` and `ClientCapabilities::default()`, ignoring what the client negotiated at `initialize`. Tools, resources, and prompts reading `ctx.protocol_version()` / `ctx.client_capabilities()` therefore saw incorrect values over HTTP, and the `initialize` response always echoed the latest version rather than the negotiated one.

## Fix

The `initialize` handler now negotiates the protocol version (the highest supported version not exceeding the client's request, falling back to the latest) and records it together with the client's capabilities on the session. Subsequent requests build their `Context` from the session's stored values, and the `initialize` response echoes the negotiated version. This mirrors the core server's negotiation.

## Breaking change + version bump

Recording the negotiated version requires a new `Session::protocol_version` field and a new parameter on `Session::mark_initialized` — breaking changes to those adapters' public API. The workspace version is bumped **0.6.0 → 0.7.0** (0.x minor bumps may carry breaking changes, which Semver Check enforces), and the documented install version is updated to match. This is the first breaking change since 0.6.0; everything else in the unreleased set is additive.

## Tests

Adds tests for the version-negotiation helper (requested supported version, missing header → latest, unknown version → latest).