### PR TITLE
docs: remove references to the nonexistent `experimental` feature

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -31,7 +31,6 @@ These APIs may change in minor versions (1.1, 1.2, etc.):
 | Category | Items |
 |----------|-------|
 | **Hidden Items** | Anything marked `#[doc(hidden)]` |
-| **Feature-Gated** | APIs behind `experimental` feature flag |
 | **Internal Modules** | Private module internals |
 | **Metrics Types** | `ServerMetrics`, `MetricsSnapshot`, `MethodStats` |
 
@@ -268,13 +267,6 @@ mcpkit = "1"
 
 # To upgrade, explicitly opt in
 mcpkit = "2"
-```
-
-### Using Unstable Features
-
-```toml
-# Opt in to unstable features (may break in minor versions)
-mcpkit = { version = "1", features = ["experimental"] }
 ```
 
 ## Commitment

--- a/docs/migration-to-1.0.md
+++ b/docs/migration-to-1.0.md
@@ -32,7 +32,6 @@ After 1.0, mcpkit follows strict semantic versioning. See [API Stability](api-st
 
 **Tier 2 - Unstable** (may change in minor versions):
 - Items marked `#[doc(hidden)]`
-- Feature-gated experimental features
 - Internal implementation details
 
 See [API Stability](api-stability.md) for the complete tier definitions.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -58,12 +58,11 @@ These APIs are covered by semver guarantees:
 - Transport trait implementations
 - JSON-RPC wire format
 
-### Tier 2: Unstable (marked with `#[doc(hidden)]` or feature flags)
+### Tier 2: Unstable (marked with `#[doc(hidden)]`)
 
 These may change without major version bumps:
 
 - Internal implementation details
-- Feature-gated experimental features
 - Items marked `#[doc(hidden)]`
 - Private modules
 - Metrics types
@@ -199,21 +198,6 @@ These are enabled by default and covered by stability guarantees:
 ```toml
 [features]
 default = ["server", "client", "tokio-runtime"]
-```
-
-### Experimental Features
-
-These may change without notice:
-
-```toml
-[features]
-experimental = []  # Experimental features
-```
-
-Enable experimental features at your own risk:
-
-```toml
-mcpkit = { version = "0.5", features = ["experimental"] }
 ```
 
 ### Optional Transports


### PR DESCRIPTION
## Problem

`docs/versioning.md`, `docs/api-stability.md`, and `docs/migration-to-1.0.md` describe an `experimental` Cargo feature as the Tier-2 gate for unstable APIs and tell users to enable it with `features = ["experimental"]`. No crate defines such a feature, and nothing is gated behind it (`grep experimental` over the Cargo.tomls and `cfg` usage returns nothing) — so the documented mechanism doesn't exist. The real Tier-2 gate is `#[doc(hidden)]`, which the docs already list.

## Fix

Remove the `experimental`-feature references: the "Experimental Features" section, the feature-flag table row, the "Using Unstable Features" snippet, and the matching Tier-2 bullets. The unrelated, accurate mentions of WebAssembly support being "experimental" are left untouched.

Docs-only; surfaced by the public-API-surface audit toward 1.0.