### PR TITLE
feat(core): rewrite task types to the 2025-11-25 spec model (#81 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ConnectionInner` (`mcpkit-core`) and `ConnectionData` (`mcpkit-server`) are
   now `#[doc(hidden)]`. They are internal implementation details of
   `Connection` and were never intended as stable API.
+- **Breaking:** the task types are rewritten to the 2025-11-25 spec model. `Task`
+  is now `{ taskId, status, statusMessage?, createdAt, lastUpdatedAt, ttl,
+  pollInterval? }`; `TaskStatus` is `working`/`input_required`/`completed`/
+  `failed`/`cancelled` (was `pending`/`running`/…). The non-spec `TaskError`,
+  `TaskSummary`, and the `Task` fields `tool`/`progress`/`result`/`error`/
+  `updatedAt` are removed; `id` is now `taskId`. New spec types: `TaskMetadata`
+  (the request `task` augmentation field), `CreateTaskResult`,
+  `GetTaskRequest`/`GetTaskResult`, `GetTaskPayloadRequest`/`GetTaskPayloadResult`
+  (`tasks/result`), `CancelTaskRequest`/`CancelTaskResult`, `ListTasksRequest`/
+  `ListTasksResult`. `ListTasksRequest` no longer carries a `status` filter (not
+  in the spec). The server's `TaskManager`/`TaskHandle` are reworked to the new
+  model (a task is `working` on create, stores a payload on `complete`).
+  `TaskProgress` is retained for the progress-notification handler pending #112.
+  This is the type layer for [#81](https://github.com/praxiomlabs/mcpkit/issues/81);
+  capability advertisement and the task-augmented `tools/call` flow follow.
 
 ### Fixed
 

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -27,7 +27,7 @@ use mcpkit_core::types::{
     GetPromptResult, GetTaskRequest, ListPromptsResult, ListResourceTemplatesResult,
     ListResourcesResult, ListTasksRequest, ListTasksResult, ListToolsResult, Prompt,
     ReadResourceRequest, ReadResourceResult, Resource, ResourceContents, ResourceTemplate, Task,
-    TaskStatus, TaskSummary, Tool,
+    TaskStatus, Tool,
 };
 use mcpkit_transport::Transport;
 use std::collections::HashMap;
@@ -738,7 +738,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
     /// # Errors
     ///
     /// Returns an error if tasks are not supported or the request fails.
-    pub async fn list_tasks(&self) -> Result<Vec<TaskSummary>, McpError> {
+    pub async fn list_tasks(&self) -> Result<Vec<Task>, McpError> {
         self.ensure_capability("tasks", self.has_tasks())?;
 
         let result: ListTasksResult = self.request("tasks/list", None).await?;
@@ -757,12 +757,18 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
     ) -> Result<ListTasksResult, McpError> {
         self.ensure_capability("tasks", self.has_tasks())?;
 
+        // `tasks/list` has no server-side status filter in the spec; filter the
+        // returned page client-side when a status is requested.
         let request = ListTasksRequest {
-            status,
             cursor: cursor.map(String::from),
         };
-        self.request("tasks/list", Some(serde_json::to_value(request)?))
-            .await
+        let mut result: ListTasksResult = self
+            .request("tasks/list", Some(serde_json::to_value(request)?))
+            .await?;
+        if let Some(status) = status {
+            result.tasks.retain(|task| task.status == status);
+        }
+        Ok(result)
     }
 
     /// Get a task by ID.
@@ -774,7 +780,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         self.ensure_capability("tasks", self.has_tasks())?;
 
         let request = GetTaskRequest {
-            id: id.into().into(),
+            task_id: id.into().into(),
         };
         self.request("tasks/get", Some(serde_json::to_value(request)?))
             .await
@@ -790,7 +796,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         self.ensure_capability("tasks", self.has_tasks())?;
 
         let request = CancelTaskRequest {
-            id: id.into().into(),
+            task_id: id.into().into(),
         };
         let _: serde_json::Value = self
             .request("tasks/cancel", Some(serde_json::to_value(request)?))

--- a/crates/mcpkit-core/src/lib.rs
+++ b/crates/mcpkit-core/src/lib.rs
@@ -105,12 +105,15 @@ pub mod prelude {
     pub use crate::types::{
         // Tool types
         CallToolResult,
+        // Task types
+        CancelTaskRequest,
         // Content types
         Content,
         ContentAnnotations,
         // Sampling types
         CreateMessageRequest,
         CreateMessageResult,
+        CreateTaskResult,
         // Elicitation types
         ElicitAction,
         ElicitRequest,
@@ -118,6 +121,10 @@ pub mod prelude {
         ElicitationSchema,
         // Prompt types
         GetPromptResult,
+        GetTaskPayloadRequest,
+        GetTaskRequest,
+        ListTasksRequest,
+        ListTasksResult,
         ModelPreferences,
         Prompt,
         PromptArgument,
@@ -131,13 +138,11 @@ pub mod prelude {
         Role,
         SamplingMessage,
         StopReason,
-        // Task types
         Task,
-        TaskError,
         TaskId,
+        TaskMetadata,
         TaskProgress,
         TaskStatus,
-        TaskSummary,
         Tool,
         ToolAnnotations,
         ToolOutput,

--- a/crates/mcpkit-core/src/types/task.rs
+++ b/crates/mcpkit-core/src/types/task.rs
@@ -1,7 +1,9 @@
-//! Task types for MCP servers.
+//! Task types for the MCP 2025-11-25 tasks utility.
 //!
-//! Tasks represent long-running operations that can be tracked, monitored,
-//! and cancelled.
+//! A task represents a long-running operation. A receiver that supports
+//! task-augmented execution returns a [`CreateTaskResult`] immediately, and the
+//! caller polls [`tasks/get`](GetTaskRequest) for status and
+//! [`tasks/result`](GetTaskPayloadRequest) for the eventual payload.
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -51,17 +53,17 @@ impl From<&str> for TaskId {
 
 /// The current status of a task.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "snake_case")]
 pub enum TaskStatus {
-    /// Task is pending execution.
-    Pending,
-    /// Task is currently running.
-    Running,
-    /// Task completed successfully.
+    /// The request is currently being processed.
+    Working,
+    /// The task is waiting for input (e.g. an elicitation or sampling round-trip).
+    InputRequired,
+    /// The request completed successfully and the result is available.
     Completed,
-    /// Task failed with an error.
+    /// The request did not complete successfully.
     Failed,
-    /// Task was cancelled.
+    /// The request was cancelled before completion.
     Cancelled,
 }
 
@@ -71,25 +73,13 @@ impl TaskStatus {
     pub const fn is_terminal(&self) -> bool {
         matches!(self, Self::Completed | Self::Failed | Self::Cancelled)
     }
-
-    /// Check if the task is actively running.
-    #[must_use]
-    pub const fn is_running(&self) -> bool {
-        matches!(self, Self::Running)
-    }
-
-    /// Check if the task is pending.
-    #[must_use]
-    pub const fn is_pending(&self) -> bool {
-        matches!(self, Self::Pending)
-    }
 }
 
 impl std::fmt::Display for TaskStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Self::Pending => write!(f, "pending"),
-            Self::Running => write!(f, "running"),
+            Self::Working => write!(f, "working"),
+            Self::InputRequired => write!(f, "input_required"),
             Self::Completed => write!(f, "completed"),
             Self::Failed => write!(f, "failed"),
             Self::Cancelled => write!(f, "cancelled"),
@@ -97,7 +87,170 @@ impl std::fmt::Display for TaskStatus {
     }
 }
 
-/// Progress information for a running task.
+/// Full state information for a task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Task {
+    /// The task identifier.
+    #[serde(rename = "taskId")]
+    pub task_id: TaskId,
+    /// Current task state.
+    pub status: TaskStatus,
+    /// Optional human-readable message describing the current state (e.g. a
+    /// failure reason or completion summary).
+    #[serde(rename = "statusMessage", skip_serializing_if = "Option::is_none")]
+    pub status_message: Option<String>,
+    /// ISO 8601 timestamp when the task was created.
+    #[serde(rename = "createdAt")]
+    pub created_at: String,
+    /// ISO 8601 timestamp when the task was last updated.
+    #[serde(rename = "lastUpdatedAt")]
+    pub last_updated_at: String,
+    /// Actual retention duration from creation, in milliseconds; `None`
+    /// (serialized as `null`) for unlimited.
+    pub ttl: Option<u64>,
+    /// Suggested polling interval, in milliseconds.
+    #[serde(rename = "pollInterval", skip_serializing_if = "Option::is_none")]
+    pub poll_interval: Option<u64>,
+}
+
+impl Task {
+    /// Create a new `working` task with the given ID, timestamped now.
+    #[must_use]
+    pub fn new(task_id: TaskId) -> Self {
+        let now = chrono::Utc::now().to_rfc3339();
+        Self {
+            task_id,
+            status: TaskStatus::Working,
+            status_message: None,
+            created_at: now.clone(),
+            last_updated_at: now,
+            ttl: None,
+            poll_interval: None,
+        }
+    }
+
+    /// Create a new `working` task with a generated ID.
+    #[must_use]
+    pub fn create() -> Self {
+        Self::new(TaskId::generate())
+    }
+
+    /// Set the status message.
+    #[must_use]
+    pub fn status_message(mut self, message: impl Into<String>) -> Self {
+        self.status_message = Some(message.into());
+        self
+    }
+
+    /// Set the retention duration in milliseconds (`None` for unlimited).
+    #[must_use]
+    pub const fn ttl(mut self, ttl: Option<u64>) -> Self {
+        self.ttl = ttl;
+        self
+    }
+
+    /// Set the suggested polling interval in milliseconds.
+    #[must_use]
+    pub const fn poll_interval(mut self, poll_interval: u64) -> Self {
+        self.poll_interval = Some(poll_interval);
+        self
+    }
+
+    /// Transition the task to a new status and bump `lastUpdatedAt`.
+    pub fn set_status(&mut self, status: TaskStatus) {
+        self.status = status;
+        self.last_updated_at = chrono::Utc::now().to_rfc3339();
+    }
+}
+
+/// Metadata for requesting task-augmented execution.
+///
+/// Include this in the `task` field of a request's params to ask the receiver
+/// to run the request as a task.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TaskMetadata {
+    /// Requested retention duration from creation, in milliseconds.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<u64>,
+}
+
+/// Metadata associating a message with a task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RelatedTaskMetadata {
+    /// The task identifier this message is associated with.
+    #[serde(rename = "taskId")]
+    pub task_id: TaskId,
+}
+
+/// Result of a task-augmented request: the created task, returned immediately.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateTaskResult {
+    /// The created task.
+    pub task: Task,
+}
+
+/// Result of `tasks/get` — the task's current state (spec `Result & Task`).
+pub type GetTaskResult = Task;
+
+/// Result of `tasks/cancel` — the task's state after cancellation (`Result & Task`).
+pub type CancelTaskResult = Task;
+
+/// Result of `tasks/result` — the eventual payload of the augmented request
+/// (e.g. the `CallToolResult`). An arbitrary result object.
+pub type GetTaskPayloadResult = Value;
+
+/// Request parameters for `tasks/list`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ListTasksRequest {
+    /// Cursor for pagination.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
+}
+
+/// Response for `tasks/list`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListTasksResult {
+    /// The list of tasks.
+    pub tasks: Vec<Task>,
+    /// Cursor for the next page, if more tasks exist.
+    #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
+}
+
+/// Request parameters for `tasks/get`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetTaskRequest {
+    /// The task identifier to query.
+    #[serde(rename = "taskId")]
+    pub task_id: TaskId,
+}
+
+/// Request parameters for `tasks/result`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetTaskPayloadRequest {
+    /// The task identifier to retrieve results for.
+    #[serde(rename = "taskId")]
+    pub task_id: TaskId,
+}
+
+/// Request parameters for `tasks/cancel`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelTaskRequest {
+    /// The task identifier to cancel.
+    #[serde(rename = "taskId")]
+    pub task_id: TaskId,
+}
+
+/// Parameters for a task status notification (spec `NotificationParams & Task`):
+/// the task's current state.
+pub type TaskStatusNotification = Task;
+
+/// Progress information carried by a `notifications/progress` message.
+///
+/// Note: this is the progress utility's payload, not part of the spec `Task`
+/// object (the 2025-11-25 `Task` has no embedded progress). It is retained for
+/// the client's progress-notification handler and will be reconciled with the
+/// typed `ProgressNotification` params in #112.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TaskProgress {
     /// Current progress value.
@@ -110,425 +263,64 @@ pub struct TaskProgress {
     pub message: Option<String>,
 }
 
-impl TaskProgress {
-    /// Create new progress information.
-    #[must_use]
-    pub const fn new(current: u64) -> Self {
-        Self {
-            current,
-            total: None,
-            message: None,
-        }
-    }
-
-    /// Set the total progress value.
-    #[must_use]
-    pub const fn total(mut self, total: u64) -> Self {
-        self.total = Some(total);
-        self
-    }
-
-    /// Set the progress message.
-    #[must_use]
-    pub fn message(mut self, message: impl Into<String>) -> Self {
-        self.message = Some(message.into());
-        self
-    }
-
-    /// Get the progress percentage (0.0 to 1.0) if total is known.
-    #[must_use]
-    pub fn percentage(&self) -> Option<f64> {
-        self.total.map(|t| {
-            if t == 0 {
-                1.0
-            } else {
-                (self.current as f64 / t as f64).min(1.0)
-            }
-        })
-    }
-}
-
-/// Error information for a failed task.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaskError {
-    /// Error code.
-    pub code: i32,
-    /// Error message.
-    pub message: String,
-    /// Additional error data.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Value>,
-}
-
-impl TaskError {
-    /// Create a new task error.
-    #[must_use]
-    pub fn new(code: i32, message: impl Into<String>) -> Self {
-        Self {
-            code,
-            message: message.into(),
-            data: None,
-        }
-    }
-
-    /// Set additional error data.
-    #[must_use]
-    pub fn data(mut self, data: Value) -> Self {
-        self.data = Some(data);
-        self
-    }
-}
-
-/// Full state information for a task.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Task {
-    /// Unique task identifier.
-    pub id: TaskId,
-    /// Current task status.
-    pub status: TaskStatus,
-    /// Name of the tool that created this task.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool: Option<String>,
-    /// Human-readable description.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// Progress information (for running tasks).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub progress: Option<TaskProgress>,
-    /// Result data (for completed tasks).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<Value>,
-    /// Error information (for failed tasks).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<TaskError>,
-    /// Timestamp when the task was created.
-    #[serde(rename = "createdAt")]
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    /// Timestamp when the task was last updated.
-    #[serde(rename = "updatedAt")]
-    pub updated_at: chrono::DateTime<chrono::Utc>,
-}
-
-impl Task {
-    /// Create a new pending task.
-    #[must_use]
-    pub fn new(id: TaskId) -> Self {
-        let now = chrono::Utc::now();
-        Self {
-            id,
-            status: TaskStatus::Pending,
-            tool: None,
-            description: None,
-            progress: None,
-            result: None,
-            error: None,
-            created_at: now,
-            updated_at: now,
-        }
-    }
-
-    /// Create a new task with a generated ID.
-    #[must_use]
-    pub fn create() -> Self {
-        Self::new(TaskId::generate())
-    }
-
-    /// Set the tool name.
-    #[must_use]
-    pub fn tool(mut self, tool: impl Into<String>) -> Self {
-        self.tool = Some(tool.into());
-        self
-    }
-
-    /// Set the description.
-    #[must_use]
-    pub fn description(mut self, description: impl Into<String>) -> Self {
-        self.description = Some(description.into());
-        self
-    }
-
-    /// Mark the task as running.
-    pub fn start(&mut self) {
-        self.status = TaskStatus::Running;
-        self.updated_at = chrono::Utc::now();
-    }
-
-    /// Update task progress.
-    pub fn update_progress(&mut self, progress: TaskProgress) {
-        self.progress = Some(progress);
-        self.updated_at = chrono::Utc::now();
-    }
-
-    /// Complete the task with a result.
-    pub fn complete(&mut self, result: Value) {
-        self.status = TaskStatus::Completed;
-        self.result = Some(result);
-        self.progress = None;
-        self.updated_at = chrono::Utc::now();
-    }
-
-    /// Fail the task with an error.
-    pub fn fail(&mut self, error: TaskError) {
-        self.status = TaskStatus::Failed;
-        self.error = Some(error);
-        self.progress = None;
-        self.updated_at = chrono::Utc::now();
-    }
-
-    /// Cancel the task.
-    pub fn cancel(&mut self) {
-        self.status = TaskStatus::Cancelled;
-        self.progress = None;
-        self.updated_at = chrono::Utc::now();
-    }
-}
-
-/// A summary of a task (for listing).
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaskSummary {
-    /// Unique task identifier.
-    pub id: TaskId,
-    /// Current task status.
-    pub status: TaskStatus,
-    /// Name of the tool that created this task.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tool: Option<String>,
-    /// Human-readable description.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
-    /// Progress percentage (0.0 to 1.0) if available.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub progress: Option<f64>,
-}
-
-impl From<&Task> for TaskSummary {
-    fn from(task: &Task) -> Self {
-        Self {
-            id: task.id.clone(),
-            status: task.status,
-            tool: task.tool.clone(),
-            description: task.description.clone(),
-            progress: task.progress.as_ref().and_then(TaskProgress::percentage),
-        }
-    }
-}
-
-/// Request parameters for listing tasks.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ListTasksRequest {
-    /// Filter by status.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<TaskStatus>,
-    /// Cursor for pagination.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub cursor: Option<String>,
-}
-
-/// Response for listing tasks.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ListTasksResult {
-    /// The list of tasks.
-    pub tasks: Vec<TaskSummary>,
-    /// Cursor for the next page.
-    #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
-    pub next_cursor: Option<String>,
-}
-
-/// Request parameters for getting a task.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct GetTaskRequest {
-    /// ID of the task to get.
-    pub id: TaskId,
-}
-
-/// Request parameters for cancelling a task.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CancelTaskRequest {
-    /// ID of the task to cancel.
-    pub id: TaskId,
-}
-
-/// Notification that a task's status has changed.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct TaskStatusNotification {
-    /// ID of the task.
-    pub id: TaskId,
-    /// New status.
-    pub status: TaskStatus,
-    /// Progress information (if running).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub progress: Option<TaskProgress>,
-    /// Result (if completed).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub result: Option<Value>,
-    /// Error (if failed).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub error: Option<TaskError>,
-}
-
-impl TaskStatusNotification {
-    /// Create a running notification.
-    #[must_use]
-    pub const fn running(id: TaskId) -> Self {
-        Self {
-            id,
-            status: TaskStatus::Running,
-            progress: None,
-            result: None,
-            error: None,
-        }
-    }
-
-    /// Create a progress notification.
-    #[must_use]
-    pub const fn progress(id: TaskId, progress: TaskProgress) -> Self {
-        Self {
-            id,
-            status: TaskStatus::Running,
-            progress: Some(progress),
-            result: None,
-            error: None,
-        }
-    }
-
-    /// Create a completed notification.
-    #[must_use]
-    pub const fn completed(id: TaskId, result: Value) -> Self {
-        Self {
-            id,
-            status: TaskStatus::Completed,
-            progress: None,
-            result: Some(result),
-            error: None,
-        }
-    }
-
-    /// Create a failed notification.
-    #[must_use]
-    pub const fn failed(id: TaskId, error: TaskError) -> Self {
-        Self {
-            id,
-            status: TaskStatus::Failed,
-            progress: None,
-            result: None,
-            error: Some(error),
-        }
-    }
-
-    /// Create a cancelled notification.
-    #[must_use]
-    pub const fn cancelled(id: TaskId) -> Self {
-        Self {
-            id,
-            status: TaskStatus::Cancelled,
-            progress: None,
-            result: None,
-            error: None,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn test_task_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
-        let mut task = Task::create().tool("analyze").description("Analyzing data");
+    fn task_serializes_with_spec_field_names() {
+        let task = Task::new(TaskId::new("t-1"));
+        let j = serde_json::to_value(&task).unwrap();
+        assert_eq!(j["taskId"], "t-1");
+        assert_eq!(j["status"], "working");
+        // ttl is required + nullable -> present as null when unset.
+        assert!(j.get("ttl").is_some() && j["ttl"].is_null());
+        // Optional fields absent when unset.
+        assert!(j.get("statusMessage").is_none());
+        assert!(j.get("pollInterval").is_none());
+        assert!(j["createdAt"].is_string());
+        assert!(j["lastUpdatedAt"].is_string());
+    }
 
-        assert_eq!(task.status, TaskStatus::Pending);
-        assert!(!task.status.is_terminal());
-
-        task.start();
-        assert_eq!(task.status, TaskStatus::Running);
-        assert!(task.status.is_running());
-
-        task.update_progress(TaskProgress::new(50).total(100).message("Halfway done"));
+    #[test]
+    fn task_status_serde_values() {
         assert_eq!(
-            task.progress
-                .as_ref()
-                .ok_or("Expected progress")?
-                .percentage(),
-            Some(0.5)
+            serde_json::to_value(TaskStatus::Working).unwrap(),
+            serde_json::json!("working")
         );
+        assert_eq!(
+            serde_json::to_value(TaskStatus::InputRequired).unwrap(),
+            serde_json::json!("input_required")
+        );
+        assert!(TaskStatus::Completed.is_terminal());
+        assert!(!TaskStatus::Working.is_terminal());
+    }
 
-        task.complete(serde_json::json!({"result": "success"}));
+    #[test]
+    fn set_status_updates_timestamp() {
+        let mut task = Task::new(TaskId::new("t"));
+        let created = task.last_updated_at.clone();
+        task.set_status(TaskStatus::Completed);
         assert_eq!(task.status, TaskStatus::Completed);
-        assert!(task.status.is_terminal());
-        assert!(task.result.is_some());
-        Ok(())
+        // created_at is stable; last_updated_at is refreshed.
+        assert_eq!(task.created_at, created);
     }
 
     #[test]
-    fn test_task_failure() {
-        let mut task = Task::create();
-        task.start();
-        task.fail(
-            TaskError::new(-1, "Something went wrong")
-                .data(serde_json::json!({"details": "error"})),
-        );
-
-        assert_eq!(task.status, TaskStatus::Failed);
-        assert!(task.status.is_terminal());
-        assert!(task.error.is_some());
+    fn create_task_result_wraps_task() {
+        let res = CreateTaskResult {
+            task: Task::new(TaskId::new("abc")),
+        };
+        let j = serde_json::to_value(&res).unwrap();
+        assert_eq!(j["task"]["taskId"], "abc");
     }
 
     #[test]
-    fn test_task_cancellation() {
-        let mut task = Task::create();
-        task.start();
-        task.cancel();
-
-        assert_eq!(task.status, TaskStatus::Cancelled);
-        assert!(task.status.is_terminal());
-    }
-
-    #[test]
-    fn test_task_summary() {
-        let mut task = Task::create()
-            .tool("process")
-            .description("Processing files");
-        task.start();
-        task.update_progress(TaskProgress::new(25).total(100));
-
-        let summary: TaskSummary = (&task).into();
-        assert_eq!(summary.id, task.id);
-        assert_eq!(summary.status, TaskStatus::Running);
-        assert_eq!(summary.progress, Some(0.25));
-    }
-
-    #[test]
-    fn test_progress_percentage() {
-        let progress = TaskProgress::new(0).total(100);
-        assert_eq!(progress.percentage(), Some(0.0));
-
-        let progress = TaskProgress::new(100).total(100);
-        assert_eq!(progress.percentage(), Some(1.0));
-
-        let progress = TaskProgress::new(150).total(100);
-        assert_eq!(progress.percentage(), Some(1.0)); // Clamped to 1.0
-
-        let progress = TaskProgress::new(50);
-        assert_eq!(progress.percentage(), None); // No total
-
-        let progress = TaskProgress::new(0).total(0);
-        assert_eq!(progress.percentage(), Some(1.0)); // Division by zero handled
-    }
-
-    #[test]
-    fn test_task_notifications() {
-        let id = TaskId::generate();
-
-        let running = TaskStatusNotification::running(id.clone());
-        assert_eq!(running.status, TaskStatus::Running);
-
-        let progress =
-            TaskStatusNotification::progress(id.clone(), TaskProgress::new(50).total(100));
-        assert!(progress.progress.is_some());
-
-        let completed =
-            TaskStatusNotification::completed(id, serde_json::json!({"data": "result"}));
-        assert_eq!(completed.status, TaskStatus::Completed);
-        assert!(completed.result.is_some());
+    fn requests_use_task_id_field() {
+        let j = serde_json::to_value(GetTaskRequest {
+            task_id: TaskId::new("x"),
+        })
+        .unwrap();
+        assert_eq!(j["taskId"], "x");
     }
 }

--- a/crates/mcpkit-server/src/capability/tasks.rs
+++ b/crates/mcpkit-server/src/capability/tasks.rs
@@ -1,9 +1,7 @@
 //! Task capability implementation.
 //!
-//! This module provides support for long-running tasks in MCP servers.
-//!
-//! Tasks allow servers to execute long-running operations while
-//! providing progress updates and supporting cancellation.
+//! Tasks let a server run a long-running operation while the caller polls for
+//! status (`tasks/get`) and, once terminal, the payload (`tasks/result`).
 
 use crate::context::CancellationToken;
 use crate::context::Context;
@@ -15,11 +13,14 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 use std::time::Instant;
 
-/// Internal state for a running task.
-#[derive(Debug)]
+/// Internal state for a tracked task.
+#[derive(Debug, Clone)]
 pub struct TaskState {
-    /// Task metadata.
+    /// Task metadata (status, timestamps, ttl).
     pub task: Task,
+    /// The eventual payload, available once the task is `completed`
+    /// (returned by `tasks/result`).
+    pub payload: Option<Value>,
     /// Cancellation token.
     pub cancel_token: CancellationToken,
     /// When the task was last accessed (for cleanup).
@@ -27,10 +28,10 @@ pub struct TaskState {
 }
 
 impl TaskState {
-    /// Create a new task state.
     fn new(task: Task) -> Self {
         Self {
             task,
+            payload: None,
             cancel_token: CancellationToken::new(),
             last_access: Instant::now(),
         }
@@ -43,10 +44,7 @@ impl TaskState {
     }
 }
 
-/// Handle for interacting with a running task.
-///
-/// This handle is given to task executors to report progress
-/// and completion.
+/// Handle for driving a tracked task to a terminal state.
 pub struct TaskHandle {
     task_id: TaskId,
     manager: Arc<TaskManager>,
@@ -59,35 +57,21 @@ impl TaskHandle {
         &self.task_id
     }
 
-    /// Report that the task is now running.
-    pub async fn running(&self) -> Result<(), McpError> {
+    /// Mark the task as waiting for input (e.g. during elicitation/sampling).
+    pub fn mark_input_required(&self) -> Result<(), McpError> {
         self.manager
-            .update_status(&self.task_id, TaskStatus::Running)
-            .await
+            .set_status(&self.task_id, TaskStatus::InputRequired, None)
     }
 
-    /// Report progress on the task.
-    pub async fn progress(
-        &self,
-        current: u64,
-        total: Option<u64>,
-        message: Option<&str>,
-    ) -> Result<(), McpError> {
-        self.manager
-            .update_progress(&self.task_id, current, total, message)
-            .await
+    /// Mark the task `completed` and store its payload.
+    pub fn complete(&self, payload: Value) -> Result<(), McpError> {
+        self.manager.complete(&self.task_id, payload)
     }
 
-    /// Mark the task as completed with a result.
-    pub async fn complete(&self, result: Value) -> Result<(), McpError> {
-        self.manager.complete_success(&self.task_id, result).await
-    }
-
-    /// Mark the task as failed with an error.
-    pub async fn error(&self, message: impl Into<String>) -> Result<(), McpError> {
+    /// Mark the task `failed` with a status message.
+    pub fn fail(&self, message: impl Into<String>) -> Result<(), McpError> {
         self.manager
-            .complete_error(&self.task_id, message.into())
-            .await
+            .set_status(&self.task_id, TaskStatus::Failed, Some(message.into()))
     }
 
     /// Check if the task has been cancelled.
@@ -98,7 +82,7 @@ impl TaskHandle {
             .is_none_or(|s| s.is_cancelled())
     }
 
-    /// Get a future that completes when the task is cancelled.
+    /// A future that completes when the task is cancelled.
     pub async fn cancelled(&self) {
         if let Some(state) = self.manager.get(&self.task_id) {
             state.cancel_token.cancelled().await;
@@ -106,10 +90,7 @@ impl TaskHandle {
     }
 }
 
-/// Manager for coordinating tasks.
-///
-/// This manages the lifecycle of tasks, including creation,
-/// progress tracking, cancellation, and cleanup.
+/// Manager coordinating the lifecycle of tracked tasks.
 pub struct TaskManager {
     tasks: RwLock<HashMap<TaskId, TaskState>>,
 }
@@ -129,16 +110,13 @@ impl TaskManager {
         }
     }
 
-    /// Create a new task.
-    pub fn create(self: &Arc<Self>, tool_name: Option<&str>) -> TaskHandle {
-        let mut task = Task::create();
-        task.tool = tool_name.map(String::from);
-
-        let task_id = task.id.clone();
-        let state = TaskState::new(task);
+    /// Create a new `working` task and return a handle to it.
+    pub fn create(self: &Arc<Self>) -> TaskHandle {
+        let task = Task::create();
+        let task_id = task.task_id.clone();
 
         if let Ok(mut tasks) = self.tasks.write() {
-            tasks.insert(task_id.clone(), state);
+            tasks.insert(task_id.clone(), TaskState::new(task));
         }
 
         TaskHandle {
@@ -147,21 +125,25 @@ impl TaskManager {
         }
     }
 
-    /// Get a task state by ID.
+    /// Get a snapshot of a task's state by ID.
+    #[must_use]
     pub fn get(&self, id: &TaskId) -> Option<TaskState> {
-        self.tasks.read().ok()?.get(id).map(|s| TaskState {
-            task: s.task.clone(),
-            cancel_token: s.cancel_token.clone(),
-            last_access: s.last_access,
-        })
+        self.tasks.read().ok()?.get(id).cloned()
     }
 
-    /// List all tasks.
+    /// List all tracked tasks.
+    #[must_use]
     pub fn list(&self) -> Vec<Task> {
         self.tasks
             .read()
             .map(|tasks| tasks.values().map(|s| s.task.clone()).collect())
             .unwrap_or_default()
+    }
+
+    /// Get the payload of a completed task, if available.
+    #[must_use]
+    pub fn payload(&self, id: &TaskId) -> Option<Value> {
+        self.tasks.read().ok()?.get(id)?.payload.clone()
     }
 
     /// Cancel a task.
@@ -173,8 +155,8 @@ impl TaskManager {
 
         if let Some(state) = tasks.get_mut(id) {
             state.cancel_token.cancel();
-            state.task.status = TaskStatus::Cancelled;
-            state.task.updated_at = chrono::Utc::now();
+            state.task.set_status(TaskStatus::Cancelled);
+            state.last_access = Instant::now();
             Ok(())
         } else {
             Err(McpError::invalid_params(
@@ -184,33 +166,12 @@ impl TaskManager {
         }
     }
 
-    /// Update task status.
-    async fn update_status(&self, id: &TaskId, status: TaskStatus) -> Result<(), McpError> {
-        let mut tasks = self
-            .tasks
-            .write()
-            .map_err(|_| McpError::internal("Failed to acquire task lock"))?;
-
-        if let Some(state) = tasks.get_mut(id) {
-            state.task.status = status;
-            state.task.updated_at = chrono::Utc::now();
-            state.last_access = Instant::now();
-            Ok(())
-        } else {
-            Err(McpError::invalid_params(
-                "tasks/get",
-                format!("Unknown task: {}", id.as_str()),
-            ))
-        }
-    }
-
-    /// Update task progress.
-    async fn update_progress(
+    /// Set a task's status (and optional status message).
+    fn set_status(
         &self,
         id: &TaskId,
-        current: u64,
-        total: Option<u64>,
-        message: Option<&str>,
+        status: TaskStatus,
+        message: Option<String>,
     ) -> Result<(), McpError> {
         let mut tasks = self
             .tasks
@@ -218,12 +179,10 @@ impl TaskManager {
             .map_err(|_| McpError::internal("Failed to acquire task lock"))?;
 
         if let Some(state) = tasks.get_mut(id) {
-            state.task.progress = Some(mcpkit_core::types::task::TaskProgress {
-                current,
-                total,
-                message: message.map(String::from),
-            });
-            state.task.updated_at = chrono::Utc::now();
+            state.task.set_status(status);
+            if message.is_some() {
+                state.task.status_message = message;
+            }
             state.last_access = Instant::now();
             Ok(())
         } else {
@@ -234,53 +193,27 @@ impl TaskManager {
         }
     }
 
-    /// Complete a task with success.
-    async fn complete_success(&self, id: &TaskId, result: Value) -> Result<(), McpError> {
+    /// Mark a task completed and store its payload.
+    fn complete(&self, id: &TaskId, payload: Value) -> Result<(), McpError> {
         let mut tasks = self
             .tasks
             .write()
             .map_err(|_| McpError::internal("Failed to acquire task lock"))?;
 
         if let Some(state) = tasks.get_mut(id) {
-            state.task.status = TaskStatus::Completed;
-            state.task.result = Some(result);
-            state.task.updated_at = chrono::Utc::now();
+            state.task.set_status(TaskStatus::Completed);
+            state.payload = Some(payload);
             state.last_access = Instant::now();
             Ok(())
         } else {
             Err(McpError::invalid_params(
-                "tasks/get",
+                "tasks/result",
                 format!("Unknown task: {}", id.as_str()),
             ))
         }
     }
 
-    /// Complete a task with an error.
-    async fn complete_error(&self, id: &TaskId, message: String) -> Result<(), McpError> {
-        let mut tasks = self
-            .tasks
-            .write()
-            .map_err(|_| McpError::internal("Failed to acquire task lock"))?;
-
-        if let Some(state) = tasks.get_mut(id) {
-            state.task.status = TaskStatus::Failed;
-            state.task.error = Some(mcpkit_core::types::task::TaskError {
-                code: -1,
-                message,
-                data: None,
-            });
-            state.task.updated_at = chrono::Utc::now();
-            state.last_access = Instant::now();
-            Ok(())
-        } else {
-            Err(McpError::invalid_params(
-                "tasks/get",
-                format!("Unknown task: {}", id.as_str()),
-            ))
-        }
-    }
-
-    /// Remove completed tasks older than the given duration.
+    /// Remove terminal tasks older than `max_age`.
     pub fn cleanup(&self, max_age: std::time::Duration) {
         if let Ok(mut tasks) = self.tasks.write() {
             tasks.retain(|_, state| {
@@ -291,7 +224,7 @@ impl TaskManager {
     }
 }
 
-/// Task service implementing the `TaskHandler` trait.
+/// Task service implementing the [`TaskHandler`] trait over a [`TaskManager`].
 pub struct TaskService {
     manager: Arc<TaskManager>,
 }
@@ -317,10 +250,10 @@ impl TaskService {
         &self.manager
     }
 
-    /// Create a new task and get a handle for it.
+    /// Create a new task and return a handle for driving it.
     #[must_use]
-    pub fn create(&self, tool_name: Option<&str>) -> TaskHandle {
-        self.manager.create(tool_name)
+    pub fn create(&self) -> TaskHandle {
+        self.manager.create()
     }
 }
 
@@ -338,10 +271,7 @@ impl TaskHandler for TaskService {
     }
 
     async fn cancel_task(&self, task_id: &TaskId, _ctx: &Context<'_>) -> Result<bool, McpError> {
-        match self.manager.cancel(task_id) {
-            Ok(()) => Ok(true),
-            Err(_) => Ok(false),
-        }
+        Ok(self.manager.cancel(task_id).is_ok())
     }
 }
 
@@ -350,73 +280,77 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_task_manager() {
+    fn test_task_manager_create_and_list() {
         let manager = Arc::new(TaskManager::new());
 
-        let handle = manager.create(Some("test-tool"));
+        let handle = manager.create();
         assert!(!handle.is_cancelled());
 
         let tasks = manager.list();
         assert_eq!(tasks.len(), 1);
-        assert_eq!(tasks[0].tool.as_deref(), Some("test-tool"));
-        assert_eq!(tasks[0].status, TaskStatus::Pending);
+        assert_eq!(tasks[0].status, TaskStatus::Working);
     }
 
-    #[tokio::test]
-    async fn test_task_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
+    #[test]
+    fn test_task_complete_stores_payload() -> Result<(), Box<dyn std::error::Error>> {
         let manager = Arc::new(TaskManager::new());
-
-        let handle = manager.create(Some("processor"));
+        let handle = manager.create();
         let task_id = handle.id().clone();
 
-        // Start running
-        handle.running().await?;
-        let state = manager.get(&task_id).ok_or("Task not found")?;
-        assert_eq!(state.task.status, TaskStatus::Running);
+        handle.complete(serde_json::json!({"result": "ok"}))?;
 
-        // Report progress
-        handle.progress(50, Some(100), Some("Halfway done")).await?;
-        let state = manager.get(&task_id).ok_or("Task not found")?;
-        assert_eq!(state.task.progress.as_ref().map(|p| p.current), Some(50));
-
-        // Complete
-        handle
-            .complete(serde_json::json!({"result": "success"}))
-            .await?;
         let state = manager.get(&task_id).ok_or("Task not found")?;
         assert_eq!(state.task.status, TaskStatus::Completed);
+        assert_eq!(
+            manager.payload(&task_id),
+            Some(serde_json::json!({"result": "ok"}))
+        );
+        Ok(())
+    }
 
+    #[test]
+    fn test_task_input_required_and_fail() -> Result<(), Box<dyn std::error::Error>> {
+        let manager = Arc::new(TaskManager::new());
+        let handle = manager.create();
+        let task_id = handle.id().clone();
+
+        handle.mark_input_required()?;
+        assert_eq!(
+            manager.get(&task_id).ok_or("not found")?.task.status,
+            TaskStatus::InputRequired
+        );
+
+        handle.fail("boom")?;
+        let state = manager.get(&task_id).ok_or("not found")?;
+        assert_eq!(state.task.status, TaskStatus::Failed);
+        assert_eq!(state.task.status_message.as_deref(), Some("boom"));
         Ok(())
     }
 
     #[test]
     fn test_task_cancellation() -> Result<(), Box<dyn std::error::Error>> {
         let manager = Arc::new(TaskManager::new());
-
-        let handle = manager.create(None);
+        let handle = manager.create();
         let task_id = handle.id().clone();
 
         assert!(!handle.is_cancelled());
-
         manager.cancel(&task_id)?;
-
         assert!(handle.is_cancelled());
-        let state = manager.get(&task_id).ok_or("Task not found")?;
-        assert_eq!(state.task.status, TaskStatus::Cancelled);
-
+        assert_eq!(
+            manager.get(&task_id).ok_or("not found")?.task.status,
+            TaskStatus::Cancelled
+        );
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_task_service() -> Result<(), Box<dyn std::error::Error>> {
+    async fn test_task_service_handler() -> Result<(), Box<dyn std::error::Error>> {
         let service = TaskService::new();
+        let handle = service.create();
+        let task_id = handle.id().clone();
 
-        let handle = service.create(Some("service-task"));
-        handle.running().await?;
-
-        let tasks = service.manager.list();
-        assert_eq!(tasks.len(), 1);
-
+        assert_eq!(service.manager().list().len(), 1);
+        assert!(service.manager().get(&task_id).is_some());
         Ok(())
     }
 }


### PR DESCRIPTION
First of three for #81. **Types only** — capability advertisement (PR2) and the task-augmented `tools/call` flow (PR3) follow.

## What

The current `task.rs` was a generic async-task abstraction (`id`/`pending`/`running`/`progress`/`result`/`error`) that diverged from the spec and wasn't wire-compatible with task-aware MCP peers. This rewrites it to the 2025-11-25 model, grounded against `schema.ts`.

| Before | After (spec) |
|---|---|
| `Task.id` | `Task.taskId` |
| status `pending`/`running`/`completed`/`failed`/`cancelled` | `working`/`input_required`/`completed`/`failed`/`cancelled` |
| `tool`/`progress`/`result`/`error`/`updatedAt` | `statusMessage?`/`createdAt`/`lastUpdatedAt`/`ttl`/`pollInterval?` |

New spec types: `TaskMetadata` (the request `task` augmentation field), `CreateTaskResult`, `GetTaskRequest`/`GetTaskResult`, `GetTaskPayloadRequest`/`GetTaskPayloadResult` (`tasks/result`), `CancelTaskRequest`/`CancelTaskResult`, `ListTasksRequest`/`ListTasksResult`, `TaskStatusNotification`, `RelatedTaskMetadata`.

Removed non-spec: `TaskError`, `TaskSummary`, the `Task` extra fields. `ListTasksRequest` loses its `status` filter (not in spec); the client method keeps the behavior by filtering the returned page client-side.

The server `TaskManager`/`TaskHandle` are reworked to the new model: a task is `working` on create, `mark_input_required()`/`fail()` set status, `complete(payload)` stores the payload for `tasks/result`.

`TaskProgress` is **retained** (not part of the spec `Task`) for the client's `on_task_progress` notification handler — it'll be reconciled with the typed `ProgressNotification` in #112.

## Breaking

The `Task`/`TaskStatus` API and the removed types break struct construction and status matching. Lands within the unreleased 0.7.0 cycle.

## Test plan

- New serde tests: spec field names (`taskId`, `ttl: null` present), status values, `CreateTaskResult` wrapping; reworked `TaskManager` tests (complete-stores-payload, input_required/fail, cancel).
- `cargo fmt --all --check`, `clippy --workspace --all-features --all-targets -D warnings`, `cargo test --workspace --all-features --locked`, `cargo doc -D warnings` all green locally.

Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks