### PR TITLE
ci: make just lint/test recipes fail fast (set -euo pipefail)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -328,6 +328,7 @@ test:
 [doc("Run tests with locked dependencies (reproducible)")]
 test-locked:
     #!/usr/bin/env bash
+    set -euo pipefail
     printf '\n{{bold}}{{blue}}══════ Running Tests (locked) ══════{{reset}}\n\n'
     {{cargo}} test --workspace --all-features --locked -j {{jobs}}
     printf '{{green}}[OK]{{reset}}   All tests passed (locked)\n'
@@ -484,6 +485,7 @@ fmt:
 [doc("Check code formatting")]
 fmt-check:
     #!/usr/bin/env bash
+    set -euo pipefail
     printf '{{cyan}}[INFO]{{reset}} Checking format...\n'
     {{cargo}} fmt --all -- --check
     printf '{{green}}[OK]{{reset}}   Format check passed\n'
@@ -492,6 +494,7 @@ fmt-check:
 [doc("Run clippy lints (matches CI configuration)")]
 clippy:
     #!/usr/bin/env bash
+    set -euo pipefail
     printf '{{cyan}}[INFO]{{reset}} Running clippy...\n'
     {{cargo}} clippy --workspace --all-features --all-targets -- -D warnings
     printf '{{green}}[OK]{{reset}}   Clippy passed\n'
@@ -625,6 +628,7 @@ doc-private:
 [doc("Check documentation for warnings")]
 doc-check:
     #!/usr/bin/env bash
+    set -euo pipefail
     printf '{{cyan}}[INFO]{{reset}} Checking documentation...\n'
     RUSTDOCFLAGS="-D warnings" {{cargo}} doc --workspace --all-features --no-deps
     printf '{{green}}[OK]{{reset}}   Documentation check passed\n'


### PR DESCRIPTION
## Problem

`just fmt-check`, `clippy`, `test-locked`, and `doc-check` run their cargo command in a `#!/usr/bin/env bash` block **without `set -e`**, then `printf` a success line unconditionally. So the recipe exits `0` even when the check fails — `just ci` / `just pre-push` report "All CI checks passed" while GitHub Actions is red. This makes the local CI mirror untrustworthy as a pre-push gate (observed on #104: `just ci` green locally, Format + Clippy failed in CI).

## Fix

Add `set -euo pipefail` after the shebang in the four affected recipes so a failing check aborts before the success `printf` and propagates a non-zero exit. `version-sync` and `link-check` already fail correctly (explicit `exit 1` / `set -e`) and are unchanged.

## Verification

- `just fmt-check` still exits `0` on a clean tree (happy path intact).
- `bash -c 'set -euo pipefail; false; echo x'` exits `1` without printing — confirms propagation.