### PR TITLE
ci: run semver-checks against all publishable crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,4 +251,8 @@ jobs:
       - name: Install cargo-semver-checks
         uses: taiki-e/install-action@cargo-semver-checks
       - name: Check semver
-        run: cargo semver-checks check-release --package mcpkit
+        # Check every publishable crate, not just the umbrella. `--workspace`
+        # skips crates marked `publish = false` (examples, benches, fuzz, the
+        # macros test crate), leaving the published crates whose API consumers
+        # depend on directly.
+        run: cargo semver-checks check-release --workspace


### PR DESCRIPTION
## Problem

The Semver Check job ran `cargo semver-checks check-release --package mcpkit` — only the umbrella crate. Breaking changes in the other ten published crates (`mcpkit-core`, `mcpkit-server`, `mcpkit-transport`, `mcpkit-client`, `mcpkit-macros`, `mcpkit-testing`, and the four framework adapters) were never validated unless they happened to be re-exported through the umbrella. (For example, a breaking change to `mcpkit-axum`'s `Session` API is invisible to the umbrella.)

## Fix

Use `cargo semver-checks check-release --workspace`, which checks every workspace member and skips those marked `publish = false` (examples, benches, fuzz, the macros test crate). Each published crate is now validated against its crates.io baseline.

This job runs on the PR itself, so this change is self-validating: a green Semver Check here means the new command works against all crates (all currently at 0.7.0 vs the published 0.6.0 baseline, so the minor bump permits the breaking changes already landed this cycle).

CI-only change; no CHANGELOG entry.