### PR TITLE
feat(warp): validate request Origin to prevent DNS rebinding (#82, PR 3/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ([#73](https://github.com/praxiomlabs/mcpkit/issues/73)).
 - `mcpkit_transport::http::OriginValidator` for `Origin`-header validation, and
   `McpRouter::with_allowed_origins(..)` / `McpRouter::allow_any_origin()` in the
-  `mcpkit-axum`, `mcpkit-actix`, and `mcpkit-rocket` adapters to configure it
+  `mcpkit-axum`, `mcpkit-actix`, `mcpkit-rocket`, and `mcpkit-warp` adapters to configure it
   ([#82](https://github.com/praxiomlabs/mcpkit/issues/82)).
 
 ### Changed
@@ -90,9 +90,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Breaking (behavior):** the `mcpkit-axum`, `mcpkit-actix`, and `mcpkit-rocket`
-  adapters now validate the request `Origin` header to defend against
-  DNS-rebinding attacks, and **reject non-loopback browser origins by default**
+- **Breaking (behavior):** the `mcpkit-axum`, `mcpkit-actix`, `mcpkit-rocket`,
+  and `mcpkit-warp` adapters now validate the request `Origin` header to defend
+  against DNS-rebinding attacks, and **reject non-loopback browser origins by
+  default**
   (previously all origins were accepted). Loopback origins and requests without
   an `Origin` header (non-browser clients) are still allowed; add production
   origins with `McpRouter::with_allowed_origins([..])`, or opt out with

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -26,6 +26,7 @@ pub async fn handle_mcp_post<H>(
     state: Arc<McpState<H>>,
     version: Option<String>,
     session_id: Option<String>,
+    origin: Option<String>,
     body: String,
 ) -> Result<impl warp::Reply, Infallible>
 where
@@ -38,6 +39,21 @@ where
         + Sync
         + 'static,
 {
+    // Reject disallowed Origins (DNS-rebinding protection) before any work.
+    if !state.origin_validator.is_allowed(origin.as_deref()) {
+        warn!(
+            origin = origin.as_deref().unwrap_or("none"),
+            "Rejected: origin not allowed"
+        );
+        let error_body = serde_json::json!({
+            "error": { "code": -32600, "message": "origin not allowed" }
+        });
+        return Ok(warp::reply::with_status(
+            warp::reply::json(&error_body),
+            StatusCode::FORBIDDEN,
+        ));
+    }
+
     // Validate protocol version
     if !is_supported_version(version.as_deref()) {
         let provided = version.as_deref().unwrap_or("none");
@@ -262,10 +278,26 @@ where
 /// Handle SSE connections for server-to-client streaming.
 ///
 /// This returns a stream of Server-Sent Events.
-pub fn handle_sse<H>(state: Arc<McpState<H>>, session_id: Option<String>) -> impl warp::Reply
+pub fn handle_sse<H>(
+    state: Arc<McpState<H>>,
+    session_id: Option<String>,
+    origin: Option<String>,
+) -> warp::reply::Response
 where
     H: HasServerInfo + Send + Sync + 'static,
 {
+    use warp::Reply;
+
+    // Reject disallowed Origins (DNS-rebinding protection) before streaming.
+    if !state.origin_validator.is_allowed(origin.as_deref()) {
+        warn!(
+            origin = origin.as_deref().unwrap_or("none"),
+            "Rejected SSE: origin not allowed"
+        );
+        return warp::reply::with_status("origin not allowed", StatusCode::FORBIDDEN)
+            .into_response();
+    }
+
     let (session_id, rx) = if let Some(id) = session_id {
         if let Some(rx) = state.sse_sessions.get_receiver(&id) {
             info!(session_id = %id, "Reconnected to SSE session");
@@ -300,7 +332,7 @@ where
         }
     });
 
-    warp::sse::reply(warp::sse::keep_alive().stream(stream))
+    warp::sse::reply(warp::sse::keep_alive().stream(stream)).into_response()
 }
 
 /// Create a filter to extract the MCP protocol version header.
@@ -315,6 +347,12 @@ pub fn with_protocol_version()
 pub fn with_session_id() -> impl Filter<Extract = (Option<String>,), Error = warp::Rejection> + Clone
 {
     warp::header::optional("mcp-session-id")
+}
+
+/// Create a filter to extract the `Origin` header (DNS-rebinding protection).
+#[must_use]
+pub fn with_origin() -> impl Filter<Extract = (Option<String>,), Error = warp::Rejection> + Clone {
+    warp::header::optional("origin")
 }
 
 #[cfg(test)]
@@ -422,6 +460,7 @@ mod tests {
             state,
             Some("unsupported-version".to_string()),
             None,
+            None,
             r#"{"jsonrpc":"2.0","method":"ping","id":1}"#.to_string(),
         )
         .await;
@@ -437,6 +476,7 @@ mod tests {
         let response = handle_mcp_post(
             state,
             Some("2025-11-25".to_string()),
+            None,
             None,
             "invalid json".to_string(),
         )
@@ -454,6 +494,7 @@ mod tests {
             state,
             Some("2025-11-25".to_string()),
             None,
+            None,
             r#"{"jsonrpc":"2.0","method":"ping","id":1}"#.to_string(),
         )
         .await;
@@ -469,6 +510,7 @@ mod tests {
         let response = handle_mcp_post(
             state,
             Some("2025-11-25".to_string()),
+            None,
             None,
             r#"{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}"#.to_string(),
         )
@@ -489,6 +531,7 @@ mod tests {
             Arc::clone(&state),
             Some("2025-11-25".to_string()),
             Some(session_id.clone()),
+            None,
             r#"{"jsonrpc":"2.0","method":"ping","id":1}"#.to_string(),
         )
         .await;
@@ -505,6 +548,7 @@ mod tests {
         let response = handle_mcp_post(
             state,
             Some("2025-11-25".to_string()),
+            None,
             None,
             r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.to_string(),
         )

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -1,8 +1,11 @@
 //! Router builder for MCP endpoints in Warp.
 
-use crate::handler::{handle_mcp_post, handle_sse, with_protocol_version, with_session_id};
+use crate::handler::{
+    handle_mcp_post, handle_sse, with_origin, with_protocol_version, with_session_id,
+};
 use crate::state::{HasServerInfo, McpState};
 use mcpkit_server::{PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use mcpkit_transport::http::OriginValidator;
 use std::convert::Infallible;
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -58,6 +61,46 @@ where
         self
     }
 
+    /// Restrict which browser `Origin`s are accepted, for DNS-rebinding
+    /// protection.
+    ///
+    /// Loopback origins (`localhost`, `127.0.0.1`, `[::1]`) are always allowed;
+    /// the given origins (e.g. `https://app.example.com`) are added to the
+    /// allow-list. Requests with no `Origin` header (non-browser clients) are
+    /// allowed. By default — without calling this — only loopback origins are
+    /// accepted.
+    #[must_use]
+    pub fn with_allowed_origins<I, S>(mut self, origins: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let mut validator = OriginValidator::allow_list();
+        for origin in origins {
+            validator = validator.allow(origin);
+        }
+        self.set_origin_validator(validator);
+        self
+    }
+
+    /// Disable `Origin` validation entirely, accepting every origin.
+    ///
+    /// **Insecure**: this removes DNS-rebinding protection. Only use it behind
+    /// other safeguards (mTLS, a trusted network, authenticated sessions).
+    #[must_use]
+    pub fn allow_any_origin(mut self) -> Self {
+        self.set_origin_validator(OriginValidator::allow_any());
+        self
+    }
+
+    fn set_origin_validator(&mut self, validator: OriginValidator) {
+        // The builder owns the only reference to the state at this point, so
+        // `get_mut` succeeds.
+        if let Some(state) = Arc::get_mut(&mut self.state) {
+            state.origin_validator = Arc::new(validator);
+        }
+    }
+
     /// Build the Warp filter for MCP endpoints with CORS enabled.
     ///
     /// Returns a filter that can be combined with other Warp filters.
@@ -77,15 +120,17 @@ where
             .and(with_state(post_state))
             .and(with_protocol_version())
             .and(with_session_id())
+            .and(with_origin())
             .and(warp::body::content_length_limit(1024 * 1024)) // 1MB limit
             .and(warp::body::bytes())
             .and_then(
                 |state: Arc<McpState<H>>,
                  version: Option<String>,
                  session_id: Option<String>,
+                 origin: Option<String>,
                  bytes: bytes::Bytes| async move {
                     let body = String::from_utf8_lossy(&bytes).to_string();
-                    handle_mcp_post(state, version, session_id, body).await
+                    handle_mcp_post(state, version, session_id, origin, body).await
                 },
             );
 
@@ -96,9 +141,12 @@ where
             .and(warp::get())
             .and(with_state(sse_state))
             .and(with_session_id())
-            .map(|state: Arc<McpState<H>>, session_id: Option<String>| {
-                handle_sse(state, session_id)
-            });
+            .and(with_origin())
+            .map(
+                |state: Arc<McpState<H>>, session_id: Option<String>, origin: Option<String>| {
+                    handle_sse(state, session_id, origin)
+                },
+            );
 
         // Combine routes with CORS
         mcp_post.or(mcp_sse).with(
@@ -131,15 +179,17 @@ where
             .and(with_state(post_state))
             .and(with_protocol_version())
             .and(with_session_id())
+            .and(with_origin())
             .and(warp::body::content_length_limit(1024 * 1024)) // 1MB limit
             .and(warp::body::bytes())
             .and_then(
                 |state: Arc<McpState<H>>,
                  version: Option<String>,
                  session_id: Option<String>,
+                 origin: Option<String>,
                  bytes: bytes::Bytes| async move {
                     let body = String::from_utf8_lossy(&bytes).to_string();
-                    handle_mcp_post(state, version, session_id, body).await
+                    handle_mcp_post(state, version, session_id, origin, body).await
                 },
             );
 
@@ -150,9 +200,12 @@ where
             .and(warp::get())
             .and(with_state(sse_state))
             .and(with_session_id())
-            .map(|state: Arc<McpState<H>>, session_id: Option<String>| {
-                handle_sse(state, session_id)
-            });
+            .and(with_origin())
+            .map(
+                |state: Arc<McpState<H>>, session_id: Option<String>, origin: Option<String>| {
+                    handle_sse(state, session_id, origin)
+                },
+            );
 
         mcp_post.or(mcp_sse)
     }
@@ -264,5 +317,45 @@ mod tests {
 
         // Router should be created without panicking
         let _ = router.into_filter();
+    }
+
+    #[test]
+    fn origin_validator_defaults_to_loopback_only() {
+        let r = McpRouter::new(TestHandler);
+        assert!(
+            r.state
+                .origin_validator
+                .is_allowed(Some("http://localhost:3000"))
+        );
+        assert!(r.state.origin_validator.is_allowed(None));
+        assert!(
+            !r.state
+                .origin_validator
+                .is_allowed(Some("https://evil.example.com"))
+        );
+    }
+
+    #[test]
+    fn with_allowed_origins_and_allow_any_configure_the_validator() {
+        let allow = McpRouter::new(TestHandler).with_allowed_origins(["https://app.example.com"]);
+        assert!(
+            allow
+                .state
+                .origin_validator
+                .is_allowed(Some("https://app.example.com"))
+        );
+        assert!(
+            !allow
+                .state
+                .origin_validator
+                .is_allowed(Some("https://evil.example.com"))
+        );
+
+        let any = McpRouter::new(TestHandler).allow_any_origin();
+        assert!(
+            any.state
+                .origin_validator
+                .is_allowed(Some("https://evil.example.com"))
+        );
     }
 }

--- a/crates/mcpkit-warp/src/state.rs
+++ b/crates/mcpkit-warp/src/state.rs
@@ -3,6 +3,7 @@
 use crate::session::SessionStore;
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_server::ServerHandler;
+use mcpkit_transport::http::OriginValidator;
 use std::sync::Arc;
 
 /// Trait for handlers that provide server info.
@@ -27,6 +28,9 @@ pub struct McpState<H> {
     pub sessions: SessionStore,
     /// SSE session manager for Server-Sent Events.
     pub sse_sessions: SessionStore,
+    /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
+    /// to loopback-only.
+    pub origin_validator: Arc<OriginValidator>,
 }
 
 impl<H> McpState<H>
@@ -41,6 +45,7 @@ where
             server_info,
             sessions: SessionStore::new(),
             sse_sessions: SessionStore::new(),
+            origin_validator: Arc::new(OriginValidator::default()),
         }
     }
 
@@ -61,6 +66,7 @@ impl<H> Clone for McpState<H> {
             server_info: self.server_info.clone(),
             sessions: self.sessions.clone(),
             sse_sessions: self.sse_sessions.clone(),
+            origin_validator: Arc::clone(&self.origin_validator),
         }
     }
 }


### PR DESCRIPTION
Closes #82. Final PR — extends the Origin validation (axum #100, actix+rocket #101) to the **warp** adapter, so all four HTTP adapters are DNS-rebinding-safe by default via the shared `OriginValidator`.

## Changes

- `McpState` gains `origin_validator` (loopback-only default); `McpRouter::with_allowed_origins([..])` / `allow_any_origin()` configure it (via `Arc::get_mut` at build time).
- New `with_origin()` warp filter extracts the `Origin` header; **both** filter chains (`into_filter`, `into_filter_without_cors`) thread it to the handlers.
- `handle_mcp_post` returns 403 (`WithStatus<Json>`); `handle_sse` now returns a unified `warp::reply::Response` so it can return 403 before streaming.

Same secure-by-default behavior change as the earlier PRs; CHANGELOG Security entry now lists all four adapters.

## Tests

Builder/validator tests (default loopback-only; `with_allowed_origins` permits only configured + loopback; `allow_any_origin` accepts all). The warp-server example builds against the new handler signatures (workspace check).

## #82 status

Complete: axum (#100), actix + rocket (#101), warp (this PR). All four adapters reject non-loopback browser origins by default. (The non-functional transport HTTP *stub*'s separate footgun remains under #83.)