### PR TITLE
ci: cache the semver baseline via the official action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -293,21 +293,23 @@ jobs:
     name: Semver Check
     runs-on: ubuntu-latest
     needs: [changes, fmt, clippy, check]
-    # Only run on PRs that change code (compare against the published baseline);
-    # docs-only PRs can't introduce API breaks, so they skip this entirely.
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' }}
+    # Run on code-changing PRs (compare against the published baseline), and on
+    # pushes to the trunk. The trunk run seeds the per-package baseline-rustdoc
+    # cache that the action shares back to PRs: GitHub caches are branch-scoped,
+    # so the cache has to be written on the default branch to be restorable by
+    # PR branches. Docs-only changes skip this (no API can change).
+    if: ${{ (github.event_name == 'pull_request' || github.event_name == 'push') && needs.changes.outputs.code == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.96
-      - uses: Swatinem/rust-cache@v2
-      - name: Install cargo-semver-checks
-        uses: taiki-e/install-action@cargo-semver-checks
+      # The official action caches each publishable crate's baseline rustdoc
+      # across runs, so the unchanging published baseline is not rebuilt on every
+      # PR (which was ~half the job). It installs the toolchain and checks the
+      # whole workspace (skipping `publish = false` crates) by default.
       - name: Check semver
-        # Check every publishable crate, not just the umbrella. `--workspace`
-        # skips crates marked `publish = false` (examples, benches, fuzz, the
-        # macros test crate), leaving the published crates whose API consumers
-        # depend on directly.
-        run: cargo semver-checks check-release --workspace
+        uses: obi1kenobi/cargo-semver-checks-action@v2
+        with:
+          rust-toolchain: "1.96"
+          verbose: true
 
   # ==========================================================================
   # Aggregate gate - a single job that summarizes the required checks. Mark


### PR DESCRIPTION
## Why

Semver Check was ~18 min. The pasted timing shows **~100% of it is rustdoc *building*** (`Checked [0.000s]` everywhere), with three compounding causes:
- Every crate built **twice** (current `0.7.0` + baseline `0.6.0`).
- **No baseline caching** — we install the binary and run `cargo semver-checks` directly, so the unchanging `0.6.0` baseline is rebuilt from scratch each PR (~half the job).
- semver-checks defaults to ~all-features, so `mcpkit-transport`'s full gRPC/otel/http stack builds at **307s/side — over half the whole job**.

## Change

Switch to `obi1kenobi/cargo-semver-checks-action@v2`, which **caches each package's baseline rustdoc** across runs (the docs note the binary doesn't, but the action does). Also run the job on **push to `main`** so the cache is seeded on the default branch — GitHub caches are branch-scoped, so without a trunk run each PR branch would build the baseline cold. Coverage is unchanged (whole workspace, same default feature set, `publish=false` crates skipped).

## Expected effect (and how to verify)

- **This PR** runs the action cold (no cache seeded on `main` yet) — it validates the action checks the right crates and passes; it won't be faster yet.
- After merge, the **push-to-`main`** run seeds the baseline cache.
- The **next** code PR (e.g. #82) restores the baseline and skips rebuilding it → expected **~18 min → ~9–10 min**.

If transport's current-side build still dominates after that, the follow-up lever is matrix-parallelizing the per-crate checks (kept out of scope here, per measure-first).