### PR TITLE
ci: skip heavy jobs on docs-only PRs and trim the PR critical path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,33 @@ env:
 
 jobs:
   # ==========================================================================
+  # Change detection - lets PRs that touch no Rust/build files skip the heavy
+  # compile/test/semver jobs. Pushes to the trunk always run everything (the
+  # `|| github.event_name == 'push'` guards below), so trunk coverage is never
+  # reduced by this filter.
+  # ==========================================================================
+
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - '**/build.rs'
+              - 'crates/mcpkit-transport/proto/**'
+              - 'deny.toml'
+              - '.github/workflows/ci.yml'
+
+  # ==========================================================================
   # Fast checks - run first, fail fast
   # ==========================================================================
 
@@ -38,21 +65,32 @@ jobs:
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
         with:
           components: clippy
       - uses: Swatinem/rust-cache@v2
+        with:
+          # PR branches restore the trunk cache but don't save their own
+          # (per-branch caches just churn the 10 GB ceiling). Only the
+          # default-branch run writes the shared cache.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo clippy --all-features --all-targets -- -D warnings
 
   check:
     name: Check
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo check --all-features --all-targets
 
   version-sync:
@@ -113,11 +151,14 @@ jobs:
   test:
     name: Test Suite
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, check]
+    needs: [changes, fmt, clippy, check]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - run: cargo test --all-features
       # trybuild spins up a throwaway cargo project under target/tests; remove it
       # so the rust-cache save step doesn't trip over its torn-down scratch dirs
@@ -128,14 +169,16 @@ jobs:
         run: rm -rf target/tests
 
   # ==========================================================================
-  # Code Coverage - PRs only (to save CI minutes)
+  # Code Coverage - runs on the trunk (push) only. Keeping it off the PR path
+  # removes ~8.5 min of interactive wait; the trunk run still publishes the
+  # coverage trend to Codecov and warms the (branch-scoped) coverage cache.
   # ==========================================================================
 
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.event_name == 'pull_request'
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
@@ -166,6 +209,8 @@ jobs:
   deny:
     name: Cargo Deny
     runs-on: ubuntu-latest
+    needs: [changes]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v6
       - uses: EmbarkStudios/cargo-deny-action@v2
@@ -179,11 +224,14 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, check]
+    needs: [changes, fmt, clippy, check]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Build documentation
         run: cargo doc --no-deps --all-features
         env:
@@ -196,24 +244,27 @@ jobs:
   msrv:
     name: MSRV (1.85)
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, check]
+    needs: [changes, fmt, clippy, check]
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.85
       - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Only check library code compiles with MSRV, not tests/dev-dependencies
       # (wiremock 0.6+ requires Rust 1.87 for let chains)
       - run: cargo check --all-features --lib -p mcpkit
 
   # ==========================================================================
-  # Cross-platform matrix - PRs only (to save CI minutes)
+  # Cross-platform matrix - PRs only, and only when code changed (skip docs PRs)
   # ==========================================================================
 
   test-matrix:
     name: Test (${{ matrix.os }})
-    if: github.event_name == 'pull_request'
+    needs: [changes, test]
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' }}
     runs-on: ${{ matrix.os }}
-    needs: [test]
     strategy:
       fail-fast: false
       matrix:
@@ -241,9 +292,10 @@ jobs:
   semver:
     name: Semver Check
     runs-on: ubuntu-latest
-    needs: [fmt, clippy, check]
-    # Only run on PRs (not pushes to main) to compare against baseline
-    if: github.event_name == 'pull_request'
+    needs: [changes, fmt, clippy, check]
+    # Only run on PRs that change code (compare against the published baseline);
+    # docs-only PRs can't introduce API breaks, so they skip this entirely.
+    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
@@ -256,3 +308,43 @@ jobs:
         # macros test crate), leaving the published crates whose API consumers
         # depend on directly.
         run: cargo semver-checks check-release --workspace
+
+  # ==========================================================================
+  # Aggregate gate - a single job that summarizes the required checks. Mark
+  # THIS job as the required status check on the branch protection rule: it
+  # stays green when heavy jobs are legitimately skipped (e.g. docs-only PRs)
+  # and fails if any required job failed or was cancelled, so path-filtering
+  # never deadlocks a required check.
+  # ==========================================================================
+
+  ci-success:
+    name: CI Success
+    if: ${{ always() }}
+    needs:
+      [
+        changes,
+        fmt,
+        clippy,
+        check,
+        version-sync,
+        link-check,
+        test,
+        deny,
+        docs,
+        msrv,
+        test-matrix,
+        semver,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify required jobs succeeded or were skipped
+        run: |
+          results="${{ join(needs.*.result, ' ') }}"
+          echo "Job results: $results"
+          for r in $results; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::A required job did not pass (result: $r)"
+              exit 1
+            fi
+          done
+          echo "All required checks passed or were skipped."


### PR DESCRIPTION
## Goal

Reduce interactive (PR) CI wait without weakening any gate. Measured baseline (last ~80 runs): **PR runs block ~14 min p50 / 19 min p95** (max 30.6), while trunk-push runs finish in ~3.6 min. The gap is the PR-only heavy jobs (Windows test ~10.6m, coverage ~8.5m, and the cold-cache semver spikes). Failure rate was ~2.5%; concurrency cancellation already works.

## Changes

**1. Change detection + aggregate gate (the main interactive win).**
- A `changes` job (`dorny/paths-filter`) sets `code` when Rust/Cargo/`build.rs`/proto/CI files change.
- Heavy jobs run when `code == true` **or** the event is a push to the trunk → trunk coverage is never reduced; **docs-only PRs skip them and finish in ~1 min instead of ~14 min**.
- `test-matrix` and `semver` additionally gate to PRs *with code changes* (a docs PR can't break the cross-platform build or the public API — this kills the 18 min cold-semver and ~10 min Windows on doc PRs).
- New `ci-success` job aggregates the required jobs' results (skipped = OK; failure/cancelled = fail). This is the forward-compatible pattern: it can be made the single required status check later **without** path-filtering deadlocking a skipped required job. (Workflow-level `paths:` would have that deadlock; this avoids it.)

**2. Coverage → trunk (push) only [C3].** Already non-gating (`fail_ci_if_error:false`) yet sat on the PR path at ~8.5m. Running it on the trunk keeps the Codecov trend line and warms its cache while removing it from interactive wait.

**3. `save-if: main` on the five trunk-running cached jobs** (clippy, check, test, docs, msrv). PR branches restore the trunk cache but no longer save per-branch copies that were churning the 10 GB cache ceiling (measured at 9.87/10 GB, saturated). PR-only jobs (test-matrix, semver) keep saving — they never run on the trunk to seed a shared cache, so `save-if: main` would make them permanently cold.

## Safety

No gate is weakened. Every check still runs on the trunk; on PRs every check still runs whenever code changes. Coverage was already non-gating. The only behavior trades are deliberate: docs-only PRs skip compile/test/semver (they can't affect those), and coverage signal moves from per-PR to the trunk trend line.

## Deferred (pending re-measurement after this lands)

- The bigger caching move (run test-matrix/semver on the trunk to seed a shared cross-PR cache) — C1 may relieve the ceiling enough that it's unnecessary.
- Windows latency (~10.6m floor; the two `cargo test` calls are a deliberate protobuf-on-Windows workaround, not redundancy). A Defender-exclusion measurement pass before considering relocation.

CI-only; no CHANGELOG entry.