### PR TITLE
docs: refresh stale version status and classify the adapter crates

### DIFF
--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -45,6 +45,14 @@ No stability guarantees (may change in any release):
 | **Build Internals** | Build scripts, CI configuration |
 | **Benchmarks** | Benchmark implementation details |
 
+### Framework Adapter Crates
+
+The framework adapter crates — `mcpkit-axum`, `mcpkit-actix`, `mcpkit-warp`, and
+`mcpkit-rocket` — are published and follow the same tier rules above. Their HTTP
+integration surface (`McpRouter`, `McpState`, the session types, `EventStore`)
+is still stabilizing ahead of 1.0 and is treated as **Tier 2 (Unstable)** until
+the 1.0 release.
+
 ## What Constitutes a Breaking Change
 
 Based on [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) and [Cargo SemVer](https://doc.rust-lang.org/cargo/reference/semver.html):

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -20,7 +20,7 @@ During the 0.x.y phase, the API is considered unstable:
 - Patch versions (0.0.x) remain backward compatible
 - We aim to minimize churn, but cannot guarantee API stability
 
-**Current Status:** 0.5.x (Release Candidate)
+**Current Status:** 0.7.x
 
 ### Crate Versioning
 
@@ -28,17 +28,17 @@ All crates in the workspace are versioned together:
 
 | Crate | Version |
 |-------|---------|
-| `mcpkit` | 0.5.x |
-| `mcpkit-core` | 0.5.x |
-| `mcpkit-server` | 0.5.x |
-| `mcpkit-client` | 0.5.x |
-| `mcpkit-transport` | 0.5.x |
-| `mcpkit-macros` | 0.5.x |
-| `mcpkit-testing` | 0.5.x |
-| `mcpkit-axum` | 0.5.x |
-| `mcpkit-actix` | 0.5.x |
-| `mcpkit-rocket` | 0.5.x |
-| `mcpkit-warp` | 0.5.x |
+| `mcpkit` | 0.7.x |
+| `mcpkit-core` | 0.7.x |
+| `mcpkit-server` | 0.7.x |
+| `mcpkit-client` | 0.7.x |
+| `mcpkit-transport` | 0.7.x |
+| `mcpkit-macros` | 0.7.x |
+| `mcpkit-testing` | 0.7.x |
+| `mcpkit-axum` | 0.7.x |
+| `mcpkit-actix` | 0.7.x |
+| `mcpkit-rocket` | 0.7.x |
+| `mcpkit-warp` | 0.7.x |
 
 This simplifies dependency management and ensures compatibility.
 


### PR DESCRIPTION
## Problem

Two staleness gaps surfaced by the public-API audit toward 1.0:

- `docs/versioning.md` listed the current status and every crate version as `0.5.x` (the workspace is at `0.7.x`).
- `docs/api-stability.md` never mentioned the four framework adapter crates, so their stability stance was undefined.

## Fix

- Update the "Current Status" line and the per-crate version table in `versioning.md` to `0.7.x`. The historical protocol-version and milestone tables are intentionally left unchanged.
- Add a short note to `api-stability.md` placing `mcpkit-axum`, `mcpkit-actix`, `mcpkit-warp`, and `mcpkit-rocket` under the same tier rules, with their HTTP integration surface (`McpRouter`, `McpState`, session types, `EventStore`) treated as **Tier 2 (Unstable)** while it stabilizes ahead of 1.0. This is deliberately conservative — those types took breaking changes this cycle — rather than committing them to Tier 1.

Docs-only.