### PR TITLE
chore: mark internal connection structs doc(hidden)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Breaking:** `Session::mark_initialized` in the `mcpkit-axum` and
   `mcpkit-actix` adapters now takes the negotiated `ProtocolVersion` in addition
   to the client capabilities, and `Session` gains a `protocol_version` field.
+- `ConnectionInner` (`mcpkit-core`) and `ConnectionData` (`mcpkit-server`) are
+  now `#[doc(hidden)]`. They are internal implementation details of
+  `Connection` and were never intended as stable API.
 
 ### Security
 

--- a/crates/mcpkit-core/src/state.rs
+++ b/crates/mcpkit-core/src/state.rs
@@ -58,6 +58,7 @@ pub struct Ready;
 pub struct Closing;
 
 /// Internal connection data shared across states.
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct ConnectionInner {
     /// Unique connection identifier.

--- a/crates/mcpkit-server/src/state.rs
+++ b/crates/mcpkit-server/src/state.rs
@@ -58,6 +58,7 @@ pub mod state {
 }
 
 /// Internal connection data shared across states.
+#[doc(hidden)]
 #[derive(Debug)]
 pub struct ConnectionData {
     /// Client capabilities (set after initialization).


### PR DESCRIPTION
## Problem

`ConnectionInner` (`mcpkit-core::state`) and `ConnectionData` (`mcpkit-server::state`) are reachable through the public `state` module, but both are internal implementation details of `Connection` — held only in its private `inner` field and not returned by any public method. Their own doc comments already say "Internal connection data shared across states." Ahead of 1.0 they appear in the rendered docs and could be mistaken for stable API.

## Fix

Mark both `#[doc(hidden)]`. This removes them from the rendered docs and signals they are not stable API, while keeping them `pub` — so it is non-breaking (the type is unchanged; Semver Check, now run across all crates, is unaffected).

Surfaced by a public-API-surface audit toward 1.0.