### PR TITLE
feat(adapters): surface the negotiated init state in the warp and rocket adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,11 +81,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   past the idle timeout when a new one is created, so the store stays bounded;
   previously their cleanup routine was never invoked on the default request
   path and sessions accumulated indefinitely.
-- The `mcpkit-axum` and `mcpkit-actix` adapters now record the protocol version
-  and client capabilities negotiated at `initialize` and surface them in the
-  `Context` passed to tools, resources, and prompts (and echo the negotiated
-  version in the `initialize` response), instead of always reporting the latest
-  protocol version and empty client capabilities.
+- The framework adapters (`mcpkit-axum`, `mcpkit-actix`, `mcpkit-warp`,
+  `mcpkit-rocket`) now record the protocol version and client capabilities
+  negotiated at `initialize` and surface them in the `Context` passed to tools,
+  resources, and prompts (and echo the negotiated version in the `initialize`
+  response), instead of always reporting the latest protocol version and empty
+  client capabilities.
 
 ## [0.6.0] - 2026-06-18
 

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -221,7 +221,24 @@ where
                 "Handling MCP request"
             );
 
-            let response = create_response_for_request(state, &request).await;
+            // On initialize, negotiate the protocol version and record it (and
+            // the client's capabilities) on the session, so subsequent requests
+            // observe the negotiated values.
+            if request.method.as_ref() == "initialize" {
+                let (negotiated, caps) = negotiate_initialize(request.params.as_ref());
+                state.sessions.set_negotiated(&session_id, negotiated, caps);
+            }
+
+            // Resolve the session's negotiated values for the request context,
+            // falling back to defaults before initialization completes.
+            let (protocol_version, client_caps) =
+                state.sessions.negotiated(&session_id).map_or_else(
+                    || (ProtocolVersion::LATEST, ClientCapabilities::default()),
+                    |(v, c)| (v, c.unwrap_or_default()),
+                );
+
+            let response =
+                create_response_for_request(state, &request, protocol_version, &client_caps).await;
 
             match serde_json::to_string(&Message::Response(response)) {
                 Ok(body) => McpResponse::success(body, session_id),
@@ -249,10 +266,33 @@ where
     }
 }
 
+/// Negotiate the protocol version and extract client capabilities from an
+/// `initialize` request's params.
+///
+/// The negotiated version is the highest supported version not exceeding the
+/// client's requested version, falling back to the latest supported version
+/// when the request omits or names an unknown version.
+fn negotiate_initialize(
+    params: Option<&serde_json::Value>,
+) -> (ProtocolVersion, Option<ClientCapabilities>) {
+    let requested = params
+        .and_then(|p| p.get("protocolVersion"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let version = ProtocolVersion::negotiate(requested, ProtocolVersion::ALL)
+        .unwrap_or(ProtocolVersion::LATEST);
+    let capabilities = params
+        .and_then(|p| p.get("capabilities"))
+        .and_then(|c| serde_json::from_value::<ClientCapabilities>(c.clone()).ok());
+    (version, capabilities)
+}
+
 /// Create a response for a request.
 async fn create_response_for_request<H>(
     state: &McpState<H>,
     request: &mcpkit_core::protocol::Request,
+    protocol_version: ProtocolVersion,
+    client_caps: &ClientCapabilities,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -265,14 +305,12 @@ where
 
     // Create a context for the request
     let req_id = request.id.clone();
-    let client_caps = ClientCapabilities::default();
     let server_caps = state.handler.capabilities();
-    let protocol_version = ProtocolVersion::LATEST;
     let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
         None,
-        &client_caps,
+        client_caps,
         &server_caps,
         protocol_version,
         &peer,
@@ -282,7 +320,7 @@ where
         "ping" => Response::success(request.id.clone(), serde_json::json!({})),
         "initialize" => {
             let init_result = serde_json::json!({
-                "protocolVersion": ProtocolVersion::LATEST.as_str(),
+                "protocolVersion": protocol_version.as_str(),
                 "serverInfo": state.server_info,
                 "capabilities": state.handler.capabilities(),
             });
@@ -373,6 +411,31 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn negotiate_uses_requested_supported_version() {
+        let params = serde_json::json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {}
+        });
+        let (version, caps) = negotiate_initialize(Some(&params));
+        assert_eq!(version, ProtocolVersion::V2025_06_18);
+        assert!(caps.is_some());
+    }
+
+    #[test]
+    fn negotiate_defaults_to_latest_when_absent() {
+        let (version, caps) = negotiate_initialize(None);
+        assert_eq!(version, ProtocolVersion::LATEST);
+        assert!(caps.is_none());
+    }
+
+    #[test]
+    fn negotiate_unknown_version_falls_back_to_latest() {
+        let params = serde_json::json!({ "protocolVersion": "2099-01-01" });
+        let (version, _caps) = negotiate_initialize(Some(&params));
+        assert_eq!(version, ProtocolVersion::LATEST);
+    }
 
     // Test HandlerContext
     struct TestHandler {

--- a/crates/mcpkit-rocket/src/session.rs
+++ b/crates/mcpkit-rocket/src/session.rs
@@ -1,6 +1,8 @@
 //! Session management for MCP Rocket integration.
 
 use dashmap::DashMap;
+use mcpkit_core::capability::ClientCapabilities;
+use mcpkit_core::protocol_version::ProtocolVersion;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
@@ -21,6 +23,10 @@ struct SessionState {
     #[allow(dead_code)] // Reserved for future session metadata/debugging
     created_at: Instant,
     last_seen: Instant,
+    /// Protocol version negotiated during initialization.
+    protocol_version: Option<ProtocolVersion>,
+    /// Client capabilities from initialization.
+    client_capabilities: Option<ClientCapabilities>,
 }
 
 impl Default for SessionStore {
@@ -62,6 +68,8 @@ impl SessionStore {
             SessionState {
                 created_at: now,
                 last_seen: now,
+                protocol_version: None,
+                client_capabilities: None,
             },
         );
         id
@@ -72,6 +80,32 @@ impl SessionStore {
         if let Some(mut session) = self.sessions.get_mut(id) {
             session.last_seen = Instant::now();
         }
+    }
+
+    /// Record the protocol version and client capabilities negotiated during
+    /// initialization for a session.
+    pub fn set_negotiated(
+        &self,
+        id: &str,
+        protocol_version: ProtocolVersion,
+        capabilities: Option<ClientCapabilities>,
+    ) {
+        if let Some(mut session) = self.sessions.get_mut(id) {
+            session.protocol_version = Some(protocol_version);
+            session.client_capabilities = capabilities;
+        }
+    }
+
+    /// Get the negotiated protocol version and client capabilities for a
+    /// session, defaulting the version to the latest before initialization.
+    #[must_use]
+    pub fn negotiated(&self, id: &str) -> Option<(ProtocolVersion, Option<ClientCapabilities>)> {
+        self.sessions.get(id).map(|s| {
+            (
+                s.protocol_version.unwrap_or(ProtocolVersion::LATEST),
+                s.client_capabilities.clone(),
+            )
+        })
     }
 
     /// Check if a session exists.

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -97,7 +97,24 @@ where
                 "Handling MCP request"
             );
 
-            let response = create_response_for_request(&state, &request).await;
+            // On initialize, negotiate the protocol version and record it (and
+            // the client's capabilities) on the session, so subsequent requests
+            // observe the negotiated values.
+            if request.method.as_ref() == "initialize" {
+                let (negotiated, caps) = negotiate_initialize(request.params.as_ref());
+                state.sessions.set_negotiated(&session_id, negotiated, caps);
+            }
+
+            // Resolve the session's negotiated values for the request context,
+            // falling back to defaults before initialization completes.
+            let (protocol_version, client_caps) =
+                state.sessions.negotiated(&session_id).map_or_else(
+                    || (ProtocolVersion::LATEST, ClientCapabilities::default()),
+                    |(v, c)| (v, c.unwrap_or_default()),
+                );
+
+            let response =
+                create_response_for_request(&state, &request, protocol_version, &client_caps).await;
 
             match serde_json::to_value(Message::Response(response)) {
                 Ok(body) => Ok(warp::reply::with_status(
@@ -145,10 +162,33 @@ where
     }
 }
 
+/// Negotiate the protocol version and extract client capabilities from an
+/// `initialize` request's params.
+///
+/// The negotiated version is the highest supported version not exceeding the
+/// client's requested version, falling back to the latest supported version
+/// when the request omits or names an unknown version.
+fn negotiate_initialize(
+    params: Option<&serde_json::Value>,
+) -> (ProtocolVersion, Option<ClientCapabilities>) {
+    let requested = params
+        .and_then(|p| p.get("protocolVersion"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+    let version = ProtocolVersion::negotiate(requested, ProtocolVersion::ALL)
+        .unwrap_or(ProtocolVersion::LATEST);
+    let capabilities = params
+        .and_then(|p| p.get("capabilities"))
+        .and_then(|c| serde_json::from_value::<ClientCapabilities>(c.clone()).ok());
+    (version, capabilities)
+}
+
 /// Create a response for a request.
 async fn create_response_for_request<H>(
     state: &McpState<H>,
     request: &mcpkit_core::protocol::Request,
+    protocol_version: ProtocolVersion,
+    client_caps: &ClientCapabilities,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -161,14 +201,12 @@ where
 
     // Create a context for the request
     let req_id = request.id.clone();
-    let client_caps = ClientCapabilities::default();
     let server_caps = state.handler.capabilities();
-    let protocol_version = ProtocolVersion::LATEST;
     let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
         None,
-        &client_caps,
+        client_caps,
         &server_caps,
         protocol_version,
         &peer,
@@ -178,7 +216,7 @@ where
         "ping" => Response::success(request.id.clone(), serde_json::json!({})),
         "initialize" => {
             let init_result = serde_json::json!({
-                "protocolVersion": ProtocolVersion::LATEST.as_str(),
+                "protocolVersion": protocol_version.as_str(),
                 "serverInfo": state.server_info,
                 "capabilities": state.handler.capabilities(),
             });
@@ -282,6 +320,31 @@ pub fn with_session_id() -> impl Filter<Extract = (Option<String>,), Error = war
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn negotiate_uses_requested_supported_version() {
+        let params = serde_json::json!({
+            "protocolVersion": "2025-06-18",
+            "capabilities": {}
+        });
+        let (version, caps) = negotiate_initialize(Some(&params));
+        assert_eq!(version, ProtocolVersion::V2025_06_18);
+        assert!(caps.is_some());
+    }
+
+    #[test]
+    fn negotiate_defaults_to_latest_when_absent() {
+        let (version, caps) = negotiate_initialize(None);
+        assert_eq!(version, ProtocolVersion::LATEST);
+        assert!(caps.is_none());
+    }
+
+    #[test]
+    fn negotiate_unknown_version_falls_back_to_latest() {
+        let params = serde_json::json!({ "protocolVersion": "2099-01-01" });
+        let (version, _caps) = negotiate_initialize(Some(&params));
+        assert_eq!(version, ProtocolVersion::LATEST);
+    }
     use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
     use mcpkit_core::error::McpError;
     use mcpkit_core::types::{

--- a/crates/mcpkit-warp/src/session.rs
+++ b/crates/mcpkit-warp/src/session.rs
@@ -1,6 +1,8 @@
 //! Session management for MCP Warp integration.
 
 use dashmap::DashMap;
+use mcpkit_core::capability::ClientCapabilities;
+use mcpkit_core::protocol_version::ProtocolVersion;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
@@ -19,6 +21,10 @@ pub struct SessionStore {
 
 struct SessionState {
     last_seen: Instant,
+    /// Protocol version negotiated during initialization.
+    protocol_version: Option<ProtocolVersion>,
+    /// Client capabilities from initialization.
+    client_capabilities: Option<ClientCapabilities>,
 }
 
 impl Default for SessionStore {
@@ -55,8 +61,14 @@ impl SessionStore {
         self.cleanup(self.idle_timeout);
         let id = Uuid::new_v4().to_string();
         let now = Instant::now();
-        self.sessions
-            .insert(id.clone(), SessionState { last_seen: now });
+        self.sessions.insert(
+            id.clone(),
+            SessionState {
+                last_seen: now,
+                protocol_version: None,
+                client_capabilities: None,
+            },
+        );
         id
     }
 
@@ -65,6 +77,32 @@ impl SessionStore {
         if let Some(mut session) = self.sessions.get_mut(id) {
             session.last_seen = Instant::now();
         }
+    }
+
+    /// Record the protocol version and client capabilities negotiated during
+    /// initialization for a session.
+    pub fn set_negotiated(
+        &self,
+        id: &str,
+        protocol_version: ProtocolVersion,
+        capabilities: Option<ClientCapabilities>,
+    ) {
+        if let Some(mut session) = self.sessions.get_mut(id) {
+            session.protocol_version = Some(protocol_version);
+            session.client_capabilities = capabilities;
+        }
+    }
+
+    /// Get the negotiated protocol version and client capabilities for a
+    /// session, defaulting the version to the latest before initialization.
+    #[must_use]
+    pub fn negotiated(&self, id: &str) -> Option<(ProtocolVersion, Option<ClientCapabilities>)> {
+        self.sessions.get(id).map(|s| {
+            (
+                s.protocol_version.unwrap_or(ProtocolVersion::LATEST),
+                s.client_capabilities.clone(),
+            )
+        })
     }
 
     /// Check if a session exists.


### PR DESCRIPTION
## Problem

The `mcpkit-warp` and `mcpkit-rocket` adapters built each request's `Context` with `ProtocolVersion::LATEST` and `ClientCapabilities::default()`, ignoring what the client negotiated at `initialize`, and echoed the latest version in the `initialize` response. Handlers reading `ctx.protocol_version()` / `ctx.client_capabilities()` therefore saw incorrect values over HTTP. This is the same bug fixed for axum/actix in #70 — this PR brings warp and rocket to parity.

## Fix

The `initialize` handler now negotiates the protocol version (highest supported version not exceeding the client's request, falling back to the latest) and records it with the client's capabilities on the session. Subsequent requests build their `Context` from the session's stored values, and the `initialize` response echoes the negotiated version.

The session store gains `set_negotiated` / `negotiated` accessors (additive; the internal `SessionState` is private, so no breaking change).

## Tests

Adds tests for the version-negotiation helper in both adapters.