### PR TITLE
feat(actix,rocket): validate request Origin to prevent DNS rebinding (#82, PR 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#73](https://github.com/praxiomlabs/mcpkit/issues/73)).
 - `mcpkit_transport::http::OriginValidator` for `Origin`-header validation, and
   `McpRouter::with_allowed_origins(..)` / `McpRouter::allow_any_origin()` in the
-  `mcpkit-axum` adapter to configure it
+  `mcpkit-axum`, `mcpkit-actix`, and `mcpkit-rocket` adapters to configure it
   ([#82](https://github.com/praxiomlabs/mcpkit/issues/82)).
 
 ### Changed
@@ -90,13 +90,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Breaking (behavior):** the `mcpkit-axum` adapter now validates the request
-  `Origin` header to defend against DNS-rebinding attacks, and **rejects
-  non-loopback browser origins by default** (previously all origins were
-  accepted). Loopback origins and requests without an `Origin` header (non-browser
-  clients) are still allowed; add production origins with
-  `McpRouter::with_allowed_origins([..])`, or opt out with `allow_any_origin()`
-  ([#82](https://github.com/praxiomlabs/mcpkit/issues/82)).
+- **Breaking (behavior):** the `mcpkit-axum`, `mcpkit-actix`, and `mcpkit-rocket`
+  adapters now validate the request `Origin` header to defend against
+  DNS-rebinding attacks, and **reject non-loopback browser origins by default**
+  (previously all origins were accepted). Loopback origins and requests without
+  an `Origin` header (non-browser clients) are still allowed; add production
+  origins with `McpRouter::with_allowed_origins([..])`, or opt out with
+  `allow_any_origin()` ([#82](https://github.com/praxiomlabs/mcpkit/issues/82)).
 - OAuth/token types (`TokenResponse`, `TokenRequest`, `AuthorizationConfig`,
   `PkceChallenge`, `ClientRegistrationResponse`) now redact their secret fields
   in `Debug` output. Previously deriving `Debug` printed access/refresh tokens,

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -40,6 +40,16 @@ pub async fn handle_mcp_post<H>(
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
 {
+    // Reject disallowed Origins (DNS-rebinding protection) before any work.
+    let origin = req.headers().get("origin").and_then(|v| v.to_str().ok());
+    if !state.origin_validator.is_allowed(origin) {
+        warn!(
+            origin = origin.unwrap_or("none"),
+            "Rejected: origin not allowed"
+        );
+        return Ok(HttpResponse::Forbidden().body("origin not allowed"));
+    }
+
     // Validate protocol version
     let version = req
         .headers()
@@ -256,6 +266,16 @@ pub async fn handle_sse<H>(req: HttpRequest, state: web::Data<McpState<H>>) -> H
 where
     H: HasServerInfo + Send + Sync + 'static,
 {
+    // Reject disallowed Origins (DNS-rebinding protection) before streaming.
+    let origin = req.headers().get("origin").and_then(|v| v.to_str().ok());
+    if !state.origin_validator.is_allowed(origin) {
+        warn!(
+            origin = origin.unwrap_or("none"),
+            "Rejected SSE: origin not allowed"
+        );
+        return HttpResponse::Forbidden().body("origin not allowed");
+    }
+
     let session_id = req
         .headers()
         .get("mcp-session-id")

--- a/crates/mcpkit-actix/src/router.rs
+++ b/crates/mcpkit-actix/src/router.rs
@@ -7,6 +7,8 @@ use actix_web::middleware::Logger;
 use actix_web::{App, HttpServer, web};
 use mcpkit_core::auth::ProtectedResourceMetadata;
 use mcpkit_server::{PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use mcpkit_transport::http::OriginValidator;
+use std::sync::Arc;
 
 /// Builder for MCP Actix routers.
 ///
@@ -74,6 +76,38 @@ where
     #[must_use]
     pub const fn with_cors(mut self) -> Self {
         self.enable_cors = true;
+        self
+    }
+
+    /// Restrict which browser `Origin`s are accepted, for DNS-rebinding
+    /// protection.
+    ///
+    /// Loopback origins (`localhost`, `127.0.0.1`, `[::1]`) are always allowed;
+    /// the given origins (e.g. `https://app.example.com`) are added to the
+    /// allow-list. Requests with no `Origin` header (non-browser clients) are
+    /// allowed. By default — without calling this — only loopback origins are
+    /// accepted.
+    #[must_use]
+    pub fn with_allowed_origins<I, S>(mut self, origins: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut validator = OriginValidator::allow_list();
+        for origin in origins {
+            validator = validator.allow(origin);
+        }
+        self.state.origin_validator = Arc::new(validator);
+        self
+    }
+
+    /// Disable `Origin` validation entirely, accepting every origin.
+    ///
+    /// **Insecure**: this removes DNS-rebinding protection. Only use it behind
+    /// other safeguards (mTLS, a trusted network, authenticated sessions).
+    #[must_use]
+    pub fn allow_any_origin(mut self) -> Self {
+        self.state.origin_validator = Arc::new(OriginValidator::allow_any());
         self
     }
 
@@ -303,5 +337,45 @@ mod tests {
 
         // Router should be created without panicking
         let _ = router;
+    }
+
+    #[test]
+    fn origin_validator_defaults_to_loopback_only() {
+        let r = McpRouter::new(TestHandler);
+        assert!(
+            r.state
+                .origin_validator
+                .is_allowed(Some("http://localhost:3000"))
+        );
+        assert!(r.state.origin_validator.is_allowed(None));
+        assert!(
+            !r.state
+                .origin_validator
+                .is_allowed(Some("https://evil.example.com"))
+        );
+    }
+
+    #[test]
+    fn with_allowed_origins_and_allow_any_configure_the_validator() {
+        let allow = McpRouter::new(TestHandler).with_allowed_origins(["https://app.example.com"]);
+        assert!(
+            allow
+                .state
+                .origin_validator
+                .is_allowed(Some("https://app.example.com"))
+        );
+        assert!(
+            !allow
+                .state
+                .origin_validator
+                .is_allowed(Some("https://evil.example.com"))
+        );
+
+        let any = McpRouter::new(TestHandler).allow_any_origin();
+        assert!(
+            any.state
+                .origin_validator
+                .is_allowed(Some("https://evil.example.com"))
+        );
     }
 }

--- a/crates/mcpkit-actix/src/state.rs
+++ b/crates/mcpkit-actix/src/state.rs
@@ -4,6 +4,7 @@ use crate::session::{SessionManager, SessionStore};
 use mcpkit_core::auth::ProtectedResourceMetadata;
 use mcpkit_core::capability::ServerInfo;
 use mcpkit_server::ServerHandler;
+use mcpkit_transport::http::OriginValidator;
 use std::sync::Arc;
 
 /// Trait for types that provide server info.
@@ -35,6 +36,9 @@ pub struct McpState<H> {
     pub sse_sessions: Arc<SessionManager>,
     /// Server info for the initialize response.
     pub server_info: ServerInfo,
+    /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
+    /// to loopback-only.
+    pub origin_validator: Arc<OriginValidator>,
 }
 
 impl<H> McpState<H>
@@ -49,6 +53,7 @@ where
             sessions: Arc::new(SessionStore::with_default_timeout()),
             sse_sessions: Arc::new(SessionManager::new()),
             server_info,
+            origin_validator: Arc::new(OriginValidator::default()),
         }
     }
 
@@ -60,6 +65,7 @@ where
             server_info,
             sessions: Arc::new(sessions),
             sse_sessions: Arc::new(sse_sessions),
+            origin_validator: Arc::new(OriginValidator::default()),
         }
     }
 }
@@ -71,6 +77,7 @@ impl<H> Clone for McpState<H> {
             sessions: Arc::clone(&self.sessions),
             sse_sessions: Arc::clone(&self.sse_sessions),
             server_info: self.server_info.clone(),
+            origin_validator: Arc::clone(&self.origin_validator),
         }
     }
 }

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -50,6 +50,19 @@ impl<'r> FromRequest<'r> for SessionIdHeader {
     }
 }
 
+/// `Origin` header, for DNS-rebinding protection.
+pub struct OriginHeader(pub Option<String>);
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for OriginHeader {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let origin = request.headers().get_one("origin").map(String::from);
+        Outcome::Success(OriginHeader(origin))
+    }
+}
+
 /// Last-Event-ID header for SSE reconnection.
 pub struct LastEventIdHeader(pub Option<String>);
 
@@ -165,6 +178,7 @@ pub async fn handle_mcp_post<H>(
     state: &McpState<H>,
     version: Option<&str>,
     session_id: Option<String>,
+    origin: Option<&str>,
     body: &str,
 ) -> McpResponse
 where
@@ -177,6 +191,15 @@ where
         + Sync
         + 'static,
 {
+    // Reject disallowed Origins (DNS-rebinding protection) before any work.
+    if !state.origin_validator.is_allowed(origin) {
+        warn!(
+            origin = origin.unwrap_or("none"),
+            "Rejected: origin not allowed"
+        );
+        return McpResponse::error(Status::Forbidden, "origin not allowed".to_string());
+    }
+
     // Validate protocol version
     if !is_supported_version(version) {
         let provided = version.unwrap_or("none");

--- a/crates/mcpkit-rocket/src/lib.rs
+++ b/crates/mcpkit-rocket/src/lib.rs
@@ -99,8 +99,8 @@ mod state;
 
 pub use error::RocketError;
 pub use handler::{
-    LastEventIdHeader, McpResponse, ProtocolVersionHeader, SessionIdHeader, handle_mcp_post,
-    handle_sse,
+    LastEventIdHeader, McpResponse, OriginHeader, ProtocolVersionHeader, SessionIdHeader,
+    handle_mcp_post, handle_sse,
 };
 pub use router::{Cors, McpRouter};
 pub use session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -2,6 +2,7 @@
 
 use crate::state::{HasServerInfo, McpState};
 use mcpkit_server::{PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use mcpkit_transport::http::OriginValidator;
 use rocket::fairing::{Fairing, Info, Kind};
 use rocket::http::Header;
 use rocket::{Build, Request, Response, Rocket};
@@ -54,6 +55,38 @@ where
     #[must_use]
     pub const fn with_cors(mut self) -> Self {
         self.enable_cors = true;
+        self
+    }
+
+    /// Restrict which browser `Origin`s are accepted, for DNS-rebinding
+    /// protection.
+    ///
+    /// Loopback origins (`localhost`, `127.0.0.1`, `[::1]`) are always allowed;
+    /// the given origins (e.g. `https://app.example.com`) are added to the
+    /// allow-list. Requests with no `Origin` header (non-browser clients) are
+    /// allowed. By default — without calling this — only loopback origins are
+    /// accepted.
+    #[must_use]
+    pub fn with_allowed_origins<I, S>(mut self, origins: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut validator = OriginValidator::allow_list();
+        for origin in origins {
+            validator = validator.allow(origin);
+        }
+        self.state.origin_validator = std::sync::Arc::new(validator);
+        self
+    }
+
+    /// Disable `Origin` validation entirely, accepting every origin.
+    ///
+    /// **Insecure**: this removes DNS-rebinding protection. Only use it behind
+    /// other safeguards (mTLS, a trusted network, authenticated sessions).
+    #[must_use]
+    pub fn allow_any_origin(mut self) -> Self {
+        self.state.origin_validator = std::sync::Arc::new(OriginValidator::allow_any());
         self
     }
 
@@ -156,18 +189,37 @@ macro_rules! create_mcp_routes {
             state: &::rocket::State<$crate::McpState<$handler_type>>,
             version: $crate::handler::ProtocolVersionHeader,
             session: $crate::handler::SessionIdHeader,
+            origin: $crate::handler::OriginHeader,
             body: String,
         ) -> $crate::handler::McpResponse {
-            $crate::handler::handle_mcp_post(state.inner(), version.0.as_deref(), session.0, &body)
-                .await
+            $crate::handler::handle_mcp_post(
+                state.inner(),
+                version.0.as_deref(),
+                session.0,
+                origin.0.as_deref(),
+                &body,
+            )
+            .await
         }
 
         #[rocket::get("/mcp/sse")]
         fn mcp_sse(
             state: &::rocket::State<$crate::McpState<$handler_type>>,
             session: $crate::handler::SessionIdHeader,
-        ) -> ::rocket::response::stream::EventStream![] {
-            $crate::handler::handle_sse(state.inner(), session.0)
+            origin: $crate::handler::OriginHeader,
+        ) -> ::std::result::Result<
+            ::rocket::response::stream::EventStream![],
+            ::rocket::http::Status,
+        > {
+            // Reject disallowed Origins (DNS-rebinding protection) before streaming.
+            if !state
+                .inner()
+                .origin_validator
+                .is_allowed(origin.0.as_deref())
+            {
+                return ::std::result::Result::Err(::rocket::http::Status::Forbidden);
+            }
+            ::std::result::Result::Ok($crate::handler::handle_sse(state.inner(), session.0))
         }
     };
 }
@@ -264,5 +316,29 @@ mod tests {
 
         assert_eq!(state.server_info.name, "test-server");
         assert_eq!(state.server_info.version, "1.0.0");
+    }
+
+    #[test]
+    fn origin_validator_defaults_to_loopback_only() {
+        let v = McpRouter::new(TestHandler).into_state().origin_validator;
+        assert!(v.is_allowed(Some("http://localhost:3000")));
+        assert!(v.is_allowed(None));
+        assert!(!v.is_allowed(Some("https://evil.example.com")));
+    }
+
+    #[test]
+    fn with_allowed_origins_and_allow_any_configure_the_validator() {
+        let allow = McpRouter::new(TestHandler)
+            .with_allowed_origins(["https://app.example.com"])
+            .into_state()
+            .origin_validator;
+        assert!(allow.is_allowed(Some("https://app.example.com")));
+        assert!(!allow.is_allowed(Some("https://evil.example.com")));
+
+        let any = McpRouter::new(TestHandler)
+            .allow_any_origin()
+            .into_state()
+            .origin_validator;
+        assert!(any.is_allowed(Some("https://evil.example.com")));
     }
 }

--- a/crates/mcpkit-rocket/src/state.rs
+++ b/crates/mcpkit-rocket/src/state.rs
@@ -3,6 +3,7 @@
 use crate::session::SessionStore;
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_server::ServerHandler;
+use mcpkit_transport::http::OriginValidator;
 use std::sync::Arc;
 
 /// Trait for handlers that provide server info.
@@ -27,6 +28,9 @@ pub struct McpState<H> {
     pub sessions: SessionStore,
     /// SSE session manager for Server-Sent Events.
     pub sse_sessions: SessionStore,
+    /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
+    /// to loopback-only.
+    pub origin_validator: Arc<OriginValidator>,
 }
 
 impl<H> McpState<H>
@@ -41,6 +45,7 @@ where
             server_info,
             sessions: SessionStore::new(),
             sse_sessions: SessionStore::new(),
+            origin_validator: Arc::new(OriginValidator::default()),
         }
     }
 
@@ -61,6 +66,7 @@ impl<H> Clone for McpState<H> {
             server_info: self.server_info.clone(),
             sessions: self.sessions.clone(),
             sse_sessions: self.sse_sessions.clone(),
+            origin_validator: Arc::clone(&self.origin_validator),
         }
     }
 }


### PR DESCRIPTION
Second of three PRs for #82, extending the axum Origin validation (#100) to **actix** and **rocket** via the shared `mcpkit_transport::http::OriginValidator`. warp follows in PR3.

## Changes

- Both adapters' `McpState` gains an `origin_validator` (loopback-only by default); `McpRouter::with_allowed_origins([..])` / `allow_any_origin()` configure it — same API as axum.
- **actix**: POST and SSE handlers read `req.headers().get("origin")` and return **403** on a disallowed origin before any work.
- **rocket**: a new `OriginHeader` request guard feeds the POST handler (403 via `McpResponse`); the SSE route (`create_mcp_routes!` macro) checks the origin and returns `Result<EventStream![], Status::Forbidden>` before streaming.

Same secure-by-default behavior change as PR1 (CHANGELOG Security entry broadened to all three adapters).

## Tests

Per-adapter builder/validator tests (default loopback-only; `with_allowed_origins` permits only configured + loopback; `allow_any_origin` accepts all). The handler 403 path is the same one-line pattern as axum's integration tests; the rocket macro expansion is compiled by the `rocket-server` example (workspace check).

## Follow-up

**PR3 = warp** — it needs more surgery (a header-extraction filter + return-type unification on both handlers + state config), so it's split out for reviewability.