### PR TITLE
feat(server): advertise tasks capability and dispatch tasks/* (#81 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compile error). **Breaking:** these structs have public fields, so code that
   constructs them with a struct literal must add the new fields
   ([#79](https://github.com/praxiomlabs/mcpkit/issues/79)).
+- MCP Tasks dispatch and capability advertisement. `ServerBuilder::with_tasks`
+  now advertises the `tasks` capability (previously it registered the handler
+  but left the capability unadvertised), and the server routes `tasks/list`,
+  `tasks/get`, and `tasks/cancel` to the registered `TaskHandler` via a new
+  `mcpkit_server::router::route_tasks` (`tasks/get`/`tasks/cancel` return the
+  task; unknown task ids are reported as errors). Wired through the consolidated
+  slot dispatch (a `DynTaskHandler`/`TaskSlot` pair). `tasks/result` and the
+  task-augmented `tools/call` flow are the next step; task dispatch on the
+  framework adapters is a follow-up
+  ([#81](https://github.com/praxiomlabs/mcpkit/issues/81)).
 
 ### Changed
 

--- a/crates/mcpkit-server/src/builder.rs
+++ b/crates/mcpkit-server/src/builder.rs
@@ -239,8 +239,7 @@ where
             resources: self.resources,
             prompts: self.prompts,
             tasks: Registered(tasks),
-            // Note: capabilities.with_tasks() would be added when supported
-            capabilities: self.capabilities,
+            capabilities: self.capabilities.with_tasks(),
         }
     }
 }
@@ -283,7 +282,7 @@ pub struct Server<H, T, R, P, K> {
     pub(crate) tools: T,
     pub(crate) resources: R,
     pub(crate) prompts: P,
-    tasks: K,
+    pub(crate) tasks: K,
     capabilities: ServerCapabilities,
 }
 
@@ -425,6 +424,41 @@ mod tests {
         assert!(server.capabilities().has_tools());
         // This compiles because tools are registered
         let _tool_handler: &TestToolHandler = server.tool_handler();
+    }
+
+    struct TestTaskHandler;
+
+    impl crate::handler::TaskHandler for TestTaskHandler {
+        async fn list_tasks(
+            &self,
+            _ctx: &Context<'_>,
+        ) -> Result<Vec<mcpkit_core::types::Task>, McpError> {
+            Ok(vec![])
+        }
+        async fn get_task(
+            &self,
+            _id: &mcpkit_core::types::TaskId,
+            _ctx: &Context<'_>,
+        ) -> Result<Option<mcpkit_core::types::Task>, McpError> {
+            Ok(None)
+        }
+        async fn cancel_task(
+            &self,
+            _id: &mcpkit_core::types::TaskId,
+            _ctx: &Context<'_>,
+        ) -> Result<bool, McpError> {
+            Ok(false)
+        }
+    }
+
+    #[test]
+    fn test_server_builder_with_tasks_advertises_capability() {
+        // Registering a TaskHandler must advertise the `tasks` capability (#81).
+        let server = ServerBuilder::new(TestHandler)
+            .with_tasks(TestTaskHandler)
+            .build();
+
+        assert!(server.capabilities().has_tasks());
     }
 
     #[test]

--- a/crates/mcpkit-server/src/dispatch.rs
+++ b/crates/mcpkit-server/src/dispatch.rs
@@ -13,10 +13,11 @@
 
 use crate::builder::{NotRegistered, Registered};
 use crate::context::Context;
-use crate::handler::{PromptHandler, ResourceHandler, ToolHandler};
+use crate::handler::{PromptHandler, ResourceHandler, TaskHandler, ToolHandler};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    GetPromptResult, Prompt, Resource, ResourceContents, ResourceTemplate, Tool, ToolOutput,
+    GetPromptResult, Prompt, Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool,
+    ToolOutput,
 };
 use serde_json::Value;
 use std::future::Future;
@@ -132,6 +133,44 @@ impl<P: PromptHandler> DynPromptHandler for P {
     }
 }
 
+/// Object-safe form of [`TaskHandler`].
+pub trait DynTaskHandler: Send + Sync {
+    /// See [`TaskHandler::list_tasks`].
+    fn list_tasks<'a>(&'a self, ctx: &'a Context<'_>) -> BoxFut<'a, Result<Vec<Task>, McpError>>;
+    /// See [`TaskHandler::get_task`].
+    fn get_task<'a>(
+        &'a self,
+        id: &'a TaskId,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Option<Task>, McpError>>;
+    /// See [`TaskHandler::cancel_task`].
+    fn cancel_task<'a>(
+        &'a self,
+        id: &'a TaskId,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<bool, McpError>>;
+}
+
+impl<K: TaskHandler> DynTaskHandler for K {
+    fn list_tasks<'a>(&'a self, ctx: &'a Context<'_>) -> BoxFut<'a, Result<Vec<Task>, McpError>> {
+        Box::pin(TaskHandler::list_tasks(self, ctx))
+    }
+    fn get_task<'a>(
+        &'a self,
+        id: &'a TaskId,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Option<Task>, McpError>> {
+        Box::pin(TaskHandler::get_task(self, id, ctx))
+    }
+    fn cancel_task<'a>(
+        &'a self,
+        id: &'a TaskId,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<bool, McpError>> {
+        Box::pin(TaskHandler::cancel_task(self, id, ctx))
+    }
+}
+
 // ============================================================================
 // Typestate slots: expose `Option<&dyn Dyn*Handler>` for both `Registered<H>`
 // and `NotRegistered`, so one router impl can be generic over the slots.
@@ -181,6 +220,22 @@ impl PromptSlot for NotRegistered {
 }
 impl<P: PromptHandler> PromptSlot for Registered<P> {
     fn as_prompt_handler(&self) -> Option<&dyn DynPromptHandler> {
+        Some(&self.0)
+    }
+}
+
+/// A task-handler slot.
+pub trait TaskSlot: Send + Sync {
+    /// The registered task handler, or `None`.
+    fn as_task_handler(&self) -> Option<&dyn DynTaskHandler>;
+}
+impl TaskSlot for NotRegistered {
+    fn as_task_handler(&self) -> Option<&dyn DynTaskHandler> {
+        None
+    }
+}
+impl<K: TaskHandler> TaskSlot for Registered<K> {
+    fn as_task_handler(&self) -> Option<&dyn DynTaskHandler> {
         Some(&self.0)
     }
 }

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -507,8 +507,8 @@ fn parse_list_params(params: Option<&Value>) -> ListParams {
 // =============================================================================
 
 use crate::context::Context;
-use crate::dispatch::{DynPromptHandler, DynResourceHandler, DynToolHandler};
-use mcpkit_core::types::CallToolResult;
+use crate::dispatch::{DynPromptHandler, DynResourceHandler, DynTaskHandler, DynToolHandler};
+use mcpkit_core::types::{CallToolResult, TaskId};
 
 /// Route tool-related requests to a handler implementing
 /// [`ToolHandler`](crate::handler::ToolHandler).
@@ -726,6 +726,71 @@ pub async fn route_prompts(
         }
         _ => None,
     }
+}
+
+/// Route task-related requests to a handler implementing
+/// [`TaskHandler`](crate::handler::TaskHandler).
+///
+/// Handles `tasks/list`, `tasks/get`, and `tasks/cancel`. Returns `None` if the
+/// method is not task-related. (`tasks/result` is handled by the task-augmented
+/// call flow, not here.)
+pub async fn route_tasks(
+    handler: &dyn DynTaskHandler,
+    method: &str,
+    params: Option<&serde_json::Value>,
+    ctx: &Context<'_>,
+) -> Option<Result<serde_json::Value, McpError>> {
+    match method {
+        methods::TASKS_LIST => {
+            let result = handler.list_tasks(ctx).await;
+            Some(result.map(|tasks| serde_json::json!({ "tasks": tasks })))
+        }
+        methods::TASKS_GET => {
+            let result = async {
+                let id = parse_task_id(params, methods::TASKS_GET)?;
+                match handler.get_task(&id, ctx).await? {
+                    Some(task) => Ok(serde_json::to_value(task).unwrap_or_default()),
+                    None => Err(McpError::invalid_params(
+                        methods::TASKS_GET,
+                        format!("unknown task: {id}"),
+                    )),
+                }
+            }
+            .await;
+            Some(result)
+        }
+        methods::TASKS_CANCEL => {
+            let result = async {
+                let id = parse_task_id(params, methods::TASKS_CANCEL)?;
+                if !handler.cancel_task(&id, ctx).await? {
+                    return Err(McpError::invalid_params(
+                        methods::TASKS_CANCEL,
+                        format!("unknown task: {id}"),
+                    ));
+                }
+                // CancelTaskResult is `Result & Task`: return the cancelled task.
+                match handler.get_task(&id, ctx).await? {
+                    Some(task) => Ok(serde_json::to_value(task).unwrap_or_default()),
+                    None => Ok(serde_json::json!({})),
+                }
+            }
+            .await;
+            Some(result)
+        }
+        _ => None,
+    }
+}
+
+/// Extract a required `taskId` parameter.
+fn parse_task_id(
+    params: Option<&serde_json::Value>,
+    method: &'static str,
+) -> Result<TaskId, McpError> {
+    let task_id = params
+        .and_then(|p| p.get("taskId"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| McpError::invalid_params(method, "missing taskId"))?;
+    Ok(TaskId::new(task_id))
 }
 
 #[cfg(test)]
@@ -1239,6 +1304,60 @@ mod tests {
         assert_eq!(
             notifications::PROMPTS_LIST_CHANGED,
             "notifications/prompts/list_changed"
+        );
+    }
+
+    #[tokio::test]
+    async fn route_tasks_dispatches_list_get_cancel() {
+        use crate::capability::tasks::TaskService;
+        use crate::context::NoOpPeer;
+        use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+        use mcpkit_core::protocol::RequestId;
+        use mcpkit_core::protocol_version::ProtocolVersion;
+
+        let service = TaskService::new();
+        let request_id = RequestId::Number(1);
+        let client_caps = ClientCapabilities::default();
+        let server_caps = ServerCapabilities::default();
+        let peer = NoOpPeer;
+        let ctx = Context::new(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            ProtocolVersion::LATEST,
+            &peer,
+        );
+
+        // tasks/list -> { "tasks": [] } (no tasks registered).
+        let listed = route_tasks(&service, methods::TASKS_LIST, None, &ctx)
+            .await
+            .expect("tasks/list is routed")
+            .expect("ok");
+        assert_eq!(listed, serde_json::json!({ "tasks": [] }));
+
+        // tasks/get with a missing taskId is a routed error.
+        let got = route_tasks(&service, methods::TASKS_GET, None, &ctx)
+            .await
+            .expect("tasks/get is routed");
+        assert!(got.is_err());
+
+        // An unknown task id is a routed error, not a panic.
+        let cancel = route_tasks(
+            &service,
+            methods::TASKS_CANCEL,
+            Some(&serde_json::json!({ "taskId": "nope" })),
+            &ctx,
+        )
+        .await
+        .expect("tasks/cancel is routed");
+        assert!(cancel.is_err());
+
+        // A non-task method is not handled here.
+        assert!(
+            route_tasks(&service, methods::TOOLS_LIST, None, &ctx)
+                .await
+                .is_none()
         );
     }
 }

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -34,9 +34,9 @@
 
 use crate::builder::Server;
 use crate::context::{CancellationToken, Context, Peer};
-use crate::dispatch::{PromptSlot, ResourceSlot, ToolSlot};
+use crate::dispatch::{PromptSlot, ResourceSlot, TaskSlot, ToolSlot};
 use crate::handler::ServerHandler;
-use crate::router::{route_prompts, route_resources, route_tools};
+use crate::router::{route_prompts, route_resources, route_tasks, route_tools};
 use futures::channel::oneshot;
 use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
 use mcpkit_core::error::McpError;
@@ -839,7 +839,7 @@ where
     T: ToolSlot,
     R: ResourceSlot,
     P: PromptSlot,
-    K: Send + Sync,
+    K: TaskSlot,
 {
     fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
         self.handler().server_info()
@@ -866,6 +866,11 @@ where
         }
         if let Some(handler) = self.prompts.as_prompt_handler() {
             if let Some(result) = route_prompts(handler, method, params, ctx).await {
+                return result;
+            }
+        }
+        if let Some(handler) = self.tasks.as_task_handler() {
+            if let Some(result) = route_tasks(handler, method, params, ctx).await {
                 return result;
             }
         }


### PR DESCRIPTION
Second of three for #81 (PR1 = task types, merged in #116). Builds on the dispatch consolidation (#118).

## What

- **Capability advertisement:** `ServerBuilder::with_tasks` now calls `.with_tasks()` on the advertised capabilities. Previously it registered the `TaskHandler` but left the `tasks` capability flag off (the `// would be added when supported` TODO) — so a task-supporting server didn't announce `tasks`.
- **Dispatch:** new `mcpkit_server::router::route_tasks` handles `tasks/list`, `tasks/get`, `tasks/cancel`, routing to the registered `TaskHandler`. `tasks/get`/`tasks/cancel` return the task (spec `Result & Task`); a missing/unknown `taskId` is a routed error, not a panic.
- Wired through the consolidated slot dispatch from #118: a `DynTaskHandler` + `TaskSlot` pair, and one new arm in the single `RequestRouter` impl (`K: TaskSlot`). This is the "one slot + one arm" payoff of the refactor.

Capability and dispatch land **together** (no #107-style advertise-without-handle).

## Deliberately deferred

- `tasks/result` (`GetTaskPayloadRequest`) — the payload only exists after a task-augmented call, so it's coherent with PR3's augmented-`tools/call` flow, not before it.
- Task dispatch on the **framework adapters** — they use a single combined-handler model; whether the macro generates `TaskHandler` or adapters accept a separate task handler is a follow-up decision. The builder/`ServerRuntime` path is complete.

## Test plan

- New: `with_tasks` advertises the capability (`has_tasks()`); `route_tasks` dispatches list/get/cancel (empty list, missing-`taskId` error, unknown-id error, non-task method → `None`).
- `cargo fmt --all --check`, `clippy --workspace --all-features --all-targets -D warnings`, `cargo test --workspace --all-features --locked`, `cargo doc -D warnings` — all green.

Spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/tasks