### PR TITLE
feat(core): add 2025-11-25 title/icons/execution to spec types (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `McpRouter::with_allowed_origins(..)` / `McpRouter::allow_any_origin()` in the
   `mcpkit-axum`, `mcpkit-actix`, `mcpkit-rocket`, and `mcpkit-warp` adapters to configure it
   ([#82](https://github.com/praxiomlabs/mcpkit/issues/82)).
+- 2025-11-25 display metadata and tool execution fields. A shared `Icon` type
+  (`src`, `mimeType`, `sizes`, `theme`) plus `IconTheme`, and the `title`/`icons`
+  fields the spec adds via `BaseMetadata`/`Icons`: `Tool`, `Resource`,
+  `ResourceTemplate`, and `Prompt` gain `title` + `icons`; `PromptArgument` gains
+  `title`; `ServerInfo`/`ClientInfo` gain `title` + `icons`. `Tool` also gains
+  `execution: Option<ToolExecution>` with `ToolExecution.task_support`
+  (`TaskSupport::{Forbidden, Optional, Required}`, default `Forbidden`) for
+  task-augmented execution negotiation. Each type has builder setters, and the
+  `#[tool(..)]` macro accepts `title = ".."` and `task_support = "optional"`
+  (a `task_support` value other than `"forbidden"`/`"optional"`/`"required"` is a
+  compile error). **Breaking:** these structs have public fields, so code that
+  constructs them with a struct literal must add the new fields
+  ([#79](https://github.com/praxiomlabs/mcpkit/issues/79)).
 
 ### Changed
 

--- a/benches/benches/serialization.rs
+++ b/benches/benches/serialization.rs
@@ -82,6 +82,7 @@ fn large_response() -> Response {
 fn tool_definition() -> Tool {
     Tool {
         name: "search_database".to_string(),
+        title: None,
         description: Some("Search the database with a SQL query".to_string()),
         input_schema: json!({
             "type": "object",
@@ -104,6 +105,7 @@ fn tool_definition() -> Tool {
             },
             "required": ["query"]
         }),
+        icons: None,
         annotations: Some(ToolAnnotations {
             title: Some("Database Search".to_string()),
             read_only_hint: Some(true),
@@ -111,6 +113,7 @@ fn tool_definition() -> Tool {
             idempotent_hint: Some(true),
             open_world_hint: None,
         }),
+        execution: None,
         output_schema: None,
     }
 }

--- a/benches/benches/tool_invocation.rs
+++ b/benches/benches/tool_invocation.rs
@@ -25,9 +25,12 @@ impl ToolHandler {
             "echo".to_string(),
             Tool {
                 name: "echo".to_string(),
+                title: None,
                 description: Some("Echo back the input".to_string()),
                 input_schema: json!({"type": "object", "properties": {"message": {"type": "string"}}}),
+                icons: None,
                 annotations: None,
+                execution: None,
                 output_schema: None,
             },
         );
@@ -36,6 +39,7 @@ impl ToolHandler {
             "calculate".to_string(),
             Tool {
                 name: "calculate".to_string(),
+                title: None,
                 description: Some("Perform arithmetic".to_string()),
                 input_schema: json!({
                     "type": "object",
@@ -46,7 +50,9 @@ impl ToolHandler {
                     },
                     "required": ["a", "b", "op"]
                 }),
+                icons: None,
                 annotations: None,
+                execution: None,
                 output_schema: None,
             },
         );

--- a/crates/mcpkit-actix/src/router.rs
+++ b/crates/mcpkit-actix/src/router.rs
@@ -267,8 +267,10 @@ mod tests {
         fn server_info(&self) -> ServerInfo {
             ServerInfo {
                 name: "test-server".to_string(),
+                title: None,
                 version: "1.0.0".to_string(),
                 protocol_version: None,
+                icons: None,
             }
         }
 

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -233,8 +233,10 @@ mod tests {
         fn server_info(&self) -> ServerInfo {
             ServerInfo {
                 name: "test-server".to_string(),
+                title: None,
                 version: "1.0.0".to_string(),
                 protocol_version: None,
+                icons: None,
             }
         }
 

--- a/crates/mcpkit-client/src/pool.rs
+++ b/crates/mcpkit-client/src/pool.rs
@@ -414,7 +414,9 @@ impl ClientPoolBuilder {
     pub fn client_info(mut self, name: impl Into<String>, version: impl Into<String>) -> Self {
         self.client_info = Some(ClientInfo {
             name: name.into(),
+            title: None,
             version: version.into(),
+            icons: None,
         });
         self
     }

--- a/crates/mcpkit-core/src/capability.rs
+++ b/crates/mcpkit-core/src/capability.rs
@@ -4,6 +4,7 @@
 //! They determine what features are available in the session.
 
 use crate::extension::ExtensionRegistry;
+use crate::types::Icon;
 use serde::{Deserialize, Serialize};
 
 /// Server capabilities advertised during initialization.
@@ -359,11 +360,17 @@ pub struct ElicitationCapability {}
 pub struct ServerInfo {
     /// Server name.
     pub name: String,
+    /// Optional human-readable display title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Server version.
     pub version: String,
     /// Protocol version supported.
     #[serde(rename = "protocolVersion", skip_serializing_if = "Option::is_none")]
     pub protocol_version: Option<String>,
+    /// Optional icons the client can display for this server.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
 }
 
 impl ServerInfo {
@@ -372,9 +379,32 @@ impl ServerInfo {
     pub fn new(name: impl Into<String>, version: impl Into<String>) -> Self {
         Self {
             name: name.into(),
+            title: None,
             version: version.into(),
             protocol_version: Some(PROTOCOL_VERSION.to_string()),
+            icons: None,
         }
+    }
+
+    /// Set the server's display title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Add an icon the client can display for this server.
+    #[must_use]
+    pub fn icon(mut self, icon: Icon) -> Self {
+        self.icons.get_or_insert_with(Vec::new).push(icon);
+        self
+    }
+
+    /// Set the server's icons, replacing any already set.
+    #[must_use]
+    pub fn icons(mut self, icons: impl IntoIterator<Item = Icon>) -> Self {
+        self.icons = Some(icons.into_iter().collect());
+        self
     }
 }
 
@@ -383,8 +413,14 @@ impl ServerInfo {
 pub struct ClientInfo {
     /// Client name.
     pub name: String,
+    /// Optional human-readable display title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Client version.
     pub version: String,
+    /// Optional icons the server can display for this client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
 }
 
 impl ClientInfo {
@@ -393,8 +429,31 @@ impl ClientInfo {
     pub fn new(name: impl Into<String>, version: impl Into<String>) -> Self {
         Self {
             name: name.into(),
+            title: None,
             version: version.into(),
+            icons: None,
         }
+    }
+
+    /// Set the client's display title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Add an icon the server can display for this client.
+    #[must_use]
+    pub fn icon(mut self, icon: Icon) -> Self {
+        self.icons.get_or_insert_with(Vec::new).push(icon);
+        self
+    }
+
+    /// Set the client's icons, replacing any already set.
+    #[must_use]
+    pub fn icons(mut self, icons: impl IntoIterator<Item = Icon>) -> Self {
+        self.icons = Some(icons.into_iter().collect());
+        self
     }
 }
 

--- a/crates/mcpkit-core/src/types/metadata.rs
+++ b/crates/mcpkit-core/src/types/metadata.rs
@@ -1,0 +1,110 @@
+//! Shared display-metadata types.
+//!
+//! These types back the `icons` field that the MCP 2025-11-25 spec adds to
+//! several objects (tools, resources, prompts, and the client/server
+//! implementation info) via the shared `Icons` mixin.
+
+use serde::{Deserialize, Serialize};
+
+/// The background theme an icon is designed for.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum IconTheme {
+    /// Designed for a light background.
+    Light,
+    /// Designed for a dark background.
+    Dark,
+}
+
+/// An icon a client can display for a tool, resource, prompt, or
+/// implementation.
+///
+/// # Example
+///
+/// ```rust
+/// use mcpkit_core::types::{Icon, IconTheme};
+///
+/// let icon = Icon::new("https://example.com/icon.png")
+///     .mime_type("image/png")
+///     .sizes(["48x48", "96x96"])
+///     .theme(IconTheme::Dark);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Icon {
+    /// A URI pointing to the icon resource (an HTTP/HTTPS URL or a `data:`
+    /// URI with Base64-encoded image data).
+    pub src: String,
+    /// Optional MIME type override if the source MIME type is missing or
+    /// generic (e.g. `"image/png"`, `"image/svg+xml"`).
+    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
+    pub mime_type: Option<String>,
+    /// Optional sizes the icon can be used at, each in `WxH` format (e.g.
+    /// `"48x48"`) or `"any"` for scalable formats like SVG.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sizes: Option<Vec<String>>,
+    /// Optional theme the icon is designed for.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub theme: Option<IconTheme>,
+}
+
+impl Icon {
+    /// Create a new icon from its source URI.
+    #[must_use]
+    pub fn new(src: impl Into<String>) -> Self {
+        Self {
+            src: src.into(),
+            mime_type: None,
+            sizes: None,
+            theme: None,
+        }
+    }
+
+    /// Set the MIME type override.
+    #[must_use]
+    pub fn mime_type(mut self, mime_type: impl Into<String>) -> Self {
+        self.mime_type = Some(mime_type.into());
+        self
+    }
+
+    /// Set the sizes the icon can be used at.
+    #[must_use]
+    pub fn sizes<I, S>(mut self, sizes: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.sizes = Some(sizes.into_iter().map(Into::into).collect());
+        self
+    }
+
+    /// Set the theme the icon is designed for.
+    #[must_use]
+    pub const fn theme(mut self, theme: IconTheme) -> Self {
+        self.theme = Some(theme);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn icon_serializes_with_camelcase_and_skips_none() {
+        let icon = Icon::new("https://example.com/i.png");
+        let j = serde_json::to_value(&icon).unwrap();
+        assert_eq!(j["src"], "https://example.com/i.png");
+        assert!(j.get("mimeType").is_none());
+        assert!(j.get("sizes").is_none());
+        assert!(j.get("theme").is_none());
+
+        let icon = Icon::new("data:image/png;base64,AAAA")
+            .mime_type("image/png")
+            .sizes(["48x48", "any"])
+            .theme(IconTheme::Dark);
+        let j = serde_json::to_value(&icon).unwrap();
+        assert_eq!(j["mimeType"], "image/png");
+        assert_eq!(j["sizes"], serde_json::json!(["48x48", "any"]));
+        assert_eq!(j["theme"], "dark");
+    }
+}

--- a/crates/mcpkit-core/src/types/mod.rs
+++ b/crates/mcpkit-core/src/types/mod.rs
@@ -18,6 +18,7 @@
 pub mod completion;
 pub mod content;
 pub mod elicitation;
+pub mod metadata;
 pub mod prompt;
 pub mod resource;
 pub mod sampling;
@@ -28,6 +29,7 @@ pub mod tool;
 pub use completion::*;
 pub use content::*;
 pub use elicitation::*;
+pub use metadata::*;
 pub use prompt::*;
 pub use resource::*;
 pub use sampling::*;

--- a/crates/mcpkit-core/src/types/prompt.rs
+++ b/crates/mcpkit-core/src/types/prompt.rs
@@ -4,6 +4,7 @@
 //! They allow servers to define reusable message patterns with arguments.
 
 use super::content::{Content, Role};
+use super::metadata::Icon;
 use serde::{Deserialize, Serialize};
 
 /// A prompt definition exposed by an MCP server.
@@ -14,9 +15,15 @@ use serde::{Deserialize, Serialize};
 pub struct Prompt {
     /// Unique name of the prompt.
     pub name: String,
+    /// Optional human-readable display title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Human-readable description of what the prompt does.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
+    /// Optional icons the client can display for this prompt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
     /// Arguments that the prompt accepts.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Vec<PromptArgument>>,
@@ -28,7 +35,9 @@ impl Prompt {
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
+            title: None,
             description: None,
+            icons: None,
             arguments: None,
         }
     }
@@ -37,6 +46,27 @@ impl Prompt {
     #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Set the prompt's display title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Add an icon the client can display for this prompt.
+    #[must_use]
+    pub fn icon(mut self, icon: Icon) -> Self {
+        self.icons.get_or_insert_with(Vec::new).push(icon);
+        self
+    }
+
+    /// Set the prompt's icons, replacing any already set.
+    #[must_use]
+    pub fn icons(mut self, icons: impl IntoIterator<Item = Icon>) -> Self {
+        self.icons = Some(icons.into_iter().collect());
         self
     }
 
@@ -65,6 +95,9 @@ impl Prompt {
 pub struct PromptArgument {
     /// Name of the argument.
     pub name: String,
+    /// Optional human-readable display title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Human-readable description.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -79,6 +112,7 @@ impl PromptArgument {
     pub fn required(name: impl Into<String>, description: impl Into<String>) -> Self {
         Self {
             name: name.into(),
+            title: None,
             description: Some(description.into()),
             required: Some(true),
         }
@@ -89,9 +123,17 @@ impl PromptArgument {
     pub fn optional(name: impl Into<String>, description: impl Into<String>) -> Self {
         Self {
             name: name.into(),
+            title: None,
             description: Some(description.into()),
             required: Some(false),
         }
+    }
+
+    /// Set the argument's display title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
     }
 }
 

--- a/crates/mcpkit-core/src/types/resource.rs
+++ b/crates/mcpkit-core/src/types/resource.rs
@@ -4,6 +4,7 @@
 //! They can be files, database entries, API responses, or any other
 //! addressable content.
 
+use super::metadata::Icon;
 use serde::{Deserialize, Serialize};
 
 /// A resource exposed by an MCP server.
@@ -16,6 +17,9 @@ pub struct Resource {
     pub uri: String,
     /// Human-readable name for the resource.
     pub name: String,
+    /// Optional human-readable display title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Description of what the resource contains.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -25,6 +29,9 @@ pub struct Resource {
     /// Size in bytes, if known.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub size: Option<u64>,
+    /// Optional icons the client can display for this resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ResourceAnnotations>,
@@ -37,9 +44,11 @@ impl Resource {
         Self {
             uri: uri.into(),
             name: name.into(),
+            title: None,
             description: None,
             mime_type: None,
             size: None,
+            icons: None,
             annotations: None,
         }
     }
@@ -48,6 +57,27 @@ impl Resource {
     #[must_use]
     pub fn description(mut self, description: impl Into<String>) -> Self {
         self.description = Some(description.into());
+        self
+    }
+
+    /// Set the resource's display title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Add an icon the client can display for this resource.
+    #[must_use]
+    pub fn icon(mut self, icon: Icon) -> Self {
+        self.icons.get_or_insert_with(Vec::new).push(icon);
+        self
+    }
+
+    /// Set the resource's icons, replacing any already set.
+    #[must_use]
+    pub fn icons(mut self, icons: impl IntoIterator<Item = Icon>) -> Self {
+        self.icons = Some(icons.into_iter().collect());
         self
     }
 
@@ -100,12 +130,18 @@ pub struct ResourceTemplate {
     pub uri_template: String,
     /// Human-readable name for this resource type.
     pub name: String,
+    /// Optional human-readable display title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Description of the resource template.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// MIME type of resources matching this template.
     #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
+    /// Optional icons the client can display for this resource template.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ResourceAnnotations>,
@@ -118,8 +154,10 @@ impl ResourceTemplate {
         Self {
             uri_template: uri_template.into(),
             name: name.into(),
+            title: None,
             description: None,
             mime_type: None,
+            icons: None,
             annotations: None,
         }
     }
@@ -135,6 +173,27 @@ impl ResourceTemplate {
     #[must_use]
     pub fn mime_type(mut self, mime_type: impl Into<String>) -> Self {
         self.mime_type = Some(mime_type.into());
+        self
+    }
+
+    /// Set the resource template's display title.
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Add an icon the client can display for this resource template.
+    #[must_use]
+    pub fn icon(mut self, icon: Icon) -> Self {
+        self.icons.get_or_insert_with(Vec::new).push(icon);
+        self
+    }
+
+    /// Set the resource template's icons, replacing any already set.
+    #[must_use]
+    pub fn icons(mut self, icons: impl IntoIterator<Item = Icon>) -> Self {
+        self.icons = Some(icons.into_iter().collect());
         self
     }
 }

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -4,6 +4,7 @@
 //! Each tool has a name, description, and JSON Schema defining its input.
 
 use super::content::Content;
+use super::metadata::Icon;
 use serde::{Deserialize, Serialize};
 
 /// A tool definition exposed by an MCP server.
@@ -31,15 +32,28 @@ use serde::{Deserialize, Serialize};
 pub struct Tool {
     /// Unique name of the tool.
     pub name: String,
+    /// Optional human-readable display title.
+    ///
+    /// Display-name precedence is `title`, then `annotations.title`, then
+    /// `name`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Human-readable description of what the tool does.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// JSON Schema defining the tool's input parameters.
     #[serde(rename = "inputSchema")]
     pub input_schema: serde_json::Value,
+    /// Optional icons the client can display for this tool.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<Icon>>,
     /// Optional annotations providing hints about tool behavior.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ToolAnnotations>,
+    /// Optional execution-related properties (e.g. task-augmented execution
+    /// support).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub execution: Option<ToolExecution>,
     /// JSON Schema describing the tool's structured output, if it produces any.
     ///
     /// When set, a successful result's `structuredContent` is expected to
@@ -54,14 +68,54 @@ impl Tool {
     pub fn new(name: impl Into<String>) -> Self {
         Self {
             name: name.into(),
+            title: None,
             description: None,
             input_schema: serde_json::json!({
                 "type": "object",
                 "properties": {}
             }),
+            icons: None,
             annotations: None,
+            execution: None,
             output_schema: None,
         }
+    }
+
+    /// Set the tool's display title (`title`).
+    #[must_use]
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Add an icon the client can display for this tool.
+    #[must_use]
+    pub fn icon(mut self, icon: Icon) -> Self {
+        self.icons.get_or_insert_with(Vec::new).push(icon);
+        self
+    }
+
+    /// Set the tool's icons, replacing any already set.
+    #[must_use]
+    pub fn icons(mut self, icons: impl IntoIterator<Item = Icon>) -> Self {
+        self.icons = Some(icons.into_iter().collect());
+        self
+    }
+
+    /// Set the tool's execution properties.
+    #[must_use]
+    pub fn execution(mut self, execution: ToolExecution) -> Self {
+        self.execution = Some(execution);
+        self
+    }
+
+    /// Declare the tool's task-augmented execution support.
+    #[must_use]
+    pub fn task_support(mut self, task_support: TaskSupport) -> Self {
+        self.execution
+            .get_or_insert_with(ToolExecution::default)
+            .task_support = Some(task_support);
+        self
     }
 
     /// Set the tool's output schema (`outputSchema`).
@@ -278,6 +332,42 @@ impl ToolAnnotations {
     pub const fn with_idempotent(mut self, idempotent: bool) -> Self {
         self.idempotent_hint = Some(idempotent);
         self
+    }
+}
+
+/// Whether a tool supports task-augmented execution.
+///
+/// Task-augmented execution lets clients drive long-running tool calls through
+/// the task system (poll for status instead of blocking on the response).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskSupport {
+    /// The tool does not support task-augmented execution (spec default).
+    #[default]
+    Forbidden,
+    /// The tool may be executed with task augmentation.
+    Optional,
+    /// The tool must be executed with task augmentation.
+    Required,
+}
+
+/// Execution-related properties for a tool.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ToolExecution {
+    /// Whether this tool supports task-augmented execution.
+    ///
+    /// Absent is equivalent to [`TaskSupport::Forbidden`].
+    #[serde(rename = "taskSupport", skip_serializing_if = "Option::is_none")]
+    pub task_support: Option<TaskSupport>,
+}
+
+impl ToolExecution {
+    /// Create execution properties declaring the given task support.
+    #[must_use]
+    pub const fn with_task_support(task_support: TaskSupport) -> Self {
+        Self {
+            task_support: Some(task_support),
+        }
     }
 }
 
@@ -579,6 +669,54 @@ mod tests {
         // Round-trips and stays absent when unset.
         let plain: CallToolResult = serde_json::from_str(r#"{"content":[]}"#).expect("deserialize");
         assert!(plain.structured_content.is_none());
+    }
+
+    #[test]
+    fn test_tool_title_icons_execution_serde() {
+        use super::super::metadata::{Icon, IconTheme};
+
+        // Absent by default.
+        let tool = Tool::new("t");
+        let j = serde_json::to_value(&tool).unwrap();
+        assert!(j.get("title").is_none());
+        assert!(j.get("icons").is_none());
+        assert!(j.get("execution").is_none());
+
+        let tool = Tool::new("t")
+            .title("Pretty Name")
+            .icon(
+                Icon::new("https://e/i.png")
+                    .mime_type("image/png")
+                    .theme(IconTheme::Light),
+            )
+            .task_support(TaskSupport::Optional);
+        let j = serde_json::to_value(&tool).unwrap();
+        assert_eq!(j["title"], "Pretty Name");
+        assert_eq!(j["icons"][0]["src"], "https://e/i.png");
+        assert_eq!(j["icons"][0]["theme"], "light");
+        // `execution.taskSupport` is camelCase and lowercase-valued.
+        assert_eq!(j["execution"]["taskSupport"], "optional");
+
+        // Round-trips.
+        let back: Tool = serde_json::from_value(j).unwrap();
+        assert_eq!(back.title.as_deref(), Some("Pretty Name"));
+        assert_eq!(
+            back.execution.and_then(|e| e.task_support),
+            Some(TaskSupport::Optional)
+        );
+    }
+
+    #[test]
+    fn test_task_support_serde_values() {
+        assert_eq!(
+            serde_json::to_value(TaskSupport::Forbidden).unwrap(),
+            serde_json::json!("forbidden")
+        );
+        assert_eq!(
+            serde_json::to_value(TaskSupport::Required).unwrap(),
+            serde_json::json!("required")
+        );
+        assert_eq!(TaskSupport::default(), TaskSupport::Forbidden);
     }
 
     #[test]

--- a/crates/mcpkit-macros-tests/tests/tool_metadata.rs
+++ b/crates/mcpkit-macros-tests/tests/tool_metadata.rs
@@ -1,0 +1,51 @@
+//! `#[tool(title = .., task_support = ..)]` populates `Tool.title` and
+//! `Tool.execution.taskSupport`.
+
+use mcpkit::mcp_server;
+use mcpkit::server::{Context, NoOpPeer, ToolHandler};
+use mcpkit::types::TaskSupport;
+use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+use mcpkit_core::protocol::RequestId;
+use mcpkit_core::protocol_version::ProtocolVersion;
+
+struct Srv;
+
+#[mcp_server(name = "srv", version = "1.0.0")]
+impl Srv {
+    /// A tool that advertises display + task metadata.
+    #[tool(
+        description = "long job",
+        title = "Long Job",
+        task_support = "optional"
+    )]
+    async fn run(&self) -> String {
+        "ok".to_string()
+    }
+}
+
+#[tokio::test]
+async fn tool_advertises_title_and_task_support() {
+    let request_id = RequestId::Number(1);
+    let client_caps = ClientCapabilities::default();
+    let server_caps = ServerCapabilities::default();
+    let peer = NoOpPeer;
+    let ctx = Context::new(
+        &request_id,
+        None,
+        &client_caps,
+        &server_caps,
+        ProtocolVersion::LATEST,
+        &peer,
+    );
+
+    let tools = <Srv as ToolHandler>::list_tools(&Srv, &ctx)
+        .await
+        .expect("list_tools");
+    let tool = tools.iter().find(|t| t.name == "run").expect("run tool");
+
+    assert_eq!(tool.title.as_deref(), Some("Long Job"));
+    assert_eq!(
+        tool.execution.as_ref().and_then(|e| e.task_support),
+        Some(TaskSupport::Optional),
+    );
+}

--- a/crates/mcpkit-macros/src/attrs.rs
+++ b/crates/mcpkit-macros/src/attrs.rs
@@ -43,6 +43,15 @@ pub struct ToolAttrs {
     #[darling(default)]
     pub name: Option<String>,
 
+    /// Optional human-readable display title (`Tool.title`).
+    #[darling(default)]
+    pub title: Option<String>,
+
+    /// Task-augmented execution support: `"forbidden"`, `"optional"`, or
+    /// `"required"` (sets `Tool.execution.taskSupport`).
+    #[darling(default)]
+    pub task_support: Option<String>,
+
     /// Hint that the tool may cause destructive changes.
     #[darling(default)]
     pub destructive: bool,

--- a/crates/mcpkit-macros/src/codegen.rs
+++ b/crates/mcpkit-macros/src/codegen.rs
@@ -18,8 +18,13 @@ pub struct ToolMethod {
     pub name: Ident,
     /// The tool name (may be overridden by attribute)
     pub tool_name: String,
+    /// Optional display title (`Tool.title`)
+    pub title: Option<String>,
     /// The description
     pub description: String,
+    /// Task-augmented execution support, validated to one of
+    /// `"forbidden"`/`"optional"`/`"required"`.
+    pub task_support: Option<String>,
     /// Whether the tool is destructive
     pub destructive: bool,
     /// Whether the tool is idempotent

--- a/crates/mcpkit-macros/src/server.rs
+++ b/crates/mcpkit-macros/src/server.rs
@@ -206,10 +206,23 @@ fn find_tool_attr(attrs: &[Attribute]) -> Result<Option<(usize, ToolAttrs)>> {
 }
 
 /// Extract tool information from a method.
-#[allow(clippy::unnecessary_wraps)] // Returns Result for future validation extensibility
 fn extract_tool_info(method: &mut ImplItemFn, attrs: ToolAttrs) -> Result<ToolMethod> {
     let name = method.sig.ident.clone();
     let tool_name = attrs.name.unwrap_or_else(|| name.to_string());
+
+    // Validate task_support up front so a typo is a clear compile error rather
+    // than a silently dropped attribute.
+    if let Some(ts) = &attrs.task_support {
+        if !matches!(ts.as_str(), "forbidden" | "optional" | "required") {
+            return Err(Error::new_spanned(
+                &method.sig.ident,
+                format!(
+                    "invalid task_support value {ts:?}\n\
+                     help: expected \"forbidden\", \"optional\", or \"required\""
+                ),
+            ));
+        }
+    }
 
     // Extract parameters (skip &self). `extract_param` also strips the
     // `#[mcp(...)]` helper attribute from each parameter so it isn't re-emitted.
@@ -227,7 +240,9 @@ fn extract_tool_info(method: &mut ImplItemFn, attrs: ToolAttrs) -> Result<ToolMe
     Ok(ToolMethod {
         name,
         tool_name,
+        title: attrs.title,
         description: attrs.description,
+        task_support: attrs.task_support,
         destructive: attrs.destructive,
         idempotent: attrs.idempotent,
         read_only: attrs.read_only,
@@ -537,11 +552,40 @@ fn generate_tool_handler(tools: &[ToolMethod], self_ty: &syn::Type) -> TokenStre
                 quote!(None)
             };
 
+            let title = if let Some(t) = &tool.title {
+                quote!(Some(#t.to_string()))
+            } else {
+                quote!(None)
+            };
+
+            // `task_support` is validated in `extract_tool_info`, so the
+            // fallback arm is unreachable.
+            let execution = match tool.task_support.as_deref() {
+                Some("optional") => {
+                    quote!(Some(::mcpkit::types::ToolExecution::with_task_support(
+                        ::mcpkit::types::TaskSupport::Optional
+                    )))
+                }
+                Some("required") => {
+                    quote!(Some(::mcpkit::types::ToolExecution::with_task_support(
+                        ::mcpkit::types::TaskSupport::Required
+                    )))
+                }
+                Some("forbidden") => {
+                    quote!(Some(::mcpkit::types::ToolExecution::with_task_support(
+                        ::mcpkit::types::TaskSupport::Forbidden
+                    )))
+                }
+                _ => quote!(None),
+            };
+
             quote! {
                 ::mcpkit::types::Tool {
                     name: #name.to_string(),
+                    title: #title,
                     description: Some(#description.to_string()),
                     input_schema: #input_schema,
+                    icons: None,
                     annotations: Some(::mcpkit::types::ToolAnnotations {
                         title: None,
                         read_only_hint: Some(#read_only),
@@ -549,6 +593,7 @@ fn generate_tool_handler(tools: &[ToolMethod], self_ty: &syn::Type) -> TokenStre
                         idempotent_hint: Some(#idempotent),
                         open_world_hint: None,
                     }),
+                    execution: #execution,
                     output_schema: #output_schema,
                 }
             }
@@ -625,9 +670,11 @@ fn generate_resource_handler(resources: &[ResourceMethod], self_ty: &syn::Type) 
                     ::mcpkit::types::Resource {
                         uri: #uri.to_string(),
                         name: #name.to_string(),
+                        title: None,
                         description: if #description.is_empty() { None } else { Some(#description.to_string()) },
                         mime_type: Some(#mime_type.to_string()),
                         size: None,
+                        icons: None,
                         annotations: None,
                     },
                 })
@@ -650,8 +697,10 @@ fn generate_resource_handler(resources: &[ResourceMethod], self_ty: &syn::Type) 
                     ::mcpkit::types::ResourceTemplate {
                         uri_template: #uri.to_string(),
                         name: #name.to_string(),
+                        title: None,
                         description: if #description.is_empty() { None } else { Some(#description.to_string()) },
                         mime_type: Some(#mime_type.to_string()),
+                        icons: None,
                         annotations: None,
                     },
                 })
@@ -784,6 +833,7 @@ fn generate_prompt_handler(prompts: &[PromptMethod], self_ty: &syn::Type) -> Tok
                     quote! {
                         ::mcpkit::types::PromptArgument {
                             name: #param_name.to_string(),
+                            title: None,
                             description: if #param_desc.is_empty() { None } else { Some(#param_desc.to_string()) },
                             required: Some(#required),
                         }
@@ -800,7 +850,9 @@ fn generate_prompt_handler(prompts: &[PromptMethod], self_ty: &syn::Type) -> Tok
             quote! {
                 ::mcpkit::types::Prompt {
                     name: #name.to_string(),
+                    title: None,
                     description: if #description.is_empty() { None } else { Some(#description.to_string()) },
+                    icons: None,
                     arguments: #arguments_expr,
                 }
             }

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -241,8 +241,10 @@ mod tests {
         fn server_info(&self) -> ServerInfo {
             ServerInfo {
                 name: "test-server".to_string(),
+                title: None,
                 version: "1.0.0".to_string(),
                 protocol_version: None,
+                icons: None,
             }
         }
 

--- a/crates/mcpkit-server/src/capability/prompts.rs
+++ b/crates/mcpkit-server/src/capability/prompts.rs
@@ -159,6 +159,7 @@ impl PromptBuilder {
     pub fn required_arg(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
         self.arguments.push(PromptArgument {
             name: name.into(),
+            title: None,
             description: Some(description.into()),
             required: Some(true),
         });
@@ -169,6 +170,7 @@ impl PromptBuilder {
     pub fn optional_arg(mut self, name: impl Into<String>, description: impl Into<String>) -> Self {
         self.arguments.push(PromptArgument {
             name: name.into(),
+            title: None,
             description: Some(description.into()),
             required: Some(false),
         });
@@ -187,7 +189,9 @@ impl PromptBuilder {
     pub fn build(self) -> Prompt {
         Prompt {
             name: self.name,
+            title: None,
             description: self.description,
+            icons: None,
             arguments: if self.arguments.is_empty() {
                 None
             } else {

--- a/crates/mcpkit-server/src/capability/resources.rs
+++ b/crates/mcpkit-server/src/capability/resources.rs
@@ -224,9 +224,11 @@ impl ResourceBuilder {
         Resource {
             uri: self.uri,
             name: self.name,
+            title: None,
             description: self.description,
             mime_type: self.mime_type,
             size: None,
+            icons: None,
             annotations: None,
         }
     }
@@ -269,8 +271,10 @@ impl ResourceTemplateBuilder {
         ResourceTemplate {
             uri_template: self.uri_template,
             name: self.name,
+            title: None,
             description: self.description,
             mime_type: self.mime_type,
+            icons: None,
             annotations: None,
         }
     }

--- a/crates/mcpkit-server/src/capability/tools.rs
+++ b/crates/mcpkit-server/src/capability/tools.rs
@@ -243,9 +243,12 @@ impl ToolBuilder {
 
         Tool {
             name: self.name,
+            title: None,
             description: self.description,
             input_schema: self.input_schema,
+            icons: None,
             annotations,
+            execution: None,
             output_schema: None,
         }
     }

--- a/crates/mcpkit-testing/src/mock.rs
+++ b/crates/mcpkit-testing/src/mock.rs
@@ -110,9 +110,12 @@ impl MockTool {
     pub fn to_tool(&self) -> Tool {
         Tool {
             name: self.name.clone(),
+            title: None,
             description: self.description.clone(),
             input_schema: self.input_schema.clone(),
+            icons: None,
             annotations: self.annotations.clone(),
+            execution: None,
             output_schema: None,
         }
     }
@@ -178,9 +181,11 @@ impl MockResource {
         Resource {
             uri: self.uri.clone(),
             name: self.name.clone(),
+            title: None,
             description: self.description.clone(),
             mime_type: self.mime_type.clone(),
             size: Some(self.content.len() as u64),
+            icons: None,
             annotations: None,
         }
     }
@@ -234,7 +239,9 @@ impl MockPrompt {
     pub fn to_prompt(&self) -> Prompt {
         Prompt {
             name: self.name.clone(),
+            title: None,
             description: self.description.clone(),
+            icons: None,
             arguments: None,
         }
     }

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -251,8 +251,10 @@ mod tests {
         fn server_info(&self) -> ServerInfo {
             ServerInfo {
                 name: "test-server".to_string(),
+                title: None,
                 version: "1.0.0".to_string(),
                 protocol_version: None,
+                icons: None,
             }
         }
 

--- a/mcpkit/tests/capabilities_compliance.rs
+++ b/mcpkit/tests/capabilities_compliance.rs
@@ -53,9 +53,11 @@ fn test_resource_definition() -> Result<(), Box<dyn std::error::Error>> {
     let resource = Resource {
         uri: "file:///config.json".to_string(),
         name: "Configuration".to_string(),
+        title: None,
         description: Some("App configuration".to_string()),
         mime_type: Some("application/json".to_string()),
         size: Some(1024),
+        icons: None,
         annotations: None,
     };
 
@@ -73,9 +75,12 @@ fn test_resource_definition() -> Result<(), Box<dyn std::error::Error>> {
 fn test_prompt_definition() -> Result<(), Box<dyn std::error::Error>> {
     let prompt = Prompt {
         name: "code_review".to_string(),
+        title: None,
         description: Some("Review code for issues".to_string()),
+        icons: None,
         arguments: Some(vec![PromptArgument {
             name: "code".to_string(),
+            title: None,
             description: Some("The code to review".to_string()),
             required: Some(true),
         }]),
@@ -153,9 +158,11 @@ fn test_resource_without_optional_fields() -> Result<(), Box<dyn std::error::Err
     let resource = Resource {
         uri: "test://resource".to_string(),
         name: "Test".to_string(),
+        title: None,
         description: None,
         mime_type: None,
         size: None,
+        icons: None,
         annotations: None,
     };
 
@@ -170,7 +177,9 @@ fn test_resource_without_optional_fields() -> Result<(), Box<dyn std::error::Err
 fn test_prompt_without_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let prompt = Prompt {
         name: "simple".to_string(),
+        title: None,
         description: Some("A simple prompt".to_string()),
+        icons: None,
         arguments: None,
     };
 

--- a/mcpkit/tests/initialization_compliance.rs
+++ b/mcpkit/tests/initialization_compliance.rs
@@ -19,7 +19,9 @@ fn test_protocol_version() {
 fn test_client_info() {
     let info = ClientInfo {
         name: "test-client".to_string(),
+        title: None,
         version: "1.0.0".to_string(),
+        icons: None,
     };
 
     let json = serde_json::to_value(&info).unwrap();
@@ -43,7 +45,9 @@ fn test_server_info() {
 fn test_initialize_request() {
     let client_info = ClientInfo {
         name: "my-client".to_string(),
+        title: None,
         version: "1.0.0".to_string(),
+        icons: None,
     };
 
     let request = InitializeRequest {


### PR DESCRIPTION
Closes #79.

## What

Adds the 2025-11-25 display-metadata and tool-execution fields, grounded against the authoritative `schema.ts`. The spec adds `title` (via `BaseMetadata`) and `icons` (via the `Icons` mixin) to several objects, plus `Tool.execution`:

| Type | `title` | `icons` | `execution` |
|------|:---:|:---:|:---:|
| `Tool` | ✓ | ✓ | ✓ |
| `Resource` | ✓ | ✓ | |
| `ResourceTemplate` | ✓ | ✓ | |
| `Prompt` | ✓ | ✓ | |
| `PromptArgument` | ✓ | — | |
| `ServerInfo` / `ClientInfo` (Implementation) | ✓ | ✓ | |

New types in `mcpkit-core`:

- `Icon { src, mime_type, sizes, theme }` + `IconTheme { Light, Dark }` (shared).
- `ToolExecution { task_support }` + `TaskSupport { Forbidden (default), Optional, Required }` — task-augmented execution negotiation (pairs with #81).

Ergonomics:

- Builder setters (`.title()`, `.icon()`/`.icons()`, `.execution()`/`.task_support()`) on each type.
- `#[tool(title = "..", task_support = "optional")]` macro attributes; an invalid `task_support` value is a compile error.

## Breaking

These structs expose public fields, so struct-literal construction must add the new fields. Consistent with the prior `output_schema` field addition; lands within the unreleased 0.7.0 cycle.

## Follow-up

PR2 of #79 (separate): mark these spec types `#[non_exhaustive]` and migrate literal construction to builders, so this is the last breaking field-addition before 1.0.

## Test plan

- New: `Icon`/`Tool` `title`/`icons`/`execution` serde round-trips; `TaskSupport` value mapping; macro test asserting `#[tool(title, task_support)]` populates the emitted `Tool`.
- `just ci` green (fmt, clippy -D warnings, locked tests, doc, version-sync).