### PR TITLE
feat(elicitation): URL-mode types + server elicit_url (#103 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- URL-mode elicitation (2025-11-25), core + server. `ElicitRequest` gains an
+  optional `mode` (absent = form); new `UrlElicitRequest`
+  (`mode`/`message`/`elicitationId`/`url`), `ElicitRequestParams` (a union that
+  parses either mode from the wire), and `ElicitationCompleteNotification`.
+  `Context::elicit_url` sends a URL-mode `elicitation/create` (gated on the
+  client's `elicitation.url` sub-capability), and `ServerNotifier::elicitation_complete`
+  sends `notifications/elicitation/complete` for the out-of-band completion.
+  `McpError::url_elicitation_required` carries the `-32042`
+  `URLElicitationRequired` error with its `data.elicitations` preserved on the
+  wire. `ClientCapabilities` gains `with_form_elicitation`/`with_url_elicitation`
+  and `has_form_elicitation`/`has_url_elicitation`; `ElicitationCapability` is now
+  `{ form?, url? }` (an empty `{}` remains form-capable for backwards
+  compatibility). Client-side URL handling (with a consent hook) and the
+  completion-notification dispatch follow in a second PR
+  ([#103](https://github.com/praxiomlabs/mcpkit/issues/103)).
 - Session-to-verified-user binding (security). A new
   `mcpkit_core::auth::VerifiedUser` (`subject` + `issuer` + `audience`) models an
   identity verified from an access token, and `check_session_binding` enforces

--- a/crates/mcpkit-core/src/capability.rs
+++ b/crates/mcpkit-core/src/capability.rs
@@ -242,11 +242,55 @@ impl ClientCapabilities {
         self
     }
 
-    /// Enable elicitation support.
+    /// Enable elicitation support (form mode).
+    ///
+    /// This declares `elicitation: {}`, which is form-capable (the 2025-06-18
+    /// behaviour). Use [`with_url_elicitation`](Self::with_url_elicitation) to
+    /// additionally declare URL-mode support.
     #[must_use]
-    pub const fn with_elicitation(mut self) -> Self {
-        self.elicitation = Some(ElicitationCapability {});
+    pub fn with_elicitation(mut self) -> Self {
+        self.elicitation = Some(ElicitationCapability {
+            form: None,
+            url: None,
+        });
         self
+    }
+
+    /// Declare form-mode elicitation support explicitly (`elicitation.form`).
+    #[must_use]
+    pub fn with_form_elicitation(mut self) -> Self {
+        self.elicitation
+            .get_or_insert_with(ElicitationCapability::default)
+            .form = Some(serde_json::json!({}));
+        self
+    }
+
+    /// Declare URL-mode elicitation support (`elicitation.url`).
+    #[must_use]
+    pub fn with_url_elicitation(mut self) -> Self {
+        self.elicitation
+            .get_or_insert_with(ElicitationCapability::default)
+            .url = Some(serde_json::json!({}));
+        self
+    }
+
+    /// Check if form-mode elicitation is supported.
+    ///
+    /// True when `elicitation.form` is declared, or when `elicitation` is present
+    /// but empty (`{}`), which is form-capable for backwards compatibility.
+    #[must_use]
+    pub fn has_form_elicitation(&self) -> bool {
+        self.elicitation
+            .as_ref()
+            .is_some_and(ElicitationCapability::has_form)
+    }
+
+    /// Check if URL-mode elicitation is supported (`elicitation.url` declared).
+    #[must_use]
+    pub fn has_url_elicitation(&self) -> bool {
+        self.elicitation
+            .as_ref()
+            .is_some_and(ElicitationCapability::has_url)
     }
 
     /// Check if roots are supported.
@@ -353,7 +397,30 @@ pub struct SamplingCapability {}
 
 /// Elicitation capability flags.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ElicitationCapability {}
+pub struct ElicitationCapability {
+    /// Declared support for form-mode elicitation. An absent `form` and `url`
+    /// (an empty `{}`) is treated as form-capable for backwards compatibility.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub form: Option<serde_json::Value>,
+    /// Declared support for URL-mode elicitation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<serde_json::Value>,
+}
+
+impl ElicitationCapability {
+    /// Whether form-mode elicitation is supported (`form` declared, or empty
+    /// `{}` which is form-capable for backwards compatibility).
+    #[must_use]
+    pub const fn has_form(&self) -> bool {
+        self.form.is_some() || self.url.is_none()
+    }
+
+    /// Whether URL-mode elicitation is supported (`url` declared).
+    #[must_use]
+    pub const fn has_url(&self) -> bool {
+        self.url.is_some()
+    }
+}
 
 /// Server information provided during initialization.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -710,6 +777,33 @@ pub struct PingResult {}
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn elicitation_form_url_capability_semantics() {
+        use super::ClientCapabilities;
+        // Empty `{}` (legacy `with_elicitation`) is form-capable, not url.
+        let form = ClientCapabilities::default().with_elicitation();
+        assert!(form.has_elicitation());
+        assert!(form.has_form_elicitation());
+        assert!(!form.has_url_elicitation());
+        assert_eq!(
+            serde_json::to_value(&form.elicitation).unwrap(),
+            serde_json::json!({}),
+            "empty elicitation must still serialize as {{}} for compatibility"
+        );
+
+        // URL-only: url present, form not.
+        let url = ClientCapabilities::default().with_url_elicitation();
+        assert!(url.has_url_elicitation());
+        assert!(!url.has_form_elicitation());
+
+        // Both.
+        let both = ClientCapabilities::default()
+            .with_form_elicitation()
+            .with_url_elicitation();
+        assert!(both.has_form_elicitation());
+        assert!(both.has_url_elicitation());
+    }
+
     use super::*;
 
     #[test]

--- a/crates/mcpkit-core/src/error/codes.rs
+++ b/crates/mcpkit-core/src/error/codes.rs
@@ -31,3 +31,6 @@ pub const USER_REJECTED: i32 = -1;
 
 /// Resource was not found.
 pub const RESOURCE_NOT_FOUND: i32 = -32002;
+
+/// The server requires a URL-mode elicitation before the request can proceed.
+pub const URL_ELICITATION_REQUIRED: i32 = -32042;

--- a/crates/mcpkit-core/src/error/jsonrpc.rs
+++ b/crates/mcpkit-core/src/error/jsonrpc.rs
@@ -95,6 +95,9 @@ impl From<&McpError> for JsonRpcError {
                 "client_version": details.client_version,
                 "server_version": details.server_version,
             })),
+            McpError::UrlElicitationRequired { elicitations } => Some(serde_json::json!({
+                "elicitations": elicitations,
+            })),
             McpError::WithContext { source, .. } => {
                 let inner: Self = source.as_ref().into();
                 inner.data

--- a/crates/mcpkit-core/src/error/types.rs
+++ b/crates/mcpkit-core/src/error/types.rs
@@ -226,6 +226,16 @@ pub enum McpError {
         /// Human-readable error message.
         message: String,
     },
+
+    /// The server requires the client to complete one or more URL-mode
+    /// elicitations before this request can proceed (JSON-RPC code `-32042`).
+    #[error("URL elicitation required")]
+    #[diagnostic(code(mcp::elicitation::url_required))]
+    UrlElicitationRequired {
+        /// The URL elicitations the client must complete first (carried in the
+        /// error `data.elicitations`).
+        elicitations: Vec<crate::types::UrlElicitRequest>,
+    },
 }
 
 // ============================================================================
@@ -315,6 +325,13 @@ impl McpError {
             message: message.into(),
             source: None,
         }
+    }
+
+    /// Signal that the client must complete the given URL-mode elicitations
+    /// before this request can proceed (JSON-RPC code `-32042`).
+    #[must_use]
+    pub fn url_elicitation_required(elicitations: Vec<crate::types::UrlElicitRequest>) -> Self {
+        Self::UrlElicitationRequired { elicitations }
     }
 
     /// Create an internal error with a source.
@@ -475,6 +492,7 @@ impl McpError {
             Self::Cancelled { .. } => codes::SERVER_ERROR_START - 8,
             Self::WithContext { source, .. } => source.code(),
             Self::InternalMessage { .. } => codes::INTERNAL_ERROR,
+            Self::UrlElicitationRequired { .. } => codes::URL_ELICITATION_REQUIRED,
         }
     }
 
@@ -528,6 +546,26 @@ impl From<std::io::Error> for McpError {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn url_elicitation_required_preserves_code_and_data() {
+        use crate::error::jsonrpc::JsonRpcError;
+        use crate::types::UrlElicitRequest;
+
+        let err = McpError::url_elicitation_required(vec![UrlElicitRequest::new(
+            "authorize",
+            "e1",
+            "https://auth/x",
+        )]);
+        assert_eq!(err.code(), codes::URL_ELICITATION_REQUIRED);
+
+        // The structured `data.elicitations` must survive the wire conversion.
+        let wire = JsonRpcError::from(&err);
+        assert_eq!(wire.code, -32042);
+        let data = wire.data.expect("data present");
+        assert_eq!(data["elicitations"][0]["elicitationId"], "e1");
+        assert_eq!(data["elicitations"][0]["mode"], "url");
+    }
 
     #[test]
     fn resource_errors_have_distinct_codes() {

--- a/crates/mcpkit-core/src/types/elicitation.rs
+++ b/crates/mcpkit-core/src/types/elicitation.rs
@@ -6,9 +6,22 @@
 
 use serde::{Deserialize, Serialize};
 
-/// A request to elicit information from the user.
+/// The mode of an elicitation request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ElicitMode {
+    /// In-band form input against a requested schema.
+    Form,
+    /// Out-of-band interaction via a URL the user navigates to.
+    Url,
+}
+
+/// A form-mode request to elicit information from the user.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ElicitRequest {
+    /// The elicitation mode. Absent is equivalent to [`ElicitMode::Form`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ElicitMode>,
     /// Message explaining what information is needed.
     pub message: String,
     /// The schema describing what input is expected.
@@ -21,6 +34,7 @@ impl ElicitRequest {
     #[must_use]
     pub fn new(message: impl Into<String>, schema: ElicitationSchema) -> Self {
         Self {
+            mode: None,
             message: message.into(),
             requested_schema: schema,
         }
@@ -55,6 +69,79 @@ impl ElicitRequest {
             message,
             ElicitationSchema::object().property(field_name, PropertySchema::enum_values(options)),
         )
+    }
+}
+
+/// A URL-mode request to elicit information via an out-of-band interaction.
+///
+/// The user is asked to navigate to `url` (e.g. for authorization or payment).
+/// The client returns an [`ElicitResult`] action immediately (consenting to open
+/// the URL); the server later sends an [`ElicitationCompleteNotification`] when
+/// the out-of-band interaction finishes.
+///
+/// Per the spec, URL mode is security-sensitive: the `elicitation_id` MUST be
+/// unguessable and bound to a verified user identity, and MUST NOT carry
+/// credentials in the URL.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UrlElicitRequest {
+    /// The elicitation mode (always [`ElicitMode::Url`]).
+    pub mode: ElicitMode,
+    /// Message explaining why the interaction is needed.
+    pub message: String,
+    /// Opaque, unguessable id, unique within the server, correlating this
+    /// elicitation with its completion notification.
+    #[serde(rename = "elicitationId")]
+    pub elicitation_id: String,
+    /// The URL the user should navigate to.
+    pub url: String,
+}
+
+impl UrlElicitRequest {
+    /// Create a URL-mode elicitation request.
+    #[must_use]
+    pub fn new(
+        message: impl Into<String>,
+        elicitation_id: impl Into<String>,
+        url: impl Into<String>,
+    ) -> Self {
+        Self {
+            mode: ElicitMode::Url,
+            message: message.into(),
+            elicitation_id: elicitation_id.into(),
+            url: url.into(),
+        }
+    }
+}
+
+/// The parameters of an `elicitation/create` request — a form or URL request,
+/// discriminated by `mode` (absent = form).
+///
+/// Used on the client to parse either mode from the wire.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum ElicitRequestParams {
+    /// A URL-mode request (`mode: "url"`).
+    Url(UrlElicitRequest),
+    /// A form-mode request (`mode` absent or `"form"`).
+    Form(ElicitRequest),
+}
+
+/// A `notifications/elicitation/complete` notification: the out-of-band
+/// interaction for a URL-mode elicitation has finished.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ElicitationCompleteNotification {
+    /// The id of the elicitation that completed.
+    #[serde(rename = "elicitationId")]
+    pub elicitation_id: String,
+}
+
+impl ElicitationCompleteNotification {
+    /// Create a completion notification for the given elicitation id.
+    #[must_use]
+    pub fn new(elicitation_id: impl Into<String>) -> Self {
+        Self {
+            elicitation_id: elicitation_id.into(),
+        }
     }
 }
 
@@ -361,6 +448,53 @@ impl std::fmt::Display for ElicitAction {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn url_request_serializes_with_mode_and_ids() {
+        let req = UrlElicitRequest::new("authorize", "elic-123", "https://auth.example/x");
+        let j = serde_json::to_value(&req).unwrap();
+        assert_eq!(j["mode"], "url");
+        assert_eq!(j["elicitationId"], "elic-123");
+        assert_eq!(j["url"], "https://auth.example/x");
+    }
+
+    #[test]
+    fn form_request_omits_mode_by_default() {
+        let req = ElicitRequest::text("name?", "name");
+        let j = serde_json::to_value(&req).unwrap();
+        assert!(
+            j.get("mode").is_none(),
+            "form mode should be absent by default"
+        );
+        assert!(j.get("requestedSchema").is_some());
+    }
+
+    #[test]
+    fn params_union_parses_both_modes() {
+        // URL mode.
+        let url = serde_json::json!({
+            "mode": "url", "message": "go", "elicitationId": "e1", "url": "https://x"
+        });
+        assert!(matches!(
+            serde_json::from_value::<ElicitRequestParams>(url).unwrap(),
+            ElicitRequestParams::Url(_)
+        ));
+        // Form mode (mode absent).
+        let form = serde_json::json!({
+            "message": "name?",
+            "requestedSchema": { "type": "object", "properties": {} }
+        });
+        assert!(matches!(
+            serde_json::from_value::<ElicitRequestParams>(form).unwrap(),
+            ElicitRequestParams::Form(_)
+        ));
+    }
+
+    #[test]
+    fn completion_notification_uses_elicitation_id() {
+        let j = serde_json::to_value(ElicitationCompleteNotification::new("e1")).unwrap();
+        assert_eq!(j["elicitationId"], "e1");
+    }
 
     #[test]
     fn test_text_elicitation() {

--- a/crates/mcpkit-server/src/context.rs
+++ b/crates/mcpkit-server/src/context.rs
@@ -47,7 +47,7 @@ use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
 use mcpkit_core::error::McpError;
 use mcpkit_core::protocol::{Notification, ProgressToken, RequestId, Response};
 use mcpkit_core::protocol_version::ProtocolVersion;
-use mcpkit_core::types::elicitation::{ElicitRequest, ElicitResult};
+use mcpkit_core::types::elicitation::{ElicitRequest, ElicitResult, UrlElicitRequest};
 use mcpkit_core::types::sampling::{CreateMessageRequest, CreateMessageResult};
 use std::borrow::Cow;
 use std::future::Future;
@@ -391,6 +391,45 @@ impl<'a> Context<'a> {
         if !self.client_caps.has_elicitation() {
             return Err(McpError::internal(
                 "the client did not declare the elicitation capability",
+            ));
+        }
+
+        let params = serde_json::to_value(&request).map_err(McpError::from)?;
+        let result = self.request("elicitation/create", Some(params)).await?;
+        serde_json::from_value(result).map_err(McpError::from)
+    }
+
+    /// Request a URL-mode elicitation: ask the client to have the user navigate
+    /// to a URL for an out-of-band interaction (e.g. authorization or payment).
+    ///
+    /// Returns the client's [`ElicitResult`] action once the user consents to
+    /// open the URL. When the out-of-band interaction later finishes, notify the
+    /// client with `ServerNotifier::elicitation_complete(elicitation_id)`.
+    ///
+    /// Gated on the client's `elicitation.url` sub-capability (which is only
+    /// declared on 2025-11-25+).
+    ///
+    /// # Security
+    ///
+    /// Per the MCP spec, the caller MUST use an unguessable `elicitation_id`
+    /// bound to a verified user identity and MUST NOT place credentials in the
+    /// URL. mcpkit provides the mechanism; associating the id with a user is the
+    /// application's responsibility (see the session-binding helpers, #86).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the negotiated protocol version does not support
+    /// elicitation, the client did not declare URL-mode elicitation, or the
+    /// request fails.
+    pub async fn elicit_url(&self, request: UrlElicitRequest) -> Result<ElicitResult, McpError> {
+        if !self.protocol_version.supports_elicitation() {
+            return Err(McpError::internal(
+                "the negotiated protocol version does not support elicitation",
+            ));
+        }
+        if !self.client_caps.has_url_elicitation() {
+            return Err(McpError::internal(
+                "the client did not declare URL-mode elicitation support",
             ));
         }
 

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -83,6 +83,8 @@ pub mod notifications {
     pub const TOOLS_LIST_CHANGED: &str = "notifications/tools/list_changed";
     /// Sent when the list of available prompts has changed.
     pub const PROMPTS_LIST_CHANGED: &str = "notifications/prompts/list_changed";
+    /// Sent when a URL-mode elicitation's out-of-band interaction has completed.
+    pub const ELICITATION_COMPLETE: &str = "notifications/elicitation/complete";
 }
 
 /// Represents a parsed MCP request with typed parameters.

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -405,6 +405,23 @@ impl ServerNotifier {
         )
         .await
     }
+
+    /// Notify the client that a URL-mode elicitation's out-of-band interaction
+    /// has completed (`notifications/elicitation/complete`).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the notification could not be sent.
+    pub async fn elicitation_complete(
+        &self,
+        elicitation_id: impl Into<String>,
+    ) -> Result<(), McpError> {
+        self.notify(
+            crate::router::notifications::ELICITATION_COMPLETE,
+            Some(serde_json::json!({ "elicitationId": elicitation_id.into() })),
+        )
+        .await
+    }
 }
 
 /// Server runtime configuration.

--- a/mcpkit/tests/capability_negotiation_compatibility.rs
+++ b/mcpkit/tests/capability_negotiation_compatibility.rs
@@ -572,7 +572,7 @@ fn test_sampling_capability_serialization() -> Result<(), Box<dyn std::error::Er
 
 #[test]
 fn test_elicitation_capability_serialization() -> Result<(), Box<dyn std::error::Error>> {
-    let cap = ElicitationCapability {};
+    let cap = ElicitationCapability::default();
 
     let json_str = serde_json::to_string(&cap)?;
 
@@ -930,7 +930,10 @@ fn test_empty_capability_structs_serialize_to_empty_object()
     assert_eq!(serde_json::to_string(&LoggingCapability {})?, "{}");
     assert_eq!(serde_json::to_string(&CompletionCapability {})?, "{}");
     assert_eq!(serde_json::to_string(&SamplingCapability {})?, "{}");
-    assert_eq!(serde_json::to_string(&ElicitationCapability {})?, "{}");
+    assert_eq!(
+        serde_json::to_string(&ElicitationCapability::default())?,
+        "{}"
+    );
     assert_eq!(serde_json::to_string(&ToolCapability::default())?, "{}");
     assert_eq!(serde_json::to_string(&ResourceCapability::default())?, "{}");
     assert_eq!(serde_json::to_string(&PromptCapability::default())?, "{}");


### PR DESCRIPTION
First of two for #103 (URL-mode elicitation, 2025-11-25). **Core + server**; client-side handling follows in PR2. Design vetted against a second-agent review (union parser at the client boundary, capability semantics, error wire-preservation, no auto-open — all incorporated).

## What

- **Core types** (`mcpkit-core::types::elicitation`): `ElicitMode`; optional `mode` on `ElicitRequest` (absent = form, backward-compatible); `UrlElicitRequest { mode, message, elicitationId, url }`; `ElicitRequestParams` — an untagged union that parses either mode from the wire (the client dispatch boundary needs this); `ElicitationCompleteNotification { elicitationId }`.
- **Capability**: `ElicitationCapability` is now `{ form?, url? }`. `ClientCapabilities` gains `with_form_elicitation`/`with_url_elicitation` and `has_form_elicitation`/`has_url_elicitation`. An empty `{}` (legacy `with_elicitation`) remains **form-capable** and still serializes as `{}` — backward-compatible.
- **Error**: `McpError::UrlElicitationRequired { elicitations }` + `URL_ELICITATION_REQUIRED = -32042`. The `From<&McpError> for JsonRpcError` conversion preserves `code: -32042` and `data.elicitations` (a `McpError::internal` path would have lost the structured semantics).
- **Server**: `Context::elicit_url(UrlElicitRequest)` sends a URL-mode `elicitation/create` gated on the client's `elicitation.url` sub-capability (reusing the #73 reverse-request path); `ServerNotifier::elicitation_complete(id)` sends `notifications/elicitation/complete`.

## Decisions (as agreed)

- Kept `ElicitRequest` as the form request + a separate `UrlElicitRequest` (minimal breakage) rather than a tagged enum.
- Security binding of `elicitationId` to a verified user is the **application's** responsibility (documented on `elicit_url`), consistent with #86; mcpkit provides the mechanism.
- `elicitation: {}` = form-only is treated as a documented backward-compat interpretation.
- **Deferred**: task-augmented elicitation (a #81 tie-in).

## Next (PR2)

Client-side: parse url-mode `elicitation/create` via `ElicitRequestParams`, a consent hook that **does not auto-open** URLs (default decline/unsupported), and dispatch of the completion notification; client capability builders/macros.

## Test plan

- New: `UrlElicitRequest`/`ElicitRequestParams`/`ElicitationCompleteNotification` serde; capability form/url semantics (incl. `{}`=form and the `{}` round-trip); the `-32042` wire conversion preserving `data.elicitations`.
- `fmt` / `clippy -D warnings` / `cargo test --workspace --all-features --locked` / `doc -D warnings` all green.

Spec: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation