### PR TITLE
feat(adapters): enforce session-user binding in the handlers (#86 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pluggable (use the JWT helpers + `VerifiedUser::from_claims`); this is the
   store-level mechanism, with adapter handler wiring (POST + SSE) to follow
   ([#86](https://github.com/praxiomlabs/mcpkit/issues/86)).
+- Session binding is now enforced by the adapter handlers (all four:
+  `mcpkit-axum`/`mcpkit-actix`/`mcpkit-warp`/`mcpkit-rocket`), on both the POST
+  and SSE paths. The handlers read the request's `VerifiedUser` (axum/actix from
+  request extensions; rocket via a `VerifiedUserGuard` reading request-local
+  cache; warp as a filter-supplied argument — the default router passes anonymous,
+  so auth-aware apps compose their own filter), bind a new session to it, and
+  reject a request that presents a mismatched, missing, or unexpectedly-present
+  identity — including before replaying buffered SSE events to a reconnecting
+  client ([#86](https://github.com/praxiomlabs/mcpkit/issues/86)).
 - Structured tool output (MCP `outputSchema` / `structuredContent`): `Tool` gains
   an `output_schema` field + `Tool::output_schema(..)`, and `CallToolResult` gains
   a `structured_content` field + `CallToolResult::with_structured_content(..)`.
@@ -108,6 +117,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (behavior):** the HTTP adapters now reject a request that presents an
+  `mcp-session-id` for a session the server does not know (previously such a
+  request was accepted and processed as if freshly created). Clients must use a
+  session id the server minted, or omit the header to start a new session. This
+  tightens session semantics alongside the user-binding work
+  ([#86](https://github.com/praxiomlabs/mcpkit/issues/86)). The adapter POST
+  handlers also gain a verified-user parameter/guard (`Option<Extension<VerifiedUser>>`
+  on axum, `VerifiedUserGuard` on rocket, an `Option<VerifiedUser>` filter argument
+  on warp), which changes their signatures.
 - **Breaking:** removed the non-functional, inverted server-side scaffolding for
   elicitation and sampling — the `ElicitationHandler`/`SamplingHandler` traits
   and the `ElicitationService`/`SamplingService` builders. They modelled the

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -4,8 +4,9 @@ use crate::error::ExtensionError;
 use crate::state::{HasServerInfo, McpState, OAuthState};
 use crate::{SUPPORTED_VERSIONS, is_supported_version};
 use actix_web::http::header::ContentType;
-use actix_web::{HttpRequest, HttpResponse, web};
+use actix_web::{HttpMessage, HttpRequest, HttpResponse, web};
 use futures::stream::{self, StreamExt};
+use mcpkit_core::auth::VerifiedUser;
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
@@ -66,6 +67,10 @@ where
         )));
     }
 
+    // The verified user (if any) is supplied by the application's auth
+    // middleware via a request extension; mcpkit binds the session to it.
+    let user = req.extensions().get::<VerifiedUser>().cloned();
+
     // Get or create session
     let session_id = req
         .headers()
@@ -74,11 +79,19 @@ where
         .map(String::from);
 
     let session_id = match session_id {
-        Some(id) => {
-            state.sessions.touch(&id);
-            id
-        }
-        None => state.sessions.create(),
+        Some(id) => match state.sessions.touch_verified(&id, user.as_ref()) {
+            Ok(true) => id,
+            // Reject an unknown session id rather than silently proceeding.
+            Ok(false) => {
+                warn!(session_id = %id, "Rejected: unknown session id");
+                return Err(ExtensionError::SessionNotFound(id));
+            }
+            Err(e) => {
+                warn!(session_id = %id, error = %e, "Rejected: session binding violation");
+                return Ok(HttpResponse::Forbidden().body(e.to_string()));
+            }
+        },
+        None => state.sessions.create_for_user(user),
     };
 
     debug!(session_id = %session_id, "Processing MCP request");
@@ -276,11 +289,20 @@ where
         return HttpResponse::Forbidden().body("origin not allowed");
     }
 
+    let user = req.extensions().get::<VerifiedUser>().cloned();
     let session_id = req
         .headers()
         .get("mcp-session-id")
         .and_then(|v| v.to_str().ok())
         .map(String::from);
+
+    // Enforce the session's user binding before replaying buffered events.
+    if let Some(id) = &session_id {
+        if let Err(e) = state.sessions.get_verified(id, user.as_ref()) {
+            warn!(session_id = %id, error = %e, "Rejected SSE: session binding violation");
+            return HttpResponse::Forbidden().body(e.to_string());
+        }
+    }
 
     let (id, rx) = if let Some(id) = session_id {
         // Try to reconnect to existing session

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -1,15 +1,29 @@
 //! HTTP handlers for MCP requests.
+//!
+//! # Authenticated sessions
+//!
+//! To bind sessions to a verified user (MCP security best practices), have your
+//! authentication middleware validate the bearer token and insert a
+//! [`mcpkit_core::auth::VerifiedUser`] into the request extensions (e.g. with a
+//! `tower` layer that calls `req.extensions_mut().insert(user)`). The handlers
+//! read it and bind the session: a session created for a user may then only be
+//! used by that same user, and a request presenting a mismatched, missing, or
+//! unexpected identity is rejected. Requests without a `VerifiedUser` extension
+//! are treated as anonymous. Token validation stays your application's
+//! responsibility; `VerifiedUser::from_claims` builds one from validated JWT
+//! claims.
 
 use crate::error::ExtensionError;
 use crate::session::{EventStore, StoredEvent};
 use crate::state::{HasServerInfo, McpState, OAuthState};
 use crate::{SUPPORTED_VERSIONS, is_supported_version};
-use axum::Json;
 use axum::extract::State;
 use axum::http::{HeaderMap, StatusCode};
 use axum::response::IntoResponse;
 use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::{Extension, Json};
 use futures::stream::Stream;
+use mcpkit_core::auth::VerifiedUser;
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
@@ -40,11 +54,15 @@ use tracing::{debug, info, warn};
 pub async fn handle_mcp_post<H>(
     State(state): State<McpState<H>>,
     headers: HeaderMap,
+    user: Option<Extension<VerifiedUser>>,
     body: String,
 ) -> impl IntoResponse
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
 {
+    // The verified user (if any) is supplied by the application's auth middleware
+    // via a request extension; mcpkit binds the session to it.
+    let user = user.map(|Extension(u)| u);
     // Reject disallowed Origins (DNS-rebinding protection) before any work.
     let origin = headers.get("origin").and_then(|v| v.to_str().ok());
     if !state.origin_validator.is_allowed(origin) {
@@ -78,11 +96,19 @@ where
         .map(String::from);
 
     let session_id = match session_id {
-        Some(id) => {
-            state.sessions.touch(&id);
-            id
-        }
-        None => state.sessions.create(),
+        Some(id) => match state.sessions.touch_verified(&id, user.as_ref()) {
+            Ok(true) => id,
+            // Reject an unknown session id rather than silently proceeding.
+            Ok(false) => {
+                warn!(session_id = %id, "Rejected: unknown session id");
+                return ExtensionError::SessionNotFound(id).into_response();
+            }
+            Err(e) => {
+                warn!(session_id = %id, error = %e, "Rejected: session binding violation");
+                return (StatusCode::FORBIDDEN, e.to_string()).into_response();
+            }
+        },
+        None => state.sessions.create_for_user(user),
     };
 
     debug!(session_id = %session_id, "Processing MCP request");
@@ -289,6 +315,7 @@ where
 pub async fn handle_sse<H>(
     State(state): State<McpState<H>>,
     headers: HeaderMap,
+    user: Option<Extension<VerifiedUser>>,
 ) -> impl IntoResponse
 where
     H: HasServerInfo + Send + Sync + 'static,
@@ -303,10 +330,20 @@ where
         return (StatusCode::FORBIDDEN, "origin not allowed").into_response();
     }
 
+    let user = user.map(|Extension(u)| u);
     let session_id = headers
         .get("mcp-session-id")
         .and_then(|v| v.to_str().ok())
         .map(String::from);
+
+    // Enforce the session's user binding before replaying any buffered events to
+    // a reconnecting client (a different user must not receive them).
+    if let Some(id) = &session_id {
+        if let Err(e) = state.sessions.get_verified(id, user.as_ref()) {
+            warn!(session_id = %id, error = %e, "Rejected SSE: session binding violation");
+            return (StatusCode::FORBIDDEN, e.to_string()).into_response();
+        }
+    }
 
     let last_event_id = headers
         .get("last-event-id")

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -2,6 +2,7 @@
 
 use crate::state::{HasServerInfo, McpState};
 use crate::{SUPPORTED_VERSIONS, is_supported_version};
+use mcpkit_core::auth::VerifiedUser;
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
@@ -47,6 +48,23 @@ impl<'r> FromRequest<'r> for SessionIdHeader {
             .get_one("mcp-session-id")
             .map(String::from);
         Outcome::Success(SessionIdHeader(session_id))
+    }
+}
+
+/// The verified user for this request.
+///
+/// An application's authentication fairing validates the bearer token and caches
+/// the resulting identity with `request.local_cache(|| Some(user))` (or `None`);
+/// this guard reads it back so mcpkit can bind the session to it.
+pub struct VerifiedUserGuard(pub Option<VerifiedUser>);
+
+#[rocket::async_trait]
+impl<'r> FromRequest<'r> for VerifiedUserGuard {
+    type Error = ();
+
+    async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
+        let user = request.local_cache(|| None::<VerifiedUser>).clone();
+        Outcome::Success(Self(user))
     }
 }
 
@@ -179,6 +197,7 @@ pub async fn handle_mcp_post<H>(
     version: Option<&str>,
     session_id: Option<String>,
     origin: Option<&str>,
+    user: Option<VerifiedUser>,
     body: &str,
 ) -> McpResponse
 where
@@ -214,13 +233,21 @@ where
         );
     }
 
-    // Get or create session
+    // Get or create session (binding it to the verified user, if any).
     let session_id = match session_id {
-        Some(id) => {
-            state.sessions.touch(&id);
-            id
-        }
-        None => state.sessions.create(),
+        Some(id) => match state.sessions.touch_verified(&id, user.as_ref()) {
+            Ok(true) => id,
+            // Reject an unknown session id rather than silently proceeding.
+            Ok(false) => {
+                warn!(session_id = %id, "Rejected: unknown session id");
+                return McpResponse::error(Status::NotFound, "unknown session id".to_string());
+            }
+            Err(e) => {
+                warn!(session_id = %id, error = %e, "Rejected: session binding violation");
+                return McpResponse::error(Status::Forbidden, e.to_string());
+            }
+        },
+        None => state.sessions.create_for_user(user),
     };
 
     debug!(session_id = %session_id, "Processing MCP request");

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -190,6 +190,7 @@ macro_rules! create_mcp_routes {
             version: $crate::handler::ProtocolVersionHeader,
             session: $crate::handler::SessionIdHeader,
             origin: $crate::handler::OriginHeader,
+            user: $crate::handler::VerifiedUserGuard,
             body: String,
         ) -> $crate::handler::McpResponse {
             $crate::handler::handle_mcp_post(
@@ -197,6 +198,7 @@ macro_rules! create_mcp_routes {
                 version.0.as_deref(),
                 session.0,
                 origin.0.as_deref(),
+                user.0,
                 &body,
             )
             .await
@@ -207,6 +209,7 @@ macro_rules! create_mcp_routes {
             state: &::rocket::State<$crate::McpState<$handler_type>>,
             session: $crate::handler::SessionIdHeader,
             origin: $crate::handler::OriginHeader,
+            user: $crate::handler::VerifiedUserGuard,
         ) -> ::std::result::Result<
             ::rocket::response::stream::EventStream![],
             ::rocket::http::Status,
@@ -218,6 +221,18 @@ macro_rules! create_mcp_routes {
                 .is_allowed(origin.0.as_deref())
             {
                 return ::std::result::Result::Err(::rocket::http::Status::Forbidden);
+            }
+            // Enforce the session's user binding before subscribing a
+            // reconnecting client to its event stream.
+            if let ::std::option::Option::Some(id) = &session.0 {
+                if state
+                    .inner()
+                    .sessions
+                    .touch_verified(id, user.0.as_ref())
+                    .is_err()
+                {
+                    return ::std::result::Result::Err(::rocket::http::Status::Forbidden);
+                }
             }
             ::std::result::Result::Ok($crate::handler::handle_sse(state.inner(), session.0))
         }

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -3,6 +3,7 @@
 use crate::state::{HasServerInfo, McpState};
 use crate::{SUPPORTED_VERSIONS, is_supported_version};
 use futures::StreamExt;
+use mcpkit_core::auth::VerifiedUser;
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
@@ -27,6 +28,7 @@ pub async fn handle_mcp_post<H>(
     version: Option<String>,
     session_id: Option<String>,
     origin: Option<String>,
+    user: Option<VerifiedUser>,
     body: String,
 ) -> Result<impl warp::Reply, Infallible>
 where
@@ -74,13 +76,32 @@ where
         ));
     }
 
-    // Get or create session
+    // Get or create session (binding it to the verified user, if any).
     let session_id = match session_id {
-        Some(id) => {
-            state.sessions.touch(&id);
-            id
-        }
-        None => state.sessions.create(),
+        Some(id) => match state.sessions.touch_verified(&id, user.as_ref()) {
+            Ok(true) => id,
+            Ok(false) => {
+                warn!(session_id = %id, "Rejected: unknown session id");
+                let error_body = serde_json::json!({
+                    "error": { "code": -32600, "message": "unknown session id" }
+                });
+                return Ok(warp::reply::with_status(
+                    warp::reply::json(&error_body),
+                    StatusCode::NOT_FOUND,
+                ));
+            }
+            Err(e) => {
+                warn!(session_id = %id, error = %e, "Rejected: session binding violation");
+                let error_body = serde_json::json!({
+                    "error": { "code": -32600, "message": e.to_string() }
+                });
+                return Ok(warp::reply::with_status(
+                    warp::reply::json(&error_body),
+                    StatusCode::FORBIDDEN,
+                ));
+            }
+        },
+        None => state.sessions.create_for_user(user),
     };
 
     debug!(session_id = %session_id, "Processing MCP request");
@@ -282,6 +303,7 @@ pub fn handle_sse<H>(
     state: Arc<McpState<H>>,
     session_id: Option<String>,
     origin: Option<String>,
+    user: Option<VerifiedUser>,
 ) -> warp::reply::Response
 where
     H: HasServerInfo + Send + Sync + 'static,
@@ -296,6 +318,15 @@ where
         );
         return warp::reply::with_status("origin not allowed", StatusCode::FORBIDDEN)
             .into_response();
+    }
+
+    // Enforce the session's user binding before subscribing a reconnecting
+    // client to its event stream.
+    if let Some(id) = &session_id {
+        if let Err(e) = state.sessions.touch_verified(id, user.as_ref()) {
+            warn!(session_id = %id, error = %e, "Rejected SSE: session binding violation");
+            return warp::reply::with_status(e.to_string(), StatusCode::FORBIDDEN).into_response();
+        }
     }
 
     let (session_id, rx) = if let Some(id) = session_id {
@@ -461,6 +492,7 @@ mod tests {
             Some("unsupported-version".to_string()),
             None,
             None,
+            None,
             r#"{"jsonrpc":"2.0","method":"ping","id":1}"#.to_string(),
         )
         .await;
@@ -476,6 +508,7 @@ mod tests {
         let response = handle_mcp_post(
             state,
             Some("2025-11-25".to_string()),
+            None,
             None,
             None,
             "invalid json".to_string(),
@@ -495,6 +528,7 @@ mod tests {
             Some("2025-11-25".to_string()),
             None,
             None,
+            None,
             r#"{"jsonrpc":"2.0","method":"ping","id":1}"#.to_string(),
         )
         .await;
@@ -510,6 +544,7 @@ mod tests {
         let response = handle_mcp_post(
             state,
             Some("2025-11-25".to_string()),
+            None,
             None,
             None,
             r#"{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}"#.to_string(),
@@ -532,6 +567,7 @@ mod tests {
             Some("2025-11-25".to_string()),
             Some(session_id.clone()),
             None,
+            None,
             r#"{"jsonrpc":"2.0","method":"ping","id":1}"#.to_string(),
         )
         .await;
@@ -548,6 +584,7 @@ mod tests {
         let response = handle_mcp_post(
             state,
             Some("2025-11-25".to_string()),
+            None,
             None,
             None,
             r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#.to_string(),

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -130,7 +130,7 @@ where
                  origin: Option<String>,
                  bytes: bytes::Bytes| async move {
                     let body = String::from_utf8_lossy(&bytes).to_string();
-                    handle_mcp_post(state, version, session_id, origin, body).await
+                    handle_mcp_post(state, version, session_id, origin, None, body).await
                 },
             );
 
@@ -144,7 +144,7 @@ where
             .and(with_origin())
             .map(
                 |state: Arc<McpState<H>>, session_id: Option<String>, origin: Option<String>| {
-                    handle_sse(state, session_id, origin)
+                    handle_sse(state, session_id, origin, None)
                 },
             );
 
@@ -189,7 +189,7 @@ where
                  origin: Option<String>,
                  bytes: bytes::Bytes| async move {
                     let body = String::from_utf8_lossy(&bytes).to_string();
-                    handle_mcp_post(state, version, session_id, origin, body).await
+                    handle_mcp_post(state, version, session_id, origin, None, body).await
                 },
             );
 
@@ -203,7 +203,7 @@ where
             .and(with_origin())
             .map(
                 |state: Arc<McpState<H>>, session_id: Option<String>, origin: Option<String>| {
-                    handle_sse(state, session_id, origin)
+                    handle_sse(state, session_id, origin, None)
                 },
             );
 


### PR DESCRIPTION
Second of two for #86 (PR1 mechanism merged in #124). Wires the binding into all four HTTP adapters, POST + SSE.

## What

The handlers now read the request's `VerifiedUser` and enforce the session binding:
- **create** a new session bound to the user (`create_for_user`);
- **reuse** verifies the presenting identity against the session's bound user (`touch_verified`/`get_verified`) — rejecting mismatched / missing / unexpectedly-present identity;
- **SSE**: the binding is checked *before* subscribing/replaying buffered events to a reconnecting client, so a different user can't receive another user's stream.

## Identity source per framework (all default to anonymous, backward-compatible except the reject-unknown change)

- **axum / actix** — from **request extensions** (`Option<Extension<VerifiedUser>>` / `req.extensions()`); the app's auth middleware inserts a `VerifiedUser`.
- **rocket** — a `VerifiedUserGuard` reading **request-local cache**; the app's fairing validates + caches the identity.
- **warp** — an `Option<VerifiedUser>` **filter argument** on `handle_mcp_post`; the default router passes anonymous (`None`), and auth-aware apps compose their own filter that supplies it (warp has no request extensions).

Token *validation* stays the app's responsibility; `VerifiedUser::from_claims` builds an identity from validated JWT claims. Axum's handler module documents the pattern.

## Breaking

- An `mcp-session-id` for a session the server doesn't know is now **rejected** (404/Forbidden) rather than silently accepted (the deliberate hardening we agreed on).
- The axum/rocket/warp POST handlers gain a verified-user parameter/guard, changing their signatures.

## Follow-ups (noted, not in scope)

- A dedicated worked JWT auth example crate.
- The standalone `mcpkit-transport` HTTP listener (the #83 stub) is intentionally not wired.

## Test plan

- `fmt` / `clippy -D warnings` / `cargo test --workspace --all-features --locked` / `doc -D warnings` all green (the store-level binding rules are covered by the PR1 core + axum store tests).

Spec: https://modelcontextprotocol.io/docs/tutorials/security/security_best_practices