### PR TITLE
feat(auth): VerifiedUser + session-to-user binding APIs (#86 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Session-to-verified-user binding (security). A new
+  `mcpkit_core::auth::VerifiedUser` (`subject` + `issuer` + `audience`) models an
+  identity verified from an access token, and `check_session_binding` enforces
+  that a session bound to a user is only ever used by that same user (identity is
+  the `(issuer, subject)` pair; audience is recorded but not part of equality —
+  validate it at the token boundary). Each adapter session store
+  (`mcpkit-axum`/`mcpkit-actix`/`mcpkit-warp`/`mcpkit-rocket`) gains
+  `create_for_user(..)` plus `touch_verified(..)` (and `get_verified(..)` on
+  axum/actix) that reject a mismatched, missing, or unexpectedly-present identity;
+  the adapter `Session` carries an `Option<VerifiedUser>`. Token validation stays
+  pluggable (use the JWT helpers + `VerifiedUser::from_claims`); this is the
+  store-level mechanism, with adapter handler wiring (POST + SSE) to follow
+  ([#86](https://github.com/praxiomlabs/mcpkit/issues/86)).
 - Structured tool output (MCP `outputSchema` / `structuredContent`): `Tool` gains
   an `output_schema` field + `Tool::output_schema(..)`, and `CallToolResult` gains
   a `structured_content` field + `CallToolResult::with_structured_content(..)`.

--- a/crates/mcpkit-actix/src/session.rs
+++ b/crates/mcpkit-actix/src/session.rs
@@ -1,6 +1,7 @@
 //! Session management for MCP HTTP connections.
 
 use dashmap::DashMap;
+use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use std::collections::VecDeque;
@@ -35,12 +36,21 @@ pub struct Session {
     pub client_capabilities: Option<ClientCapabilities>,
     /// Protocol version negotiated during initialization.
     pub protocol_version: Option<ProtocolVersion>,
+    /// The verified user this session is bound to, if any. Once bound, the
+    /// session may only be used by the same user (see [`SessionBindingError`]).
+    pub user: Option<VerifiedUser>,
 }
 
 impl Session {
-    /// Create a new session.
+    /// Create a new anonymous session.
     #[must_use]
     pub fn new(id: String) -> Self {
+        Self::with_user(id, None)
+    }
+
+    /// Create a new session bound to an optional verified user.
+    #[must_use]
+    pub fn with_user(id: String, user: Option<VerifiedUser>) -> Self {
         let now = Instant::now();
         Self {
             id,
@@ -49,6 +59,7 @@ impl Session {
             initialized: false,
             client_capabilities: None,
             protocol_version: None,
+            user,
         }
     }
 
@@ -520,9 +531,19 @@ impl SessionStore {
     /// background cleanup task.
     #[must_use]
     pub fn create(&self) -> String {
+        self.create_for_user(None)
+    }
+
+    /// Create a new session bound to an optional verified user.
+    ///
+    /// A session created with `Some(user)` may then only be used by that same
+    /// user (see [`SessionStore::get_verified`]).
+    #[must_use]
+    pub fn create_for_user(&self, user: Option<VerifiedUser>) -> String {
         self.cleanup_expired();
         let id = uuid::Uuid::new_v4().to_string();
-        self.sessions.insert(id.clone(), Session::new(id.clone()));
+        self.sessions
+            .insert(id.clone(), Session::with_user(id.clone(), user));
         id
     }
 
@@ -532,11 +553,46 @@ impl SessionStore {
         self.sessions.get(id).map(|r| r.clone())
     }
 
+    /// Get a session by ID, enforcing its user binding against the identity
+    /// presenting this request.
+    ///
+    /// Returns `Ok(None)` if no such session exists, `Ok(Some(session))` if the
+    /// binding holds, or `Err` if the presenting identity does not match the
+    /// session's bound user.
+    pub fn get_verified(
+        &self,
+        id: &str,
+        presenting: Option<&VerifiedUser>,
+    ) -> Result<Option<Session>, SessionBindingError> {
+        let Some(session) = self.get(id) else {
+            return Ok(None);
+        };
+        check_session_binding(session.user.as_ref(), presenting)?;
+        Ok(Some(session))
+    }
+
     /// Touch a session to update its last active time.
     pub fn touch(&self, id: &str) {
         if let Some(mut session) = self.sessions.get_mut(id) {
             session.touch();
         }
+    }
+
+    /// Touch a session, enforcing its user binding first.
+    ///
+    /// Returns `Ok(true)` if the session existed and was touched, `Ok(false)` if
+    /// it did not exist, or `Err` on a binding violation.
+    pub fn touch_verified(
+        &self,
+        id: &str,
+        presenting: Option<&VerifiedUser>,
+    ) -> Result<bool, SessionBindingError> {
+        let Some(mut session) = self.sessions.get_mut(id) else {
+            return Ok(false);
+        };
+        check_session_binding(session.user.as_ref(), presenting)?;
+        session.touch();
+        Ok(true)
     }
 
     /// Update a session.

--- a/crates/mcpkit-axum/src/session.rs
+++ b/crates/mcpkit-axum/src/session.rs
@@ -1,6 +1,7 @@
 //! Session management for MCP HTTP connections.
 
 use dashmap::DashMap;
+use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use std::collections::VecDeque;
@@ -25,12 +26,21 @@ pub struct Session {
     pub client_capabilities: Option<ClientCapabilities>,
     /// Protocol version negotiated during initialization.
     pub protocol_version: Option<ProtocolVersion>,
+    /// The verified user this session is bound to, if any. Once bound, the
+    /// session may only be used by the same user (see [`SessionBindingError`]).
+    pub user: Option<VerifiedUser>,
 }
 
 impl Session {
-    /// Create a new session.
+    /// Create a new anonymous session.
     #[must_use]
     pub fn new(id: String) -> Self {
+        Self::with_user(id, None)
+    }
+
+    /// Create a new session bound to an optional verified user.
+    #[must_use]
+    pub fn with_user(id: String, user: Option<VerifiedUser>) -> Self {
         let now = Instant::now();
         Self {
             id,
@@ -39,6 +49,7 @@ impl Session {
             initialized: false,
             client_capabilities: None,
             protocol_version: None,
+            user,
         }
     }
 
@@ -539,9 +550,19 @@ impl SessionStore {
     /// background cleanup task.
     #[must_use]
     pub fn create(&self) -> String {
+        self.create_for_user(None)
+    }
+
+    /// Create a new session bound to an optional verified user.
+    ///
+    /// A session created with `Some(user)` may then only be used by that same
+    /// user (see [`SessionStore::get_verified`]).
+    #[must_use]
+    pub fn create_for_user(&self, user: Option<VerifiedUser>) -> String {
         self.cleanup_expired();
         let id = uuid::Uuid::new_v4().to_string();
-        self.sessions.insert(id.clone(), Session::new(id.clone()));
+        self.sessions
+            .insert(id.clone(), Session::with_user(id.clone(), user));
         id
     }
 
@@ -551,11 +572,46 @@ impl SessionStore {
         self.sessions.get(id).map(|r| r.clone())
     }
 
+    /// Get a session by ID, enforcing its user binding against the identity
+    /// presenting this request.
+    ///
+    /// Returns `Ok(None)` if no such session exists, `Ok(Some(session))` if the
+    /// binding holds, or `Err` if the presenting identity does not match the
+    /// session's bound user.
+    pub fn get_verified(
+        &self,
+        id: &str,
+        presenting: Option<&VerifiedUser>,
+    ) -> Result<Option<Session>, SessionBindingError> {
+        let Some(session) = self.get(id) else {
+            return Ok(None);
+        };
+        check_session_binding(session.user.as_ref(), presenting)?;
+        Ok(Some(session))
+    }
+
     /// Touch a session to update its last active time.
     pub fn touch(&self, id: &str) {
         if let Some(mut session) = self.sessions.get_mut(id) {
             session.touch();
         }
+    }
+
+    /// Touch a session, enforcing its user binding first.
+    ///
+    /// Returns `Ok(true)` if the session existed and was touched, `Ok(false)` if
+    /// it did not exist, or `Err` on a binding violation.
+    pub fn touch_verified(
+        &self,
+        id: &str,
+        presenting: Option<&VerifiedUser>,
+    ) -> Result<bool, SessionBindingError> {
+        let Some(mut session) = self.sessions.get_mut(id) else {
+            return Ok(false);
+        };
+        check_session_binding(session.user.as_ref(), presenting)?;
+        session.touch();
+        Ok(true)
     }
 
     /// Update a session.
@@ -611,6 +667,43 @@ mod tests {
         assert_eq!(session.id, "test-123");
         assert!(!session.initialized);
         assert!(session.client_capabilities.is_none());
+        assert!(session.user.is_none());
+    }
+
+    #[test]
+    fn user_bound_session_enforces_identity() {
+        let store = SessionStore::new(Duration::from_secs(60));
+        let alice = VerifiedUser::new("alice").issuer("https://idp");
+        let bob = VerifiedUser::new("bob").issuer("https://idp");
+
+        let id = store.create_for_user(Some(alice.clone()));
+
+        // Same user: ok.
+        assert_eq!(store.touch_verified(&id, Some(&alice)), Ok(true));
+        assert!(store.get_verified(&id, Some(&alice)).unwrap().is_some());
+        // Different user: mismatch.
+        assert_eq!(
+            store.touch_verified(&id, Some(&bob)),
+            Err(SessionBindingError::IdentityMismatch)
+        );
+        // Missing identity on a bound session: rejected.
+        assert_eq!(
+            store.get_verified(&id, None).unwrap_err(),
+            SessionBindingError::IdentityRequired
+        );
+
+        // Anonymous session: anonymous ok, but a verified identity is rejected
+        // (no silent upgrade).
+        let anon = store.create();
+        assert_eq!(store.touch_verified(&anon, None), Ok(true));
+        assert_eq!(
+            store.touch_verified(&anon, Some(&alice)),
+            Err(SessionBindingError::UnexpectedIdentity)
+        );
+
+        // Unknown session id: not found, not an error.
+        assert_eq!(store.touch_verified("nope", Some(&alice)), Ok(false));
+        assert!(store.get_verified("nope", Some(&alice)).unwrap().is_none());
     }
 
     #[test]

--- a/crates/mcpkit-core/src/auth/identity.rs
+++ b/crates/mcpkit-core/src/auth/identity.rs
@@ -1,0 +1,184 @@
+//! Verified user identity and session-to-user binding.
+//!
+//! The MCP security best practices require that per-user state is not associated
+//! with a session id alone — user identity should derive from the validated
+//! access token (its `sub`, scoped by `iss`). [`VerifiedUser`] is that identity,
+//! and [`check_session_binding`] enforces that a session bound to a user is only
+//! ever used by that same user.
+
+use serde::{Deserialize, Serialize};
+
+/// A user identity verified from an access token.
+///
+/// Identity is the `(issuer, subject)` pair: a `subject` (`sub`) is only
+/// globally meaningful within its `issuer` (`iss`). `audience` is recorded for
+/// context but is deliberately *not* part of identity equality — validating the
+/// audience is a token-validation concern (is this token meant for this
+/// resource?), and a returning user's token may legitimately be re-issued with a
+/// different audience.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifiedUser {
+    /// The token subject (`sub`).
+    pub subject: String,
+    /// The token issuer (`iss`), if present.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issuer: Option<String>,
+    /// The token audience(s) (`aud`). Context only; not used for binding.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub audience: Vec<String>,
+}
+
+impl VerifiedUser {
+    /// Create a verified user from a subject.
+    #[must_use]
+    pub fn new(subject: impl Into<String>) -> Self {
+        Self {
+            subject: subject.into(),
+            issuer: None,
+            audience: Vec::new(),
+        }
+    }
+
+    /// Set the issuer (`iss`).
+    #[must_use]
+    pub fn issuer(mut self, issuer: impl Into<String>) -> Self {
+        self.issuer = Some(issuer.into());
+        self
+    }
+
+    /// Set the audience(s) (`aud`).
+    #[must_use]
+    pub fn audience<I, S>(mut self, audience: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.audience = audience.into_iter().map(Into::into).collect();
+        self
+    }
+
+    /// Whether two identities are the same user — equal `(issuer, subject)`.
+    ///
+    /// Audience is intentionally not compared.
+    #[must_use]
+    pub fn is_same_user(&self, other: &Self) -> bool {
+        self.subject == other.subject && self.issuer == other.issuer
+    }
+
+    /// Build a verified user from validated JWT claims, or `None` if the token
+    /// has no `sub`.
+    ///
+    /// The caller is responsible for having *validated* the token first; this
+    /// only projects the claims into an identity.
+    #[cfg(feature = "jwt")]
+    #[must_use]
+    pub fn from_claims(claims: &crate::auth::jwt::TokenClaims) -> Option<Self> {
+        use crate::auth::jwt::Audience;
+        let subject = claims.sub.clone()?;
+        let audience = match &claims.aud {
+            Some(Audience::Single(a)) => vec![a.clone()],
+            Some(Audience::Multiple(v)) => v.clone(),
+            None => Vec::new(),
+        };
+        Some(Self {
+            subject,
+            issuer: claims.iss.clone(),
+            audience,
+        })
+    }
+}
+
+/// Why a request was refused against a session's bound identity.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionBindingError {
+    /// The session is bound to a user, but the request presented no identity.
+    IdentityRequired,
+    /// The session is bound to a different user than the request presented.
+    IdentityMismatch,
+    /// The session is anonymous, but the request presented a verified identity.
+    /// A user-bound session must be created up front rather than silently
+    /// upgraded from an anonymous one.
+    UnexpectedIdentity,
+}
+
+impl std::fmt::Display for SessionBindingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let msg = match self {
+            Self::IdentityRequired => "session requires a verified identity",
+            Self::IdentityMismatch => "session is bound to a different user",
+            Self::UnexpectedIdentity => "anonymous session cannot be used with a verified identity",
+        };
+        f.write_str(msg)
+    }
+}
+
+impl std::error::Error for SessionBindingError {}
+
+/// Enforce the session-to-user binding rule for a request.
+///
+/// - anonymous session + anonymous request → `Ok`
+/// - user-bound session + same user → `Ok`
+/// - user-bound session + no identity → [`SessionBindingError::IdentityRequired`]
+/// - user-bound session + different user → [`SessionBindingError::IdentityMismatch`]
+/// - anonymous session + verified identity → [`SessionBindingError::UnexpectedIdentity`]
+///   (no silent upgrade)
+pub fn check_session_binding(
+    bound: Option<&VerifiedUser>,
+    presenting: Option<&VerifiedUser>,
+) -> Result<(), SessionBindingError> {
+    match (bound, presenting) {
+        (None, None) => Ok(()),
+        (None, Some(_)) => Err(SessionBindingError::UnexpectedIdentity),
+        (Some(_), None) => Err(SessionBindingError::IdentityRequired),
+        (Some(b), Some(p)) if b.is_same_user(p) => Ok(()),
+        (Some(_), Some(_)) => Err(SessionBindingError::IdentityMismatch),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn same_user_compares_issuer_and_subject_not_audience() {
+        let a = VerifiedUser::new("alice")
+            .issuer("https://idp")
+            .audience(["res-1"]);
+        let b = VerifiedUser::new("alice")
+            .issuer("https://idp")
+            .audience(["res-2"]);
+        assert!(a.is_same_user(&b), "audience must not affect identity");
+
+        let c = VerifiedUser::new("alice").issuer("https://other");
+        assert!(!a.is_same_user(&c), "different issuer is a different user");
+
+        let d = VerifiedUser::new("bob").issuer("https://idp");
+        assert!(!a.is_same_user(&d), "different subject is a different user");
+    }
+
+    #[test]
+    fn binding_rules() {
+        let alice = VerifiedUser::new("alice").issuer("https://idp");
+        let bob = VerifiedUser::new("bob").issuer("https://idp");
+
+        // anonymous session + anonymous request
+        assert!(check_session_binding(None, None).is_ok());
+        // bound + same user
+        assert!(check_session_binding(Some(&alice), Some(&alice)).is_ok());
+        // bound + missing identity
+        assert_eq!(
+            check_session_binding(Some(&alice), None),
+            Err(SessionBindingError::IdentityRequired)
+        );
+        // bound + different user
+        assert_eq!(
+            check_session_binding(Some(&alice), Some(&bob)),
+            Err(SessionBindingError::IdentityMismatch)
+        );
+        // anonymous session + verified identity (no silent upgrade)
+        assert_eq!(
+            check_session_binding(None, Some(&alice)),
+            Err(SessionBindingError::UnexpectedIdentity)
+        );
+    }
+}

--- a/crates/mcpkit-core/src/auth/mod.rs
+++ b/crates/mcpkit-core/src/auth/mod.rs
@@ -58,10 +58,13 @@
 //! let auth_url = auth_request.build_url("https://auth.example.com/authorize");
 //! ```
 
+pub mod identity;
 mod oauth;
 
 #[cfg(feature = "jwt")]
 pub mod jwt;
+
+pub use identity::{SessionBindingError, VerifiedUser, check_session_binding};
 
 // Re-export all OAuth types
 pub use oauth::{

--- a/crates/mcpkit-rocket/src/session.rs
+++ b/crates/mcpkit-rocket/src/session.rs
@@ -1,6 +1,7 @@
 //! Session management for MCP Rocket integration.
 
 use dashmap::DashMap;
+use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use std::sync::Arc;
@@ -27,6 +28,8 @@ struct SessionState {
     protocol_version: Option<ProtocolVersion>,
     /// Client capabilities from initialization.
     client_capabilities: Option<ClientCapabilities>,
+    /// The verified user this session is bound to, if any.
+    user: Option<VerifiedUser>,
 }
 
 impl Default for SessionStore {
@@ -60,6 +63,15 @@ impl SessionStore {
     /// bounded without a background cleanup task.
     #[must_use]
     pub fn create(&self) -> String {
+        self.create_for_user(None)
+    }
+
+    /// Create a new session bound to an optional verified user, returning its ID.
+    ///
+    /// A session created with `Some(user)` may then only be used by that same
+    /// user (see [`touch_verified`](Self::touch_verified)).
+    #[must_use]
+    pub fn create_for_user(&self, user: Option<VerifiedUser>) -> String {
         self.cleanup(self.idle_timeout);
         let id = Uuid::new_v4().to_string();
         let now = Instant::now();
@@ -70,9 +82,28 @@ impl SessionStore {
                 last_seen: now,
                 protocol_version: None,
                 client_capabilities: None,
+                user,
             },
         );
         id
+    }
+
+    /// Touch a session, enforcing its user binding against the identity
+    /// presenting this request first.
+    ///
+    /// Returns `Ok(true)` if the session existed and was touched, `Ok(false)` if
+    /// it did not exist, or `Err` on a binding violation.
+    pub fn touch_verified(
+        &self,
+        id: &str,
+        presenting: Option<&VerifiedUser>,
+    ) -> Result<bool, SessionBindingError> {
+        let Some(mut session) = self.sessions.get_mut(id) else {
+            return Ok(false);
+        };
+        check_session_binding(session.user.as_ref(), presenting)?;
+        session.last_seen = Instant::now();
+        Ok(true)
     }
 
     /// Update the last seen time for a session.

--- a/crates/mcpkit-warp/src/session.rs
+++ b/crates/mcpkit-warp/src/session.rs
@@ -1,6 +1,7 @@
 //! Session management for MCP Warp integration.
 
 use dashmap::DashMap;
+use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use std::sync::Arc;
@@ -25,6 +26,8 @@ struct SessionState {
     protocol_version: Option<ProtocolVersion>,
     /// Client capabilities from initialization.
     client_capabilities: Option<ClientCapabilities>,
+    /// The verified user this session is bound to, if any.
+    user: Option<VerifiedUser>,
 }
 
 impl Default for SessionStore {
@@ -58,6 +61,15 @@ impl SessionStore {
     /// bounded without a background cleanup task.
     #[must_use]
     pub fn create(&self) -> String {
+        self.create_for_user(None)
+    }
+
+    /// Create a new session bound to an optional verified user, returning its ID.
+    ///
+    /// A session created with `Some(user)` may then only be used by that same
+    /// user (see [`touch_verified`](Self::touch_verified)).
+    #[must_use]
+    pub fn create_for_user(&self, user: Option<VerifiedUser>) -> String {
         self.cleanup(self.idle_timeout);
         let id = Uuid::new_v4().to_string();
         let now = Instant::now();
@@ -67,6 +79,7 @@ impl SessionStore {
                 last_seen: now,
                 protocol_version: None,
                 client_capabilities: None,
+                user,
             },
         );
         id
@@ -77,6 +90,24 @@ impl SessionStore {
         if let Some(mut session) = self.sessions.get_mut(id) {
             session.last_seen = Instant::now();
         }
+    }
+
+    /// Touch a session, enforcing its user binding against the identity
+    /// presenting this request first.
+    ///
+    /// Returns `Ok(true)` if the session existed and was touched, `Ok(false)` if
+    /// it did not exist, or `Err` on a binding violation.
+    pub fn touch_verified(
+        &self,
+        id: &str,
+        presenting: Option<&VerifiedUser>,
+    ) -> Result<bool, SessionBindingError> {
+        let Some(mut session) = self.sessions.get_mut(id) else {
+            return Ok(false);
+        };
+        check_session_binding(session.user.as_ref(), presenting)?;
+        session.last_seen = Instant::now();
+        Ok(true)
     }
 
     /// Record the protocol version and client capabilities negotiated during


### PR DESCRIPTION
First of two for #86. **Store-level mechanism**; adapter handler wiring (POST + SSE) follows in PR2.

## Problem

Per the MCP security best practices, per-user state must not be associated with a session id alone — identity should derive from the validated access token (`sub`, scoped by `iss`). Today the adapter `Session` has no identity field, handlers `touch`/accept any `mcp-session-id` regardless of who presents it, and although `validate_token → TokenClaims { iss, sub, aud }` exists, nothing connects it to sessions. #103 (URL-mode elicitation) depends on this binding.

## What

- **`mcpkit_core::auth::VerifiedUser`** `{ subject, issuer, audience }`. Identity equality is `(issuer, subject)` (`is_same_user`); **audience is recorded but not compared** — validating `aud` is a token-validation concern, and a returning user's token may be re-issued with a different audience. A jwt-gated `VerifiedUser::from_claims` projects validated claims.
- **`check_session_binding(bound, presenting) -> Result<(), SessionBindingError>`** enforcing:
  - anonymous + anonymous → ok
  - bound + same user → ok
  - bound + missing identity → `IdentityRequired`
  - bound + different user → `IdentityMismatch`
  - anonymous + verified identity → `UnexpectedIdentity` (no silent upgrade)
- **All four adapter stores** gain `create_for_user(..)` and `touch_verified(..)` (plus `get_verified(..)` on axum/actix); `Session`/`SessionState` carries `Option<VerifiedUser>`.

## Design notes (from the review)

- Binding equality is `(iss, sub)`, not audience — deliberately, per the refinement we agreed on.
- Token *validation* stays pluggable (apps wire their own middleware + the JWT helpers); the library owns only the binding check.
- The standalone transport listener (`mcpkit-transport`) is intentionally **not** wired here — that's the stub from #83.

## Next (PR2)

Adapter handler integration for **all four** adapters across **POST and SSE-replay** (reading the verified identity from request context, calling the verified store APIs), the "reject unknown session id on reuse" hardening (a deliberate breaking change), and an end-to-end example with the JWT helpers.

## Test plan

- Core: identity equality (audience ignored) + all five binding rules.
- Store: a representative axum test (create-for-user → same/different/missing/unexpected identity, unknown id) confirming the wiring.
- `fmt`/`clippy -D warnings`/`cargo test --workspace --all-features --locked`/`doc -D warnings` all green.

Spec: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices