### PR TITLE
feat(client): handle URL-mode elicitation + completion (#103 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   wire. `ClientCapabilities` gains `with_form_elicitation`/`with_url_elicitation`
   and `has_form_elicitation`/`has_url_elicitation`; `ElicitationCapability` is now
   `{ form?, url? }` (an empty `{}` remains form-capable for backwards
-  compatibility). Client-side URL handling (with a consent hook) and the
-  completion-notification dispatch follow in a second PR
+  compatibility).
+  The client now handles both modes: it parses `elicitation/create` via the
+  `ElicitRequestParams` union and dispatches URL-mode requests to a new
+  `ClientHandler::elicit_url` (default: **decline** — a client must not open a
+  URL without explicit user consent), and dispatches
+  `notifications/elicitation/complete` to `ClientHandler::on_elicitation_complete`.
+  The `#[mcp_client]` macro gains `#[elicit_url]` and `#[on_elicitation_complete]`
+  handler attributes
   ([#103](https://github.com/praxiomlabs/mcpkit/issues/103)).
 - Session-to-verified-user binding (security). A new
   `mcpkit_core::auth::VerifiedUser` (`subject` + `issuer` + `audience`) models an

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -23,7 +23,7 @@ use mcpkit_core::protocol::{Message, Notification, Request, RequestId, Response}
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_core::types::{
     CallToolRequest, CallToolResult, CancelTaskRequest, CompleteRequest, CompleteResult,
-    CompletionArgument, CompletionRef, CreateMessageRequest, ElicitRequest, GetPromptRequest,
+    CompletionArgument, CompletionRef, CreateMessageRequest, ElicitRequestParams, GetPromptRequest,
     GetPromptResult, GetTaskRequest, ListPromptsResult, ListResourceTemplatesResult,
     ListResourcesResult, ListTasksRequest, ListTasksResult, ListToolsResult, Prompt,
     ReadResourceRequest, ReadResourceResult, Resource, ResourceContents, ResourceTemplate, Task,
@@ -379,25 +379,29 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
 
     /// Handle an elicitation/create request.
     async fn handle_elicitation_request(request: &Request, handler: &Arc<H>) -> Response {
-        let params = match &request.params {
-            Some(p) => match serde_json::from_value::<ElicitRequest>(p.clone()) {
-                Ok(req) => req,
-                Err(e) => {
-                    return Response::error(
-                        request.id.clone(),
-                        JsonRpcError::invalid_params(format!("Invalid params: {e}")),
-                    );
-                }
-            },
-            None => {
+        let Some(p) = &request.params else {
+            return Response::error(
+                request.id.clone(),
+                JsonRpcError::invalid_params("Missing params for elicitation/create"),
+            );
+        };
+        // Parse either form- or url-mode params (discriminated by `mode`).
+        let params = match serde_json::from_value::<ElicitRequestParams>(p.clone()) {
+            Ok(params) => params,
+            Err(e) => {
                 return Response::error(
                     request.id.clone(),
-                    JsonRpcError::invalid_params("Missing params for elicitation/create"),
+                    JsonRpcError::invalid_params(format!("Invalid params: {e}")),
                 );
             }
         };
 
-        match handler.elicit(params).await {
+        let outcome = match params {
+            ElicitRequestParams::Form(req) => handler.elicit(req).await,
+            ElicitRequestParams::Url(req) => handler.elicit_url(req).await,
+        };
+
+        match outcome {
             Ok(result) => match serde_json::to_value(result) {
                 Ok(value) => Response::success(request.id.clone(), value),
                 Err(e) => Response::error(
@@ -486,6 +490,17 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             "notifications/prompts/list_changed" => {
                 debug!("Prompts list changed");
                 handler.on_prompts_list_changed().await;
+            }
+            "notifications/elicitation/complete" => {
+                if let Some(id) = notification
+                    .params
+                    .as_ref()
+                    .and_then(|p| p.get("elicitationId"))
+                    .and_then(|v| v.as_str())
+                {
+                    debug!(elicitation_id = %id, "Elicitation completed");
+                    handler.on_elicitation_complete(id.to_string()).await;
+                }
             }
             _ => {
                 trace!(method = %notification.method, "Unhandled notification");

--- a/crates/mcpkit-client/src/handler.rs
+++ b/crates/mcpkit-client/src/handler.rs
@@ -11,6 +11,7 @@
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
     CreateMessageRequest, CreateMessageResult, ElicitRequest, ElicitResult, TaskId, TaskProgress,
+    UrlElicitRequest,
 };
 use std::future::Future;
 
@@ -71,6 +72,29 @@ pub trait ClientHandler: Send + Sync {
                 available: Box::new([]),
             })
         }
+    }
+
+    /// Handle a URL-mode elicitation request from the server.
+    ///
+    /// The server is asking the user to navigate to a URL for an out-of-band
+    /// interaction (e.g. authorization).
+    ///
+    /// **Security:** the default implementation **declines** — a client MUST NOT
+    /// open the URL without explicit user consent. Override this to clearly show
+    /// the URL's domain, obtain consent, open the URL, and return the action.
+    /// Only override it (and declare the `elicitation.url` capability) if you can
+    /// honour that consent requirement.
+    fn elicit_url(
+        &self,
+        _request: UrlElicitRequest,
+    ) -> impl Future<Output = Result<ElicitResult, McpError>> + Send {
+        async { Ok(ElicitResult::declined()) }
+    }
+
+    /// Called when a URL-mode elicitation's out-of-band interaction has
+    /// completed (`notifications/elicitation/complete`).
+    fn on_elicitation_complete(&self, _elicitation_id: String) -> impl Future<Output = ()> + Send {
+        async {}
     }
 
     /// List roots that the client exposes.

--- a/crates/mcpkit-macros-tests/tests/client_url_elicitation.rs
+++ b/crates/mcpkit-macros-tests/tests/client_url_elicitation.rs
@@ -1,0 +1,48 @@
+//! `#[mcp_client]` wires `#[elicit_url]` and `#[on_elicitation_complete]` to the
+//! `ClientHandler` methods (rather than silently using the defaults).
+
+use mcpkit::client::ClientHandler;
+use mcpkit::error::McpError;
+use mcpkit::mcp_client;
+use mcpkit::types::{ElicitResult, UrlElicitRequest};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+struct H {
+    completed: AtomicBool,
+}
+
+#[mcp_client]
+impl H {
+    // A real client would show the URL's domain, get consent, and open it.
+    #[elicit_url]
+    async fn on_url(&self, _request: UrlElicitRequest) -> Result<ElicitResult, McpError> {
+        Ok(ElicitResult::accepted(serde_json::Map::new()))
+    }
+
+    #[on_elicitation_complete]
+    async fn on_done(&self, _elicitation_id: String) {
+        self.completed.store(true, Ordering::SeqCst);
+    }
+}
+
+#[tokio::test]
+async fn client_wires_url_elicitation_handlers() {
+    let handler = H {
+        completed: AtomicBool::new(false),
+    };
+
+    // `elicit_url` dispatches to the user method (which accepts) rather than the
+    // trait default (which declines).
+    let result = handler
+        .elicit_url(UrlElicitRequest::new("authorize", "e1", "https://auth/x"))
+        .await
+        .expect("elicit_url");
+    assert!(
+        result.is_accepted(),
+        "the #[elicit_url] method must be wired, not the default decline"
+    );
+
+    // `on_elicitation_complete` dispatches to the user method.
+    handler.on_elicitation_complete("e1".to_string()).await;
+    assert!(handler.completed.load(Ordering::SeqCst));
+}

--- a/crates/mcpkit-macros/src/client.rs
+++ b/crates/mcpkit-macros/src/client.rs
@@ -32,6 +32,9 @@ pub fn expand_mcp_client(attr: TokenStream, item: TokenStream) -> Result<TokenSt
     // Find handler methods
     let sampling_method = find_and_remove_handler(&mut impl_block, "sampling");
     let elicitation_method = find_and_remove_handler(&mut impl_block, "elicitation");
+    let elicit_url_method = find_and_remove_handler(&mut impl_block, "elicit_url");
+    let on_elicitation_complete_method =
+        find_and_remove_handler(&mut impl_block, "on_elicitation_complete");
     let roots_method = find_and_remove_handler(&mut impl_block, "roots");
 
     // Find lifecycle hooks
@@ -57,6 +60,8 @@ pub fn expand_mcp_client(attr: TokenStream, item: TokenStream) -> Result<TokenSt
         self_ty,
         sampling_method.as_ref(),
         elicitation_method.as_ref(),
+        elicit_url_method.as_ref(),
+        on_elicitation_complete_method.as_ref(),
         roots_method.as_ref(),
         on_connected_method.as_ref(),
         on_disconnected_method.as_ref(),
@@ -126,6 +131,8 @@ fn generate_client_handler(
     self_ty: &syn::Type,
     sampling_method: Option<&HandlerMethod>,
     elicitation_method: Option<&HandlerMethod>,
+    elicit_url_method: Option<&HandlerMethod>,
+    on_elicitation_complete_method: Option<&HandlerMethod>,
     roots_method: Option<&HandlerMethod>,
     on_connected_method: Option<&HandlerMethod>,
     on_disconnected_method: Option<&HandlerMethod>,
@@ -198,6 +205,55 @@ fn generate_client_handler(
                     async move {
                         Ok(#call)
                     }
+                }
+            }
+        }
+    } else {
+        quote!()
+    };
+
+    // Generate elicit_url method
+    let elicit_url_impl = if let Some(method) = elicit_url_method {
+        let method_name = &method.name;
+        let call = if method.is_async {
+            quote!(self.#method_name(request).await)
+        } else {
+            quote!(self.#method_name(request))
+        };
+        let body = if method.returns_result {
+            quote!(#call)
+        } else {
+            quote!(Ok(#call))
+        };
+        quote! {
+            fn elicit_url(
+                &self,
+                request: ::mcpkit::types::UrlElicitRequest,
+            ) -> impl std::future::Future<Output = Result<::mcpkit::types::ElicitResult, ::mcpkit::error::McpError>> + Send {
+                async move {
+                    #body
+                }
+            }
+        }
+    } else {
+        quote!()
+    };
+
+    // Generate on_elicitation_complete method
+    let on_elicitation_complete_impl = if let Some(method) = on_elicitation_complete_method {
+        let method_name = &method.name;
+        let call = if method.is_async {
+            quote!(self.#method_name(elicitation_id).await)
+        } else {
+            quote!(self.#method_name(elicitation_id))
+        };
+        quote! {
+            fn on_elicitation_complete(
+                &self,
+                elicitation_id: String,
+            ) -> impl std::future::Future<Output = ()> + Send {
+                async move {
+                    #call
                 }
             }
         }
@@ -374,6 +430,8 @@ fn generate_client_handler(
         impl ::mcpkit::client::ClientHandler for #self_ty {
             #create_message_impl
             #elicit_impl
+            #elicit_url_impl
+            #on_elicitation_complete_impl
             #list_roots_impl
             #on_connected_impl
             #on_disconnected_impl


### PR DESCRIPTION
Completes #103 (PR1 core+server merged in #126). Client-side URL-mode elicitation handling.

## What

- **Dispatch both modes:** `handle_elicitation_request` now parses `elicitation/create` via the `ElicitRequestParams` union and routes form requests to `ClientHandler::elicit` and url requests to a new `ClientHandler::elicit_url`.
- **Consent-safe default:** `elicit_url`'s default implementation **declines** — a client must not open a URL without explicit user consent. The doc directs implementors to show the URL's domain, obtain consent, open it, and return the action.
- **Completion notification:** `notifications/elicitation/complete` is dispatched to a new `ClientHandler::on_elicitation_complete`.
- **Macro parity (footgun fix):** `#[mcp_client]` now maps `#[elicit_url]` and `#[on_elicitation_complete]` handler methods. Without this, a user's `elicit_url` method would be silently ignored in favour of the default.

## Test plan

- New macro test: a `#[mcp_client]` handler whose `#[elicit_url]` accepts and `#[on_elicitation_complete]` sets a flag — asserts both are wired (the accept distinguishes it from the default decline).
- `fmt` / `clippy -D warnings` / `cargo test --workspace --all-features --locked` / `doc -D warnings` all green.

Spec: https://modelcontextprotocol.io/specification/2025-11-25/client/elicitation