### PR TITLE
fix(core): nest embedded resource content under `resource` (#106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `cancelled()`). Previously the context held an unregistered token, so cancel
   notifications had no effect; numeric request ids are now matched as well
   ([#87](https://github.com/praxiomlabs/mcpkit/issues/87)).
+- **Breaking (wire format):** embedded resource content (`Content::Resource`)
+  now nests its payload under a `resource` key to match the spec's
+  `EmbeddedResource` (`{ "type": "resource", "resource": { "uri": .. } }`).
+  Previously the `uri`/`mimeType`/`text`/`blob` fields were hoisted to the top
+  level, which spec-compliant peers could not parse. `ResourceContent` now holds
+  a single `resource: ResourceContents` field plus `annotations`
+  ([#106](https://github.com/praxiomlabs/mcpkit/issues/106)).
 
 ### Security
 

--- a/crates/mcpkit-core/src/types/content.rs
+++ b/crates/mcpkit-core/src/types/content.rs
@@ -3,6 +3,7 @@
 //! Content represents the payload in tool results, resource contents,
 //! and prompt messages. MCP supports text, images, audio, and embedded resources.
 
+use super::resource::ResourceContents;
 use serde::{Deserialize, Serialize};
 
 /// Content that can be included in messages and results.
@@ -68,10 +69,12 @@ impl Content {
     #[must_use]
     pub fn resource(uri: impl Into<String>) -> Self {
         Self::Resource(ResourceContent {
-            uri: uri.into(),
-            mime_type: None,
-            text: None,
-            blob: None,
+            resource: ResourceContents {
+                uri: uri.into(),
+                mime_type: None,
+                text: None,
+                blob: None,
+            },
             annotations: None,
         })
     }
@@ -165,19 +168,13 @@ pub struct AudioContent {
 }
 
 /// Embedded resource content.
+///
+/// The resource payload is nested under `resource` to match the spec's
+/// `EmbeddedResource` (`{ "type": "resource", "resource": { "uri": .. } }`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResourceContent {
-    /// URI of the resource.
-    pub uri: String,
-    /// MIME type of the content.
-    #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
-    pub mime_type: Option<String>,
-    /// Text content if the resource is text.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub text: Option<String>,
-    /// Base64-encoded binary content.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub blob: Option<String>,
+    /// The embedded resource contents.
+    pub resource: ResourceContents,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ContentAnnotations>,
@@ -299,6 +296,23 @@ mod tests {
                 .ok_or("Expected audience")?
                 .contains(&Role::User)
         );
+        Ok(())
+    }
+
+    #[test]
+    fn test_embedded_resource_nests_under_resource_key() -> Result<(), Box<dyn std::error::Error>> {
+        // Spec EmbeddedResource: { "type": "resource", "resource": { "uri": .. } }
+        let content = Content::resource("file:///main.rs");
+        assert!(content.is_resource());
+        let j = serde_json::to_value(&content)?;
+        assert_eq!(j["type"], "resource");
+        assert_eq!(j["resource"]["uri"], "file:///main.rs");
+        // The uri must NOT be hoisted to the top level (the old, non-conformant shape).
+        assert!(j.get("uri").is_none());
+
+        // Round-trips from the spec shape.
+        let back: Content = serde_json::from_value(j)?;
+        assert!(back.is_resource());
         Ok(())
     }
 


### PR DESCRIPTION
Closes #106.

## Problem

Spec `EmbeddedResource` nests its payload under `resource`:

```json
{ "type": "resource", "resource": { "uri": "file:///main.rs", "text": ".." } }
```

mcpkit's `Content::Resource` is `#[serde(tag = "type")]` over a flattened `ResourceContent`, so it emitted the non-conformant:

```json
{ "type": "resource", "uri": "file:///main.rs", "text": ".." }
```

A spec-compliant client reading `block.resource.uri` finds nothing.

## Fix

`ResourceContent` now holds a single `resource: ResourceContents` field (reusing the existing `ResourceContents` = `{ uri, mimeType?, text?, blob? }`) plus the sibling `annotations`. Construction is contained to the `Content::resource(..)` constructor; no other code read the old flat fields.

**Breaking (wire format):** anyone relying on the flattened embedded-resource shape, or constructing `ResourceContent { uri, .. }` directly, must move to the nested form.

## Test plan

- New regression test asserts `{"type":"resource","resource":{"uri":..}}` and that `uri` is no longer hoisted to the top level, with a round-trip.
- `cargo fmt --all --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `cargo test --workspace --all-features --locked`, and `cargo doc -D warnings` all green locally.

Spec: https://modelcontextprotocol.io/specification/2025-11-25/server/tools#embedded-resources