### PR TITLE
feat(axum): validate request Origin to prevent DNS rebinding (#82, PR 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sampling: a handler can ask the client to run an LLM completion and await the
   result. Gated on the client's `sampling` capability
   ([#73](https://github.com/praxiomlabs/mcpkit/issues/73)).
+- `mcpkit_transport::http::OriginValidator` for `Origin`-header validation, and
+  `McpRouter::with_allowed_origins(..)` / `McpRouter::allow_any_origin()` in the
+  `mcpkit-axum` adapter to configure it
+  ([#82](https://github.com/praxiomlabs/mcpkit/issues/82)).
 
 ### Changed
 
@@ -86,6 +90,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Breaking (behavior):** the `mcpkit-axum` adapter now validates the request
+  `Origin` header to defend against DNS-rebinding attacks, and **rejects
+  non-loopback browser origins by default** (previously all origins were
+  accepted). Loopback origins and requests without an `Origin` header (non-browser
+  clients) are still allowed; add production origins with
+  `McpRouter::with_allowed_origins([..])`, or opt out with `allow_any_origin()`
+  ([#82](https://github.com/praxiomlabs/mcpkit/issues/82)).
 - OAuth/token types (`TokenResponse`, `TokenRequest`, `AuthorizationConfig`,
   `PkceChallenge`, `ClientRegistrationResponse`) now redact their secret fields
   in `Debug` output. Previously deriving `Debug` printed access/refresh tokens,

--- a/crates/mcpkit-axum/Cargo.toml
+++ b/crates/mcpkit-axum/Cargo.toml
@@ -39,6 +39,8 @@ futures = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["full", "test-util"] }
 tokio-test.workspace = true
+# `util` enables `ServiceExt::oneshot` for driving the router in tests.
+tower = { version = "0.4", features = ["util"] }
 
 [lints]
 workspace = true

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -45,6 +45,16 @@ pub async fn handle_mcp_post<H>(
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
 {
+    // Reject disallowed Origins (DNS-rebinding protection) before any work.
+    let origin = headers.get("origin").and_then(|v| v.to_str().ok());
+    if !state.origin_validator.is_allowed(origin) {
+        warn!(
+            origin = origin.unwrap_or("none"),
+            "Rejected: origin not allowed"
+        );
+        return (StatusCode::FORBIDDEN, "origin not allowed").into_response();
+    }
+
     // Validate protocol version
     let version = headers
         .get("mcp-protocol-version")
@@ -283,6 +293,16 @@ pub async fn handle_sse<H>(
 where
     H: HasServerInfo + Send + Sync + 'static,
 {
+    // Reject disallowed Origins (DNS-rebinding protection) before streaming.
+    let origin = headers.get("origin").and_then(|v| v.to_str().ok());
+    if !state.origin_validator.is_allowed(origin) {
+        warn!(
+            origin = origin.unwrap_or("none"),
+            "Rejected SSE: origin not allowed"
+        );
+        return (StatusCode::FORBIDDEN, "origin not allowed").into_response();
+    }
+
     let session_id = headers
         .get("mcp-session-id")
         .and_then(|v| v.to_str().ok())
@@ -328,7 +348,9 @@ where
 
     let event_store = state.sse_sessions.get_event_store(&id);
     let stream = create_sse_stream_with_replay(id, rx, replay_events, event_store);
-    Sse::new(stream).keep_alive(KeepAlive::default())
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
 }
 
 /// Create an SSE stream with support for event replay.

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -6,6 +6,8 @@ use axum::Router;
 use axum::routing::{get, post};
 use mcpkit_core::auth::ProtectedResourceMetadata;
 use mcpkit_server::{PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use mcpkit_transport::http::OriginValidator;
+use std::sync::Arc;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::trace::TraceLayer;
 
@@ -71,6 +73,38 @@ where
     #[must_use]
     pub const fn with_cors(mut self) -> Self {
         self.enable_cors = true;
+        self
+    }
+
+    /// Restrict which browser `Origin`s are accepted, for DNS-rebinding
+    /// protection.
+    ///
+    /// Loopback origins (`localhost`, `127.0.0.1`, `[::1]`) are always allowed;
+    /// the given origins (e.g. `https://app.example.com`) are added to the
+    /// allow-list. Requests with no `Origin` header (non-browser clients) are
+    /// allowed. By default — without calling this — only loopback origins are
+    /// accepted.
+    #[must_use]
+    pub fn with_allowed_origins<I, S>(mut self, origins: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut validator = OriginValidator::allow_list();
+        for origin in origins {
+            validator = validator.allow(origin);
+        }
+        self.state.origin_validator = Arc::new(validator);
+        self
+    }
+
+    /// Disable `Origin` validation entirely, accepting every origin.
+    ///
+    /// **Insecure**: this removes DNS-rebinding protection. Only use it behind
+    /// other safeguards (mTLS, a trusted network, authenticated sessions).
+    #[must_use]
+    pub fn allow_any_origin(mut self) -> Self {
+        self.state.origin_validator = Arc::new(OriginValidator::allow_any());
         self
     }
 
@@ -270,5 +304,83 @@ mod tests {
 
         // Router should be created without panicking
         let _ = router;
+    }
+
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt; // for `oneshot`
+
+    fn post_with_origin(origin: Option<&str>) -> Request<Body> {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/mcp")
+            .header("mcp-protocol-version", "2025-06-18");
+        if let Some(o) = origin {
+            builder = builder.header("origin", o);
+        }
+        builder
+            .body(Body::from(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn rejects_external_origin_by_default() {
+        let router = McpRouter::new(TestHandler).into_router();
+        let resp = router
+            .oneshot(post_with_origin(Some("https://evil.example.com")))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn allows_loopback_and_missing_origin_by_default() {
+        let router = McpRouter::new(TestHandler).into_router();
+        for origin in [
+            Some("http://localhost:3000"),
+            Some("http://127.0.0.1"),
+            None,
+        ] {
+            let resp = router
+                .clone()
+                .oneshot(post_with_origin(origin))
+                .await
+                .unwrap();
+            assert_ne!(
+                resp.status(),
+                StatusCode::FORBIDDEN,
+                "origin {origin:?} should pass the origin gate"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn with_allowed_origins_permits_only_configured() {
+        let router = McpRouter::new(TestHandler)
+            .with_allowed_origins(["https://app.example.com"])
+            .into_router();
+
+        let ok = router
+            .clone()
+            .oneshot(post_with_origin(Some("https://app.example.com")))
+            .await
+            .unwrap();
+        assert_ne!(ok.status(), StatusCode::FORBIDDEN);
+
+        let blocked = router
+            .oneshot(post_with_origin(Some("https://other.example.com")))
+            .await
+            .unwrap();
+        assert_eq!(blocked.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn allow_any_origin_accepts_external() {
+        let router = McpRouter::new(TestHandler).allow_any_origin().into_router();
+        let resp = router
+            .oneshot(post_with_origin(Some("https://evil.example.com")))
+            .await
+            .unwrap();
+        assert_ne!(resp.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/crates/mcpkit-axum/src/state.rs
+++ b/crates/mcpkit-axum/src/state.rs
@@ -3,6 +3,7 @@
 use crate::session::{SessionManager, SessionStore};
 use mcpkit_core::auth::ProtectedResourceMetadata;
 use mcpkit_core::capability::ServerInfo;
+use mcpkit_transport::http::OriginValidator;
 use std::fmt;
 use std::sync::Arc;
 
@@ -22,6 +23,9 @@ pub struct McpState<H> {
     pub sessions: Arc<SessionStore>,
     /// Session manager for SSE streaming.
     pub sse_sessions: Arc<SessionManager>,
+    /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
+    /// to loopback-only.
+    pub origin_validator: Arc<OriginValidator>,
 }
 
 // Manual Clone implementation to avoid requiring H: Clone
@@ -32,6 +36,7 @@ impl<H> Clone for McpState<H> {
             server_info: self.server_info.clone(),
             sessions: Arc::clone(&self.sessions),
             sse_sessions: Arc::clone(&self.sse_sessions),
+            origin_validator: Arc::clone(&self.origin_validator),
         }
     }
 }
@@ -44,6 +49,7 @@ impl<H> fmt::Debug for McpState<H> {
             .field("server_info", &self.server_info)
             .field("sessions", &self.sessions)
             .field("sse_sessions", &format_args!("Arc<SessionManager>"))
+            .field("origin_validator", &self.origin_validator)
             .finish()
     }
 }
@@ -60,6 +66,7 @@ impl<H> McpState<H> {
             server_info,
             sessions: Arc::new(SessionStore::with_default_timeout()),
             sse_sessions: Arc::new(SessionManager::new()),
+            origin_validator: Arc::new(OriginValidator::default()),
         }
     }
 
@@ -74,6 +81,7 @@ impl<H> McpState<H> {
             server_info,
             sessions: Arc::new(sessions),
             sse_sessions: Arc::new(sse_sessions),
+            origin_validator: Arc::new(OriginValidator::default()),
         }
     }
 }

--- a/crates/mcpkit-transport/src/http/mod.rs
+++ b/crates/mcpkit-transport/src/http/mod.rs
@@ -46,6 +46,9 @@ mod sse;
 #[cfg(feature = "http")]
 mod server;
 
+#[cfg(feature = "http")]
+mod origin;
+
 // Re-export public types
 pub use client::HttpTransport;
 pub use config::{
@@ -53,6 +56,8 @@ pub use config::{
     MCP_PROTOCOL_VERSION_HEADER, MCP_SESSION_ID_HEADER,
 };
 
+#[cfg(feature = "http")]
+pub use origin::OriginValidator;
 #[cfg(feature = "http")]
 pub use server::{HttpServerConfig, HttpTransportListener, OriginValidationMode};
 

--- a/crates/mcpkit-transport/src/http/origin.rs
+++ b/crates/mcpkit-transport/src/http/origin.rs
@@ -1,0 +1,155 @@
+//! `Origin` header validation for HTTP MCP servers (DNS-rebinding protection).
+//!
+//! DNS rebinding lets a malicious web page bind its own domain to `127.0.0.1`
+//! and then make same-origin requests to a local server. The defense is for the
+//! server to validate the request's `Origin` header against an allow-list. Only
+//! browsers send `Origin`, so non-browser clients (which cannot be used for DNS
+//! rebinding) are unaffected.
+//!
+//! See: <https://modelcontextprotocol.io/specification/2025-11-25/basic/transports>
+
+use super::server::OriginValidationMode;
+
+/// Validates request `Origin` headers to protect an HTTP MCP server from
+/// DNS-rebinding attacks.
+///
+/// The default ([`allow_list`](Self::allow_list)) is secure: only loopback
+/// origins (`localhost`, `127.0.0.1`, `[::1]`) and any origins added with
+/// [`allow`](Self::allow) are accepted, and requests with no `Origin` header are
+/// allowed (they cannot come from a browser). An empty allow-list therefore
+/// means "loopback only", **not** "allow all".
+#[derive(Debug, Clone)]
+pub struct OriginValidator {
+    mode: OriginValidationMode,
+    allowed_origins: Vec<String>,
+}
+
+impl Default for OriginValidator {
+    fn default() -> Self {
+        Self::allow_list()
+    }
+}
+
+impl OriginValidator {
+    /// The secure default: accept loopback origins plus any added with
+    /// [`allow`](Self::allow); reject all other browser origins. Requests
+    /// without an `Origin` header are allowed.
+    #[must_use]
+    pub const fn allow_list() -> Self {
+        Self {
+            mode: OriginValidationMode::AllowList,
+            allowed_origins: Vec::new(),
+        }
+    }
+
+    /// Disable origin validation: accept every origin.
+    ///
+    /// **Insecure** — this removes DNS-rebinding protection. Only use it behind
+    /// other safeguards (mTLS, a trusted network, authenticated sessions).
+    #[must_use]
+    pub const fn allow_any() -> Self {
+        Self {
+            mode: OriginValidationMode::Disabled,
+            allowed_origins: Vec::new(),
+        }
+    }
+
+    /// Add an allowed origin, e.g. `https://app.example.com`. Matched exactly
+    /// (scheme, host, and port).
+    #[must_use]
+    pub fn allow(mut self, origin: impl Into<String>) -> Self {
+        self.allowed_origins.push(origin.into());
+        self
+    }
+
+    /// Whether a request carrying this `Origin` header value should be allowed.
+    #[must_use]
+    pub fn is_allowed(&self, origin: Option<&str>) -> bool {
+        match self.mode {
+            OriginValidationMode::Disabled | OriginValidationMode::WarnAndAllow => true,
+            OriginValidationMode::AllowList => match origin {
+                // No Origin header: not a browser request, so not a DNS-rebinding
+                // vector.
+                None => true,
+                Some(origin) => self.is_origin_listed(origin),
+            },
+            // Strict additionally requires that an `Origin` header be present.
+            OriginValidationMode::Strict => origin.is_some_and(|o| self.is_origin_listed(o)),
+        }
+    }
+
+    fn is_origin_listed(&self, origin: &str) -> bool {
+        is_loopback_origin(origin) || self.allowed_origins.iter().any(|a| a == origin)
+    }
+}
+
+/// Returns true if the origin's host is a loopback name/address
+/// (`localhost`, `127.0.0.1`, or `[::1]`), regardless of scheme or port.
+fn is_loopback_origin(origin: &str) -> bool {
+    let Some((_scheme, rest)) = origin.split_once("://") else {
+        return false;
+    };
+    // An Origin is scheme://host[:port]; guard against any stray path anyway.
+    let authority = rest.split(['/', '?', '#']).next().unwrap_or(rest);
+    let host = if let Some(after_bracket) = authority.strip_prefix('[') {
+        // IPv6 literal, e.g. [::1]:8080
+        after_bracket.split(']').next().unwrap_or(after_bracket)
+    } else {
+        // host[:port]
+        authority.rsplit_once(':').map_or(authority, |(h, _)| h)
+    };
+    host.eq_ignore_ascii_case("localhost") || host == "127.0.0.1" || host == "::1"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn loopback_origins_are_allowed_by_default() {
+        let v = OriginValidator::allow_list();
+        assert!(v.is_allowed(Some("http://localhost")));
+        assert!(v.is_allowed(Some("http://localhost:3000")));
+        assert!(v.is_allowed(Some("http://127.0.0.1:8080")));
+        assert!(v.is_allowed(Some("https://[::1]:9000")));
+        assert!(v.is_allowed(Some("http://LocalHost:1234")));
+    }
+
+    #[test]
+    fn external_origins_are_rejected_by_default() {
+        let v = OriginValidator::allow_list();
+        assert!(!v.is_allowed(Some("https://evil.example.com")));
+        assert!(!v.is_allowed(Some("http://attacker.test")));
+        // A host that merely contains "localhost" must not pass.
+        assert!(!v.is_allowed(Some("http://localhost.evil.com")));
+        assert!(!v.is_allowed(Some("http://127.0.0.1.evil.com")));
+    }
+
+    #[test]
+    fn missing_origin_is_allowed_but_strict_rejects_it() {
+        assert!(OriginValidator::allow_list().is_allowed(None));
+        let strict = OriginValidator {
+            mode: OriginValidationMode::Strict,
+            allowed_origins: Vec::new(),
+        };
+        assert!(!strict.is_allowed(None));
+        assert!(strict.is_allowed(Some("http://localhost")));
+    }
+
+    #[test]
+    fn configured_origins_are_allowed_exactly() {
+        let v = OriginValidator::allow_list().allow("https://app.example.com");
+        assert!(v.is_allowed(Some("https://app.example.com")));
+        assert!(!v.is_allowed(Some("https://app.example.com:8443")));
+        assert!(!v.is_allowed(Some("http://app.example.com")));
+        // Loopback still allowed alongside configured origins.
+        assert!(v.is_allowed(Some("http://localhost:5173")));
+    }
+
+    #[test]
+    fn allow_any_accepts_everything() {
+        let v = OriginValidator::allow_any();
+        assert!(v.is_allowed(Some("https://evil.example.com")));
+        assert!(v.is_allowed(None));
+    }
+}


### PR DESCRIPTION
First of two PRs for #82. Establishes the shared `OriginValidator` and wires the **axum** adapter; actix/warp/rocket follow in PR2.

## Problem

The HTTP adapters did **no Origin validation** — `with_cors()` is just `allow_origin(Any)` — so a local MCP server is exposed to DNS-rebinding (a malicious page rebinding its domain to `127.0.0.1` and making same-origin requests). The MCP transports spec says to validate `Origin`. The transport's existing `is_origin_allowed` had the classic footgun: an empty allow-list returned `true` (allow-all).

## What this adds

- **`mcpkit_transport::http::OriginValidator`** (reuses `OriginValidationMode`) with correct semantics:
  - Loopback origins (`localhost`/`127.0.0.1`/`[::1]`) always allowed.
  - **No `Origin` header → allowed** (DNS rebinding is browser-only; non-browser clients are unaffected).
  - **Empty allow-list → loopback-only**, not allow-all.
  - Exact-match for configured origins (scheme+host+port).
- **axum `McpRouter`**: loopback-only **by default**, `with_allowed_origins([..])` to add production origins, `allow_any_origin()` as an explicit insecure opt-out. POST **and** SSE handlers return **403** on a disallowed origin before any work.

## Behavior change (called out)

This is **secure-by-default and breaking**: the adapter previously accepted every origin; it now rejects non-loopback browser origins unless configured. Documented in CHANGELOG under Security. On the 0.x line this is acceptable and is the posture the spec requires.

## Tests

- `OriginValidator` units: loopback variants, exact allow-list match (e.g. `app.example.com` ≠ `app.example.com:8443`, `localhost.evil.com` rejected), missing-origin, strict mode, allow-any.
- axum integration (`tower::ServiceExt::oneshot`): external origin → 403; loopback/none/configured pass; `allow_any_origin` accepts external.

## Note

This PR's Semver Check is the **first to restore the warm baseline cache** seeded by #99 — so it doubles as the re-measurement of the semver-speedup (expected ~5–6 min vs the old ~18).

## Follow-up

PR2 wires actix/warp/rocket to the same `OriginValidator`. (The non-functional transport HTTP stub's footgun is tracked separately under #83.)