### PR TITLE
refactor(server): consolidate request dispatch into one slot-based router (#117)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `TaskProgress` is retained for the progress-notification handler pending #112.
   This is the type layer for [#81](https://github.com/praxiomlabs/mcpkit/issues/81);
   capability advertisement and the task-augmented `tools/call` flow follow.
+- Server request dispatch is consolidated. The combinatorial
+  `impl_request_router!` macro (one `RequestRouter` impl per registered-handler
+  combination) is replaced by a single slot-based impl backed by a new
+  `mcpkit_server::dispatch` module (object-safe `DynToolHandler`/
+  `DynResourceHandler`/`DynPromptHandler` + `ToolSlot`/`ResourceSlot`/
+  `PromptSlot`). The duplicate per-method routing in `server.rs` is removed; the
+  single source of truth is `mcpkit_server::router` (`route_tools`/
+  `route_resources`/`route_prompts` now take `&dyn Dyn*Handler`), shared by the
+  server runtime and the framework adapters. Behavior is unchanged. **Breaking
+  (minor):** the `route_*` functions' signatures changed from generic
+  `<H: ToolHandler>(&H, ..)` to `(&dyn DynToolHandler, ..)` — a concrete `&handler`
+  reference still coerces in, so most call sites are unaffected
+  ([#117](https://github.com/praxiomlabs/mcpkit/issues/117)).
 
 ### Fixed
 

--- a/crates/mcpkit-server/src/builder.rs
+++ b/crates/mcpkit-server/src/builder.rs
@@ -280,9 +280,9 @@ where
 /// - `K`: Task handler
 pub struct Server<H, T, R, P, K> {
     handler: H,
-    tools: T,
-    resources: R,
-    prompts: P,
+    pub(crate) tools: T,
+    pub(crate) resources: R,
+    pub(crate) prompts: P,
     tasks: K,
     capabilities: ServerCapabilities,
 }

--- a/crates/mcpkit-server/src/dispatch.rs
+++ b/crates/mcpkit-server/src/dispatch.rs
@@ -1,0 +1,186 @@
+//! Object-safe dispatch layer.
+//!
+//! The public handler traits ([`ToolHandler`] et al.) return `impl Future`
+//! (RPITIT) and so are not object-safe, which previously forced request routing
+//! into a combinatorial per-handler-combination typestate macro. The `Dyn*`
+//! traits here box the handler futures so a single router impl can dispatch any
+//! registered handler, and the `*Slot` traits expose "the registered handler,
+//! or `None`" uniformly across the typestate slots (`Registered<H>` /
+//! `NotRegistered`).
+//!
+//! Adding a dispatched capability is then one `Dyn`/`Slot` pair plus one match
+//! arm — no combinatorial growth.
+
+use crate::builder::{NotRegistered, Registered};
+use crate::context::Context;
+use crate::handler::{PromptHandler, ResourceHandler, ToolHandler};
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    GetPromptResult, Prompt, Resource, ResourceContents, ResourceTemplate, Tool, ToolOutput,
+};
+use serde_json::Value;
+use std::future::Future;
+use std::pin::Pin;
+
+/// A boxed, `Send` future borrowing for `'a`.
+type BoxFut<'a, T> = Pin<Box<dyn Future<Output = T> + Send + 'a>>;
+
+// ============================================================================
+// Object-safe handler traits (boxed futures), blanket-impl'd over the public
+// RPITIT traits.
+// ============================================================================
+
+/// Object-safe form of [`ToolHandler`] (only the dispatched methods).
+pub trait DynToolHandler: Send + Sync {
+    /// See [`ToolHandler::list_tools`].
+    fn list_tools<'a>(&'a self, ctx: &'a Context<'_>) -> BoxFut<'a, Result<Vec<Tool>, McpError>>;
+    /// See [`ToolHandler::call_tool`].
+    fn call_tool<'a>(
+        &'a self,
+        name: &'a str,
+        args: Value,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<ToolOutput, McpError>>;
+}
+
+impl<T: ToolHandler> DynToolHandler for T {
+    fn list_tools<'a>(&'a self, ctx: &'a Context<'_>) -> BoxFut<'a, Result<Vec<Tool>, McpError>> {
+        Box::pin(ToolHandler::list_tools(self, ctx))
+    }
+    fn call_tool<'a>(
+        &'a self,
+        name: &'a str,
+        args: Value,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<ToolOutput, McpError>> {
+        Box::pin(ToolHandler::call_tool(self, name, args, ctx))
+    }
+}
+
+/// Object-safe form of [`ResourceHandler`] (only the dispatched methods).
+pub trait DynResourceHandler: Send + Sync {
+    /// See [`ResourceHandler::list_resources`].
+    fn list_resources<'a>(
+        &'a self,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Vec<Resource>, McpError>>;
+    /// See [`ResourceHandler::list_resource_templates`].
+    fn list_resource_templates<'a>(
+        &'a self,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Vec<ResourceTemplate>, McpError>>;
+    /// See [`ResourceHandler::read_resource`].
+    fn read_resource<'a>(
+        &'a self,
+        uri: &'a str,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Vec<ResourceContents>, McpError>>;
+}
+
+impl<R: ResourceHandler> DynResourceHandler for R {
+    fn list_resources<'a>(
+        &'a self,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Vec<Resource>, McpError>> {
+        Box::pin(ResourceHandler::list_resources(self, ctx))
+    }
+    fn list_resource_templates<'a>(
+        &'a self,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Vec<ResourceTemplate>, McpError>> {
+        Box::pin(ResourceHandler::list_resource_templates(self, ctx))
+    }
+    fn read_resource<'a>(
+        &'a self,
+        uri: &'a str,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Vec<ResourceContents>, McpError>> {
+        Box::pin(ResourceHandler::read_resource(self, uri, ctx))
+    }
+}
+
+/// Object-safe form of [`PromptHandler`] (only the dispatched methods).
+pub trait DynPromptHandler: Send + Sync {
+    /// See [`PromptHandler::list_prompts`].
+    fn list_prompts<'a>(
+        &'a self,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Vec<Prompt>, McpError>>;
+    /// See [`PromptHandler::get_prompt`].
+    fn get_prompt<'a>(
+        &'a self,
+        name: &'a str,
+        args: Option<serde_json::Map<String, Value>>,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<GetPromptResult, McpError>>;
+}
+
+impl<P: PromptHandler> DynPromptHandler for P {
+    fn list_prompts<'a>(
+        &'a self,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Vec<Prompt>, McpError>> {
+        Box::pin(PromptHandler::list_prompts(self, ctx))
+    }
+    fn get_prompt<'a>(
+        &'a self,
+        name: &'a str,
+        args: Option<serde_json::Map<String, Value>>,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<GetPromptResult, McpError>> {
+        Box::pin(PromptHandler::get_prompt(self, name, args, ctx))
+    }
+}
+
+// ============================================================================
+// Typestate slots: expose `Option<&dyn Dyn*Handler>` for both `Registered<H>`
+// and `NotRegistered`, so one router impl can be generic over the slots.
+// ============================================================================
+
+/// A tool-handler slot.
+pub trait ToolSlot: Send + Sync {
+    /// The registered tool handler, or `None`.
+    fn as_tool_handler(&self) -> Option<&dyn DynToolHandler>;
+}
+impl ToolSlot for NotRegistered {
+    fn as_tool_handler(&self) -> Option<&dyn DynToolHandler> {
+        None
+    }
+}
+impl<T: ToolHandler> ToolSlot for Registered<T> {
+    fn as_tool_handler(&self) -> Option<&dyn DynToolHandler> {
+        Some(&self.0)
+    }
+}
+
+/// A resource-handler slot.
+pub trait ResourceSlot: Send + Sync {
+    /// The registered resource handler, or `None`.
+    fn as_resource_handler(&self) -> Option<&dyn DynResourceHandler>;
+}
+impl ResourceSlot for NotRegistered {
+    fn as_resource_handler(&self) -> Option<&dyn DynResourceHandler> {
+        None
+    }
+}
+impl<R: ResourceHandler> ResourceSlot for Registered<R> {
+    fn as_resource_handler(&self) -> Option<&dyn DynResourceHandler> {
+        Some(&self.0)
+    }
+}
+
+/// A prompt-handler slot.
+pub trait PromptSlot: Send + Sync {
+    /// The registered prompt handler, or `None`.
+    fn as_prompt_handler(&self) -> Option<&dyn DynPromptHandler>;
+}
+impl PromptSlot for NotRegistered {
+    fn as_prompt_handler(&self) -> Option<&dyn DynPromptHandler> {
+        None
+    }
+}
+impl<P: PromptHandler> PromptSlot for Registered<P> {
+    fn as_prompt_handler(&self) -> Option<&dyn DynPromptHandler> {
+        Some(&self.0)
+    }
+}

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -60,6 +60,7 @@
 pub mod builder;
 pub mod capability;
 pub mod context;
+pub mod dispatch;
 pub mod handler;
 pub mod health;
 pub mod metrics;

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -507,10 +507,11 @@ fn parse_list_params(params: Option<&Value>) -> ListParams {
 // =============================================================================
 
 use crate::context::Context;
-use crate::handler::{PromptHandler, ResourceHandler, ToolHandler};
+use crate::dispatch::{DynPromptHandler, DynResourceHandler, DynToolHandler};
 use mcpkit_core::types::CallToolResult;
 
-/// Route tool-related requests to a handler implementing [`ToolHandler`].
+/// Route tool-related requests to a handler implementing
+/// [`ToolHandler`](crate::handler::ToolHandler).
 ///
 /// This function handles `tools/list` and `tools/call` methods.
 /// Returns `None` if the method is not tool-related.
@@ -522,8 +523,8 @@ use mcpkit_core::types::CallToolResult;
 ///     return result;
 /// }
 /// ```
-pub async fn route_tools<TH: ToolHandler + Send + Sync>(
-    handler: &TH,
+pub async fn route_tools(
+    handler: &dyn DynToolHandler,
     method: &str,
     params: Option<&serde_json::Value>,
     ctx: &Context<'_>,
@@ -581,7 +582,8 @@ pub async fn route_tools<TH: ToolHandler + Send + Sync>(
     }
 }
 
-/// Route resource-related requests to a handler implementing [`ResourceHandler`].
+/// Route resource-related requests to a handler implementing
+/// [`ResourceHandler`](crate::handler::ResourceHandler).
 ///
 /// This function handles `resources/list`, `resources/templates/list`, and `resources/read` methods.
 /// Returns `None` if the method is not resource-related.
@@ -593,8 +595,8 @@ pub async fn route_tools<TH: ToolHandler + Send + Sync>(
 ///     return result;
 /// }
 /// ```
-pub async fn route_resources<RH: ResourceHandler + Send + Sync>(
-    handler: &RH,
+pub async fn route_resources(
+    handler: &dyn DynResourceHandler,
     method: &str,
     params: Option<&serde_json::Value>,
     ctx: &Context<'_>,
@@ -658,7 +660,8 @@ pub async fn route_resources<RH: ResourceHandler + Send + Sync>(
     }
 }
 
-/// Route prompt-related requests to a handler implementing [`PromptHandler`].
+/// Route prompt-related requests to a handler implementing
+/// [`PromptHandler`](crate::handler::PromptHandler).
 ///
 /// This function handles `prompts/list` and `prompts/get` methods.
 /// Returns `None` if the method is not prompt-related.
@@ -670,8 +673,8 @@ pub async fn route_resources<RH: ResourceHandler + Send + Sync>(
 ///     return result;
 /// }
 /// ```
-pub async fn route_prompts<PH: PromptHandler + Send + Sync>(
-    handler: &PH,
+pub async fn route_prompts(
+    handler: &dyn DynPromptHandler,
     method: &str,
     params: Option<&serde_json::Value>,
     ctx: &Context<'_>,

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -32,15 +32,16 @@
 //! assert!(!state.is_initialized());
 //! ```
 
-use crate::builder::{NotRegistered, Registered, Server};
+use crate::builder::Server;
 use crate::context::{CancellationToken, Context, Peer};
-use crate::handler::{PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use crate::dispatch::{PromptSlot, ResourceSlot, ToolSlot};
+use crate::handler::ServerHandler;
+use crate::router::{route_prompts, route_resources, route_tools};
 use futures::channel::oneshot;
 use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
 use mcpkit_core::error::McpError;
 use mcpkit_core::protocol::{Message, Notification, ProgressToken, Request, RequestId, Response};
 use mcpkit_core::protocol_version::ProtocolVersion;
-use mcpkit_core::types::CallToolResult;
 use mcpkit_transport::Transport;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -822,417 +823,55 @@ where
 }
 
 // ============================================================================
-// RequestRouter implementations via macro
+// Request routing
 // ============================================================================
 
-// Internal routing functions to reduce code duplication.
-// Each function handles a specific handler type's methods.
-
-async fn route_tools<TH: ToolHandler + Send + Sync>(
-    handler: &TH,
-    method: &str,
-    params: Option<&serde_json::Value>,
-    ctx: &Context<'_>,
-) -> Option<Result<serde_json::Value, McpError>> {
-    match method {
-        "tools/list" => {
-            tracing::debug!("Listing available tools");
-            let result = handler.list_tools(ctx).await;
-            match &result {
-                Ok(tools) => tracing::debug!(count = tools.len(), "Listed tools"),
-                Err(e) => tracing::warn!(error = %e, "Failed to list tools"),
-            }
-            Some(result.map(|tools| serde_json::json!({ "tools": tools })))
-        }
-        "tools/call" => {
-            let result = async {
-                let params = params.ok_or_else(|| {
-                    McpError::invalid_params("tools/call", "missing params")
-                })?;
-                let name = params.get("name")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| McpError::invalid_params("tools/call", "missing tool name"))?;
-                let args = params.get("arguments")
-                    .cloned()
-                    .unwrap_or_else(|| serde_json::json!({}));
-
-                tracing::info!(tool = %name, "Calling tool");
-                let start = std::time::Instant::now();
-                let output = handler.call_tool(name, args, ctx).await;
-                let duration = start.elapsed();
-
-                match &output {
-                    Ok(_) => tracing::info!(tool = %name, duration_ms = duration.as_millis(), "Tool call completed"),
-                    Err(e) => tracing::warn!(tool = %name, duration_ms = duration.as_millis(), error = %e, "Tool call failed"),
-                }
-
-                let output = output?;
-                let result: CallToolResult = output.into();
-                Ok(serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})))
-            }.await;
-            Some(result)
-        }
-        _ => None,
-    }
-}
-
-async fn route_resources<RH: ResourceHandler + Send + Sync>(
-    handler: &RH,
-    method: &str,
-    params: Option<&serde_json::Value>,
-    ctx: &Context<'_>,
-) -> Option<Result<serde_json::Value, McpError>> {
-    match method {
-        "resources/list" => {
-            tracing::debug!("Listing available resources");
-            let result = handler.list_resources(ctx).await;
-            match &result {
-                Ok(resources) => tracing::debug!(count = resources.len(), "Listed resources"),
-                Err(e) => tracing::warn!(error = %e, "Failed to list resources"),
-            }
-            Some(result.map(|resources| serde_json::json!({ "resources": resources })))
-        }
-        "resources/templates/list" => {
-            tracing::debug!("Listing available resource templates");
-            let result = handler.list_resource_templates(ctx).await;
-            match &result {
-                Ok(templates) => {
-                    tracing::debug!(count = templates.len(), "Listed resource templates");
-                }
-                Err(e) => tracing::warn!(error = %e, "Failed to list resource templates"),
-            }
-            Some(result.map(|templates| serde_json::json!({ "resourceTemplates": templates })))
-        }
-        "resources/read" => {
-            let result = async {
-                let params = params.ok_or_else(|| {
-                    McpError::invalid_params("resources/read", "missing params")
-                })?;
-                let uri = params.get("uri")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| McpError::invalid_params("resources/read", "missing uri"))?;
-
-                tracing::info!(uri = %uri, "Reading resource");
-                let start = std::time::Instant::now();
-                let contents = handler.read_resource(uri, ctx).await;
-                let duration = start.elapsed();
-
-                match &contents {
-                    Ok(_) => tracing::info!(uri = %uri, duration_ms = duration.as_millis(), "Resource read completed"),
-                    Err(e) => tracing::warn!(uri = %uri, duration_ms = duration.as_millis(), error = %e, "Resource read failed"),
-                }
-
-                let contents = contents?;
-                Ok(serde_json::json!({ "contents": contents }))
-            }.await;
-            Some(result)
-        }
-        _ => None,
-    }
-}
-
-async fn route_prompts<PH: PromptHandler + Send + Sync>(
-    handler: &PH,
-    method: &str,
-    params: Option<&serde_json::Value>,
-    ctx: &Context<'_>,
-) -> Option<Result<serde_json::Value, McpError>> {
-    match method {
-        "prompts/list" => {
-            tracing::debug!("Listing available prompts");
-            let result = handler.list_prompts(ctx).await;
-            match &result {
-                Ok(prompts) => tracing::debug!(count = prompts.len(), "Listed prompts"),
-                Err(e) => tracing::warn!(error = %e, "Failed to list prompts"),
-            }
-            Some(result.map(|prompts| serde_json::json!({ "prompts": prompts })))
-        }
-        "prompts/get" => {
-            let result = async {
-                let params = params.ok_or_else(|| {
-                    McpError::invalid_params("prompts/get", "missing params")
-                })?;
-                let name = params.get("name")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| McpError::invalid_params("prompts/get", "missing prompt name"))?;
-                let args = params.get("arguments")
-                    .and_then(|v| v.as_object())
-                    .cloned();
-
-                tracing::info!(prompt = %name, "Getting prompt");
-                let start = std::time::Instant::now();
-                let prompt_result = handler.get_prompt(name, args, ctx).await;
-                let duration = start.elapsed();
-
-                match &prompt_result {
-                    Ok(_) => tracing::info!(prompt = %name, duration_ms = duration.as_millis(), "Prompt retrieval completed"),
-                    Err(e) => tracing::warn!(prompt = %name, duration_ms = duration.as_millis(), error = %e, "Prompt retrieval failed"),
-                }
-
-                let result = prompt_result?;
-                Ok(serde_json::to_value(result).unwrap_or_else(|_| serde_json::json!({})))
-            }.await;
-            Some(result)
-        }
-        _ => None,
-    }
-}
-
-/// Macro to generate `RequestRouter` implementations for all handler combinations.
+/// Single [`RequestRouter`] implementation over the typestate handler slots.
 ///
-/// This macro reduces code duplication by generating all 2^3 = 8 combinations
-/// of tool/resource/prompt handler registration states.
-macro_rules! impl_request_router {
-    // Base case: no handlers
-    (base; $($bounds:tt)*) => {
-        impl<H $($bounds)*> RequestRouter for Server<H, NotRegistered, NotRegistered, NotRegistered, NotRegistered>
-        where
-            H: ServerHandler + Send + Sync,
-        {
-            fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
-                self.handler().server_info()
-            }
+/// Each capability is a slot (`Registered<H>` / `NotRegistered`) exposing an
+/// optional object-safe handler; routing checks each in turn. Adding a
+/// dispatched capability is one slot plus one arm here -- there is no
+/// per-combination explosion. The shared per-method routing logic lives in
+/// [`crate::router`].
+impl<H, T, R, P, K> RequestRouter for Server<H, T, R, P, K>
+where
+    H: ServerHandler + Send + Sync,
+    T: ToolSlot,
+    R: ResourceSlot,
+    P: PromptSlot,
+    K: Send + Sync,
+{
+    fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
+        self.handler().server_info()
+    }
 
-            async fn route(
-                &self,
-                method: &str,
-                _params: Option<&serde_json::Value>,
-                _ctx: &Context<'_>,
-            ) -> Result<serde_json::Value, McpError> {
-                match method {
-                    "ping" => Ok(serde_json::json!({})),
-                    _ => Err(McpError::method_not_found(method)),
-                }
+    async fn route(
+        &self,
+        method: &str,
+        params: Option<&serde_json::Value>,
+        ctx: &Context<'_>,
+    ) -> Result<serde_json::Value, McpError> {
+        if method == "ping" {
+            return Ok(serde_json::json!({}));
+        }
+        if let Some(handler) = self.tools.as_tool_handler() {
+            if let Some(result) = route_tools(handler, method, params, ctx).await {
+                return result;
             }
         }
-    };
-
-    // Tools only
-    (tools; $($bounds:tt)*) => {
-        impl<H, TH $($bounds)*> RequestRouter for Server<H, Registered<TH>, NotRegistered, NotRegistered, NotRegistered>
-        where
-            H: ServerHandler + Send + Sync,
-            TH: ToolHandler + Send + Sync,
-        {
-            fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
-                self.handler().server_info()
-            }
-
-            async fn route(
-                &self,
-                method: &str,
-                params: Option<&serde_json::Value>,
-                ctx: &Context<'_>,
-            ) -> Result<serde_json::Value, McpError> {
-                if method == "ping" {
-                    return Ok(serde_json::json!({}));
-                }
-                if let Some(result) = route_tools(self.tool_handler(), method, params, ctx).await {
-                    return result;
-                }
-                Err(McpError::method_not_found(method))
+        if let Some(handler) = self.resources.as_resource_handler() {
+            if let Some(result) = route_resources(handler, method, params, ctx).await {
+                return result;
             }
         }
-    };
-
-    // Resources only
-    (resources; $($bounds:tt)*) => {
-        impl<H, RH $($bounds)*> RequestRouter for Server<H, NotRegistered, Registered<RH>, NotRegistered, NotRegistered>
-        where
-            H: ServerHandler + Send + Sync,
-            RH: ResourceHandler + Send + Sync,
-        {
-            fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
-                self.handler().server_info()
-            }
-
-            async fn route(
-                &self,
-                method: &str,
-                params: Option<&serde_json::Value>,
-                ctx: &Context<'_>,
-            ) -> Result<serde_json::Value, McpError> {
-                if method == "ping" {
-                    return Ok(serde_json::json!({}));
-                }
-                if let Some(result) = route_resources(self.resource_handler(), method, params, ctx).await {
-                    return result;
-                }
-                Err(McpError::method_not_found(method))
+        if let Some(handler) = self.prompts.as_prompt_handler() {
+            if let Some(result) = route_prompts(handler, method, params, ctx).await {
+                return result;
             }
         }
-    };
-
-    // Prompts only
-    (prompts; $($bounds:tt)*) => {
-        impl<H, PH $($bounds)*> RequestRouter for Server<H, NotRegistered, NotRegistered, Registered<PH>, NotRegistered>
-        where
-            H: ServerHandler + Send + Sync,
-            PH: PromptHandler + Send + Sync,
-        {
-            fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
-                self.handler().server_info()
-            }
-
-            async fn route(
-                &self,
-                method: &str,
-                params: Option<&serde_json::Value>,
-                ctx: &Context<'_>,
-            ) -> Result<serde_json::Value, McpError> {
-                if method == "ping" {
-                    return Ok(serde_json::json!({}));
-                }
-                if let Some(result) = route_prompts(self.prompt_handler(), method, params, ctx).await {
-                    return result;
-                }
-                Err(McpError::method_not_found(method))
-            }
-        }
-    };
-
-    // Tools + Resources
-    (tools_resources; $($bounds:tt)*) => {
-        impl<H, TH, RH $($bounds)*> RequestRouter for Server<H, Registered<TH>, Registered<RH>, NotRegistered, NotRegistered>
-        where
-            H: ServerHandler + Send + Sync,
-            TH: ToolHandler + Send + Sync,
-            RH: ResourceHandler + Send + Sync,
-        {
-            fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
-                self.handler().server_info()
-            }
-
-            async fn route(
-                &self,
-                method: &str,
-                params: Option<&serde_json::Value>,
-                ctx: &Context<'_>,
-            ) -> Result<serde_json::Value, McpError> {
-                if method == "ping" {
-                    return Ok(serde_json::json!({}));
-                }
-                if let Some(result) = route_tools(self.tool_handler(), method, params, ctx).await {
-                    return result;
-                }
-                if let Some(result) = route_resources(self.resource_handler(), method, params, ctx).await {
-                    return result;
-                }
-                Err(McpError::method_not_found(method))
-            }
-        }
-    };
-
-    // Tools + Prompts
-    (tools_prompts; $($bounds:tt)*) => {
-        impl<H, TH, PH $($bounds)*> RequestRouter for Server<H, Registered<TH>, NotRegistered, Registered<PH>, NotRegistered>
-        where
-            H: ServerHandler + Send + Sync,
-            TH: ToolHandler + Send + Sync,
-            PH: PromptHandler + Send + Sync,
-        {
-            fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
-                self.handler().server_info()
-            }
-
-            async fn route(
-                &self,
-                method: &str,
-                params: Option<&serde_json::Value>,
-                ctx: &Context<'_>,
-            ) -> Result<serde_json::Value, McpError> {
-                if method == "ping" {
-                    return Ok(serde_json::json!({}));
-                }
-                if let Some(result) = route_tools(self.tool_handler(), method, params, ctx).await {
-                    return result;
-                }
-                if let Some(result) = route_prompts(self.prompt_handler(), method, params, ctx).await {
-                    return result;
-                }
-                Err(McpError::method_not_found(method))
-            }
-        }
-    };
-
-    // Resources + Prompts
-    (resources_prompts; $($bounds:tt)*) => {
-        impl<H, RH, PH $($bounds)*> RequestRouter for Server<H, NotRegistered, Registered<RH>, Registered<PH>, NotRegistered>
-        where
-            H: ServerHandler + Send + Sync,
-            RH: ResourceHandler + Send + Sync,
-            PH: PromptHandler + Send + Sync,
-        {
-            fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
-                self.handler().server_info()
-            }
-
-            async fn route(
-                &self,
-                method: &str,
-                params: Option<&serde_json::Value>,
-                ctx: &Context<'_>,
-            ) -> Result<serde_json::Value, McpError> {
-                if method == "ping" {
-                    return Ok(serde_json::json!({}));
-                }
-                if let Some(result) = route_resources(self.resource_handler(), method, params, ctx).await {
-                    return result;
-                }
-                if let Some(result) = route_prompts(self.prompt_handler(), method, params, ctx).await {
-                    return result;
-                }
-                Err(McpError::method_not_found(method))
-            }
-        }
-    };
-
-    // Tools + Resources + Prompts
-    (tools_resources_prompts; $($bounds:tt)*) => {
-        impl<H, TH, RH, PH $($bounds)*> RequestRouter for Server<H, Registered<TH>, Registered<RH>, Registered<PH>, NotRegistered>
-        where
-            H: ServerHandler + Send + Sync,
-            TH: ToolHandler + Send + Sync,
-            RH: ResourceHandler + Send + Sync,
-            PH: PromptHandler + Send + Sync,
-        {
-            fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
-                self.handler().server_info()
-            }
-
-            async fn route(
-                &self,
-                method: &str,
-                params: Option<&serde_json::Value>,
-                ctx: &Context<'_>,
-            ) -> Result<serde_json::Value, McpError> {
-                if method == "ping" {
-                    return Ok(serde_json::json!({}));
-                }
-                if let Some(result) = route_tools(self.tool_handler(), method, params, ctx).await {
-                    return result;
-                }
-                if let Some(result) = route_resources(self.resource_handler(), method, params, ctx).await {
-                    return result;
-                }
-                if let Some(result) = route_prompts(self.prompt_handler(), method, params, ctx).await {
-                    return result;
-                }
-                Err(McpError::method_not_found(method))
-            }
-        }
-    };
+        Err(McpError::method_not_found(method))
+    }
 }
-
-// Generate all RequestRouter implementations
-impl_request_router!(base;);
-impl_request_router!(tools;);
-impl_request_router!(resources;);
-impl_request_router!(prompts;);
-impl_request_router!(tools_resources;);
-impl_request_router!(tools_prompts;);
-impl_request_router!(resources_prompts;);
-impl_request_router!(tools_resources_prompts;);
 
 // ============================================================================
 // Helper functions


### PR DESCRIPTION
Closes #117. Foundational refactor before resuming #81 (and ahead of #107/#108/#110/#111/#112). **Behavior-preserving** — no new functionality.

## Problem

Server-side dispatch did not scale. `ServerRuntime` routing was a combinatorial typestate macro (`impl_request_router!`) generating one `RequestRouter` impl per combination of `{tools, resources, prompts}` (2³ = 8 impls) — and the 4th typestate slot, **tasks**, was never wired in. Adding tasks would double the matrix to 16; logging → 32; roots → 64. The per-method routing logic was also duplicated between `server.rs` (private) and `router.rs` (public, used by the adapters).

## Change

- New `mcpkit_server::dispatch` module: object-safe `DynToolHandler`/`DynResourceHandler`/`DynPromptHandler` (boxed futures) blanket-impl'd over the public RPITIT handler traits, plus `ToolSlot`/`ResourceSlot`/`PromptSlot` over `Registered`/`NotRegistered`.
- One `impl<H, T, R, P, K> RequestRouter for Server` dispatches by checking each slot — replacing the 8 macro-generated impls.
- Deleted `server.rs`'s private `route_*`; the single source is `router.rs`, whose `route_*` now take `&dyn Dyn*Handler` and are shared by the runtime and all four adapters (a concrete `&handler` coerces in, so adapter call sites are unchanged).
- `Server`'s tool/resource/prompt fields are `pub(crate)` so the slots can borrow them.

Net **−158 lines**. Adding a dispatched capability is now one slot + one match arm, in one place.

## What I deliberately left alone

- No `build()`/`serve()`/handler-trait API changes; the typestate **builder** is untouched (keeps its compile-time "register once" ergonomics).
- Tasks are still **not** dispatched (intentional — that's #81 PR2, now trivial).
- `subscribe`/`unsubscribe` still parsed-but-not-routed (unchanged; #107).
- Did not unify the adapters' dispatch loop onto the erased `Server` (the "bold" option) — out of scope, higher risk.

## Breaking

Minor: `route_tools`/`route_resources`/`route_prompts` signatures changed from `<H: ToolHandler>(&H, ..)` to `(&dyn DynToolHandler, ..)`. A `&handler` reference still coerces in.

## Verification

Behavior-preservation independently re-verified by a separate agent (re-ran the full gate, grepped the macro is gone, confirmed dispatch order/methods unchanged and all 4 adapters consume the shared `route_*`):
- `cargo fmt --all -- --check` — clean
- `cargo clippy --workspace --all-features --all-targets -- -D warnings` — clean
- `cargo test --workspace --all-features --locked` — **1259 passed, 0 failed** (0 tests added/removed/newly-ignored)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps` — clean