### PR TITLE
fix: rename elicitation/elicit to elicitation/create

### DIFF
--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -321,7 +321,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
 
         let response = match request.method.as_ref() {
             "sampling/createMessage" => Self::handle_sampling_request(&request, handler).await,
-            "elicitation/elicit" => Self::handle_elicitation_request(&request, handler).await,
+            "elicitation/create" => Self::handle_elicitation_request(&request, handler).await,
             "roots/list" => Self::handle_roots_request(&request, handler).await,
             "ping" => {
                 // Respond to ping with empty result
@@ -377,7 +377,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         }
     }
 
-    /// Handle an elicitation/elicit request.
+    /// Handle an elicitation/create request.
     async fn handle_elicitation_request(request: &Request, handler: &Arc<H>) -> Response {
         let params = match &request.params {
             Some(p) => match serde_json::from_value::<ElicitRequest>(p.clone()) {
@@ -392,7 +392,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             None => {
                 return Response::error(
                     request.id.clone(),
-                    JsonRpcError::invalid_params("Missing params for elicitation/elicit"),
+                    JsonRpcError::invalid_params("Missing params for elicitation/create"),
                 );
             }
         };

--- a/crates/mcpkit-macros/src/lib.rs
+++ b/crates/mcpkit-macros/src/lib.rs
@@ -364,7 +364,7 @@ pub fn derive_tool_input(input: TokenStream) -> TokenStream {
 /// The following attributes mark methods as handlers:
 ///
 /// - `#[sampling]` - Handle `sampling/createMessage` requests
-/// - `#[elicitation]` - Handle `elicitation/elicit` requests
+/// - `#[elicitation]` - Handle `elicitation/create` requests
 /// - `#[roots]` - Handle `roots/list` requests
 /// - `#[on_connected]` - Called when connection is established
 /// - `#[on_disconnected]` - Called when connection is closed


### PR DESCRIPTION
Fixes #88

The client was handling `elicitation/elicit` but the MCP spec 
defines the method as `elicitation/create`.

Changes:
- crates/mcpkit-client/src/client.rs (lines 324, 380, 395)
- crates/mcpkit-macros/src/lib.rs (line 367)