### PR TITLE
feat: add ResourceLinkContent type

### DIFF
--- a/crates/mcpkit-core/src/types/content.rs
+++ b/crates/mcpkit-core/src/types/content.rs
@@ -99,11 +99,14 @@ impl Content {
     pub const fn is_resource(&self) -> bool {
         matches!(self, Self::Resource(_))
     }
+
     /// Create a resource link.
     #[must_use]
-    pub fn resource_link(uri: impl Into<String>) -> Self {
+    pub fn resource_link(uri: impl Into<String>, name: impl Into<String>) -> Self {
         Self::ResourceLink(ResourceLinkContent {
             uri: uri.into(),
+            name: name.into(),
+            description: None,
             mime_type: None,
             annotations: None,
         })
@@ -180,6 +183,24 @@ pub struct ResourceContent {
     pub annotations: Option<ContentAnnotations>,
 }
 
+/// A link to a resource (not embedded inline, just a URI reference).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceLinkContent {
+    /// URI of the resource.
+    pub uri: String,
+    /// Name of the resource.
+    pub name: String,
+    /// Description of the resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// MIME type of the resource.
+    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    /// Optional annotations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<ContentAnnotations>,
+}
+
 /// Annotations that can be attached to content.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ContentAnnotations {
@@ -236,18 +257,7 @@ impl std::fmt::Display for Role {
         }
     }
 }
-/// A link to a resource (not embedded inline, just a URI reference).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ResourceLinkContent {
-    /// URI of the resource.
-    pub uri: String,
-    /// MIME type of the resource.
-    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
-    pub mime_type: Option<String>,
-    /// Optional annotations.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<ContentAnnotations>,
-}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -291,15 +301,17 @@ mod tests {
         );
         Ok(())
     }
+
     #[test]
     fn test_resource_link_content() -> Result<(), Box<dyn std::error::Error>> {
-        let content = Content::resource_link("https://example.com/file.pdf");
+        let content = Content::resource_link("https://example.com/file.pdf", "My File");
         assert!(content.is_resource_link());
         let json = serde_json::to_string(&content)?;
         let parsed: Content = serde_json::from_str(&json)?;
         assert!(parsed.is_resource_link());
         assert!(json.contains("\"type\":\"resource_link\""));
         assert!(json.contains("\"uri\":\"https://example.com/file.pdf\""));
+        assert!(json.contains("\"name\":\"My File\""));
         Ok(())
     }
 }

--- a/crates/mcpkit-core/src/types/content.rs
+++ b/crates/mcpkit-core/src/types/content.rs
@@ -20,6 +20,9 @@ pub enum Content {
     Audio(AudioContent),
     /// Embedded resource reference.
     Resource(ResourceContent),
+    /// A link to a resource (not embedded).
+    #[serde(rename = "resource_link")]
+    ResourceLink(ResourceLinkContent),
 }
 
 impl Content {
@@ -95,6 +98,21 @@ impl Content {
     #[must_use]
     pub const fn is_resource(&self) -> bool {
         matches!(self, Self::Resource(_))
+    }
+    /// Create a resource link.
+    #[must_use]
+    pub fn resource_link(uri: impl Into<String>) -> Self {
+        Self::ResourceLink(ResourceLinkContent {
+            uri: uri.into(),
+            mime_type: None,
+            annotations: None,
+        })
+    }
+
+    /// Check if this is a resource link.
+    #[must_use]
+    pub const fn is_resource_link(&self) -> bool {
+        matches!(self, Self::ResourceLink(_))
     }
 
     /// Get the text if this is text content.
@@ -218,7 +236,18 @@ impl std::fmt::Display for Role {
         }
     }
 }
-
+/// A link to a resource (not embedded inline, just a URI reference).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceLinkContent {
+    /// URI of the resource.
+    pub uri: String,
+    /// MIME type of the resource.
+    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    /// Optional annotations.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<ContentAnnotations>,
+}
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -260,6 +289,17 @@ mod tests {
                 .ok_or("Expected audience")?
                 .contains(&Role::User)
         );
+        Ok(())
+    }
+    #[test]
+    fn test_resource_link_content() -> Result<(), Box<dyn std::error::Error>> {
+        let content = Content::resource_link("https://example.com/file.pdf");
+        assert!(content.is_resource_link());
+        let json = serde_json::to_string(&content)?;
+        let parsed: Content = serde_json::from_str(&json)?;
+        assert!(parsed.is_resource_link());
+        assert!(json.contains("\"type\":\"resource_link\""));
+        assert!(json.contains("\"uri\":\"https://example.com/file.pdf\""));
         Ok(())
     }
 }


### PR DESCRIPTION
Closes #80

Added `ResourceLinkContent` struct and `ResourceLink` variant to the `Content` enum.

Changes:
- Added `ResourceLinkContent` struct with `uri`, `mime_type`, and `annotations` fields
- Added `ResourceLink(ResourceLinkContent)` variant to `Content` enum with explicit `#[serde(rename = "resource_link")]`
- Added `Content::resource_link()` helper function
- Added `Content::is_resource_link()` helper function
- Added round-trip serialization test