### PR TITLE
feat(server): opt-in list pagination with opaque cursors (#78 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- List pagination (opt-in). A new `mcpkit_core::pagination` module provides an
+  opaque, versioned base64url cursor codec and a `paginate` helper. The server
+  now honours the inbound `cursor` and returns a `nextCursor` for `tools/list`,
+  `resources/list`, `resources/templates/list`, and `prompts/list`.
+  `Server::list_page_size(n)` enables paging at page size `n` (default: disabled
+  — lists return everything with no `nextCursor`, unchanged behaviour); an
+  invalid cursor is an `Invalid params` error. Handler traits are unchanged
+  (routing-layer paging). Cursors are offset-based, so a list that changes
+  between page requests may skip or repeat entries — fine for static tool/prompt
+  lists, a documented caveat for dynamic resource lists. Adapter (axum/actix/
+  warp/rocket) page-size configuration and client "list all" cursor-following
+  follow in subsequent PRs
+  ([#78](https://github.com/praxiomlabs/mcpkit/issues/78)).
 - URL-mode elicitation (2025-11-25), core + server. `ElicitRequest` gains an
   optional `mode` (absent = form); new `UrlElicitRequest`
   (`mode`/`message`/`elicitationId`/`url`), `ElicitRequestParams` (a union that

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -227,7 +227,9 @@ where
         }
         _ => {
             // Try routing to tools
-            if let Some(result) = route_tools(state.handler.as_ref(), method, params, &ctx).await {
+            if let Some(result) =
+                route_tools(state.handler.as_ref(), method, params, &ctx, None).await
+            {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
                     Err(e) => Response::error(request.id.clone(), e.into()),
@@ -236,7 +238,7 @@ where
 
             // Try routing to resources
             if let Some(result) =
-                route_resources(state.handler.as_ref(), method, params, &ctx).await
+                route_resources(state.handler.as_ref(), method, params, &ctx, None).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -245,7 +247,8 @@ where
             }
 
             // Try routing to prompts
-            if let Some(result) = route_prompts(state.handler.as_ref(), method, params, &ctx).await
+            if let Some(result) =
+                route_prompts(state.handler.as_ref(), method, params, &ctx, None).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -256,7 +256,9 @@ where
         }
         _ => {
             // Try routing to tools
-            if let Some(result) = route_tools(state.handler.as_ref(), method, params, &ctx).await {
+            if let Some(result) =
+                route_tools(state.handler.as_ref(), method, params, &ctx, None).await
+            {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
                     Err(e) => Response::error(request.id.clone(), e.into()),
@@ -265,7 +267,7 @@ where
 
             // Try routing to resources
             if let Some(result) =
-                route_resources(state.handler.as_ref(), method, params, &ctx).await
+                route_resources(state.handler.as_ref(), method, params, &ctx, None).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -274,7 +276,8 @@ where
             }
 
             // Try routing to prompts
-            if let Some(result) = route_prompts(state.handler.as_ref(), method, params, &ctx).await
+            if let Some(result) =
+                route_prompts(state.handler.as_ref(), method, params, &ctx, None).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-core/src/lib.rs
+++ b/crates/mcpkit-core/src/lib.rs
@@ -63,6 +63,7 @@ pub mod capability;
 pub mod debug;
 pub mod error;
 pub mod extension;
+pub mod pagination;
 pub mod protocol;
 pub mod protocol_version;
 pub mod schema;

--- a/crates/mcpkit-core/src/pagination.rs
+++ b/crates/mcpkit-core/src/pagination.rs
@@ -1,0 +1,144 @@
+//! Opaque cursor pagination for list results.
+//!
+//! MCP list operations (`tools/list`, `resources/list`, etc.) use an opaque
+//! `cursor` and return an optional `nextCursor`. This module provides an
+//! offset-based cursor codec and a helper to page a `Vec` of results.
+//!
+//! Cursors are versioned, base64url-encoded tokens; a client MUST treat them as
+//! opaque. Because they are offset-based, if the underlying list changes between
+//! page requests entries may be skipped or repeated — acceptable for the
+//! mostly-static tool/prompt lists, and a documented limitation for dynamic
+//! resource lists.
+
+use crate::error::McpError;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+
+const CURSOR_VERSION: u8 = 1;
+
+#[derive(Serialize, Deserialize)]
+struct CursorToken {
+    v: u8,
+    offset: usize,
+}
+
+/// Encode an offset as an opaque, versioned cursor token.
+#[must_use]
+pub fn encode_cursor(offset: usize) -> String {
+    let json = serde_json::to_vec(&CursorToken {
+        v: CURSOR_VERSION,
+        offset,
+    })
+    .unwrap_or_default();
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(json)
+}
+
+/// Decode an opaque cursor into its offset.
+///
+/// # Errors
+///
+/// Returns `invalid_params` if the cursor is malformed or carries an unsupported
+/// version.
+pub fn decode_cursor(method: &str, cursor: &str) -> Result<usize, McpError> {
+    let bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| McpError::invalid_params(method, "invalid cursor"))?;
+    let token: CursorToken = serde_json::from_slice(&bytes)
+        .map_err(|_| McpError::invalid_params(method, "invalid cursor"))?;
+    if token.v != CURSOR_VERSION {
+        return Err(McpError::invalid_params(
+            method,
+            "unsupported cursor version",
+        ));
+    }
+    Ok(token.offset)
+}
+
+/// Paginate `items` given an inbound `cursor` and an optional `page_size`.
+///
+/// When `page_size` is `None` (or zero) pagination is disabled: all items from
+/// the cursor offset are returned with no next cursor. Otherwise a single page
+/// is returned, plus a `nextCursor` when more items remain.
+///
+/// # Errors
+///
+/// Returns `invalid_params` if `cursor` is malformed.
+pub fn paginate<T>(
+    items: Vec<T>,
+    cursor: Option<&str>,
+    page_size: Option<usize>,
+    method: &str,
+) -> Result<(Vec<T>, Option<String>), McpError> {
+    let offset = match cursor {
+        Some(c) => decode_cursor(method, c)?,
+        None => 0,
+    };
+
+    let Some(page_size) = page_size.filter(|&n| n > 0) else {
+        // Pagination disabled: return the remainder from the offset, no cursor.
+        return Ok((items.into_iter().skip(offset).collect(), None));
+    };
+
+    if offset >= items.len() {
+        return Ok((Vec::new(), None));
+    }
+    let end = (offset + page_size).min(items.len());
+    let has_more = end < items.len();
+    let page = items.into_iter().skip(offset).take(page_size).collect();
+    let next = has_more.then(|| encode_cursor(end));
+    Ok((page, next))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cursor_roundtrips_and_is_opaque() {
+        let c = encode_cursor(100);
+        assert!(
+            !c.contains("100"),
+            "cursor should be opaque, not a raw offset"
+        );
+        assert_eq!(decode_cursor("tools/list", &c).unwrap(), 100);
+    }
+
+    #[test]
+    fn invalid_cursor_is_invalid_params() {
+        assert!(decode_cursor("tools/list", "not-base64!!!").is_err());
+        // Valid base64 but not a cursor token.
+        let junk = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}");
+        assert!(decode_cursor("tools/list", &junk).is_err());
+    }
+
+    #[test]
+    fn disabled_pagination_returns_all() {
+        let (page, next) = paginate(vec![1, 2, 3], None, None, "m").unwrap();
+        assert_eq!(page, vec![1, 2, 3]);
+        assert!(next.is_none());
+    }
+
+    #[test]
+    fn pages_and_emits_next_cursor() {
+        let items: Vec<u32> = (0..5).collect();
+        // First page.
+        let (page, next) = paginate(items.clone(), None, Some(2), "m").unwrap();
+        assert_eq!(page, vec![0, 1]);
+        let next = next.expect("more remain");
+        // Second page via the cursor.
+        let (page, next) = paginate(items.clone(), Some(&next), Some(2), "m").unwrap();
+        assert_eq!(page, vec![2, 3]);
+        let next = next.expect("more remain");
+        // Final page: exactly one item, no further cursor.
+        let (page, next) = paginate(items, Some(&next), Some(2), "m").unwrap();
+        assert_eq!(page, vec![4]);
+        assert!(next.is_none());
+    }
+
+    #[test]
+    fn offset_at_or_past_end_is_empty() {
+        let (page, next) = paginate(vec![1, 2], Some(&encode_cursor(2)), Some(10), "m").unwrap();
+        assert!(page.is_empty());
+        assert!(next.is_none());
+    }
+}

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -378,7 +378,9 @@ where
         }
         _ => {
             // Try routing to tools
-            if let Some(result) = route_tools(state.handler.as_ref(), method, params, &ctx).await {
+            if let Some(result) =
+                route_tools(state.handler.as_ref(), method, params, &ctx, None).await
+            {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
                     Err(e) => Response::error(request.id.clone(), e.into()),
@@ -387,7 +389,7 @@ where
 
             // Try routing to resources
             if let Some(result) =
-                route_resources(state.handler.as_ref(), method, params, &ctx).await
+                route_resources(state.handler.as_ref(), method, params, &ctx, None).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -396,7 +398,8 @@ where
             }
 
             // Try routing to prompts
-            if let Some(result) = route_prompts(state.handler.as_ref(), method, params, &ctx).await
+            if let Some(result) =
+                route_prompts(state.handler.as_ref(), method, params, &ctx, None).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-server/src/builder.rs
+++ b/crates/mcpkit-server/src/builder.rs
@@ -265,6 +265,7 @@ where
             prompts: self.prompts,
             tasks: self.tasks,
             capabilities: self.capabilities,
+            list_page_size: None,
         }
     }
 }
@@ -284,6 +285,9 @@ pub struct Server<H, T, R, P, K> {
     pub(crate) prompts: P,
     pub(crate) tasks: K,
     capabilities: ServerCapabilities,
+    /// Page size for `*/list` results; `None` disables pagination (list
+    /// responses return everything, no `nextCursor`).
+    pub(crate) list_page_size: Option<usize>,
 }
 
 impl<H, T, R, P, K> Server<H, T, R, P, K>
@@ -294,6 +298,19 @@ where
     #[must_use]
     pub const fn capabilities(&self) -> &ServerCapabilities {
         &self.capabilities
+    }
+
+    /// Enable pagination of `tools/list`, `resources/list`,
+    /// `resources/templates/list`, and `prompts/list` at the given page size.
+    ///
+    /// By default pagination is disabled (each list returns all items with no
+    /// `nextCursor`). Setting a page size bounds the response payload; clients
+    /// follow the returned `nextCursor` to fetch subsequent pages. A size of `0`
+    /// is treated as disabled.
+    #[must_use]
+    pub const fn list_page_size(mut self, page_size: usize) -> Self {
+        self.list_page_size = Some(page_size);
+        self
     }
 
     /// Get a reference to the base handler.

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -510,7 +510,27 @@ fn parse_list_params(params: Option<&Value>) -> ListParams {
 
 use crate::context::Context;
 use crate::dispatch::{DynPromptHandler, DynResourceHandler, DynTaskHandler, DynToolHandler};
+use mcpkit_core::pagination::paginate;
 use mcpkit_core::types::{CallToolResult, TaskId};
+
+/// Build a paginated list result: the items under `key` plus an optional
+/// `nextCursor`.
+fn list_result<T: serde::Serialize>(key: &str, items: Vec<T>, next: Option<String>) -> Value {
+    let mut obj = serde_json::Map::new();
+    obj.insert(
+        key.to_string(),
+        serde_json::to_value(items).unwrap_or_default(),
+    );
+    if let Some(cursor) = next {
+        obj.insert("nextCursor".to_string(), Value::String(cursor));
+    }
+    Value::Object(obj)
+}
+
+/// The `cursor` string from list-request params, if present.
+fn list_cursor(params: Option<&Value>) -> Option<&str> {
+    params.and_then(|p| p.get("cursor")).and_then(Value::as_str)
+}
 
 /// Route tool-related requests to a handler implementing
 /// [`ToolHandler`](crate::handler::ToolHandler).
@@ -530,16 +550,20 @@ pub async fn route_tools(
     method: &str,
     params: Option<&serde_json::Value>,
     ctx: &Context<'_>,
+    page_size: Option<usize>,
 ) -> Option<Result<serde_json::Value, McpError>> {
     match method {
         methods::TOOLS_LIST => {
             tracing::debug!("Listing available tools");
-            let result = handler.list_tools(ctx).await;
-            match &result {
-                Ok(tools) => tracing::debug!(count = tools.len(), "Listed tools"),
-                Err(e) => tracing::warn!(error = %e, "Failed to list tools"),
+            let result = async {
+                let tools = handler.list_tools(ctx).await?;
+                let (page, next) =
+                    paginate(tools, list_cursor(params), page_size, methods::TOOLS_LIST)?;
+                tracing::debug!(count = page.len(), "Listed tools");
+                Ok(list_result("tools", page, next))
             }
-            Some(result.map(|tools| serde_json::json!({ "tools": tools })))
+            .await;
+            Some(result)
         }
         methods::TOOLS_CALL => {
             let result = async {
@@ -602,27 +626,40 @@ pub async fn route_resources(
     method: &str,
     params: Option<&serde_json::Value>,
     ctx: &Context<'_>,
+    page_size: Option<usize>,
 ) -> Option<Result<serde_json::Value, McpError>> {
     match method {
         methods::RESOURCES_LIST => {
             tracing::debug!("Listing available resources");
-            let result = handler.list_resources(ctx).await;
-            match &result {
-                Ok(resources) => tracing::debug!(count = resources.len(), "Listed resources"),
-                Err(e) => tracing::warn!(error = %e, "Failed to list resources"),
+            let result = async {
+                let resources = handler.list_resources(ctx).await?;
+                let (page, next) = paginate(
+                    resources,
+                    list_cursor(params),
+                    page_size,
+                    methods::RESOURCES_LIST,
+                )?;
+                tracing::debug!(count = page.len(), "Listed resources");
+                Ok(list_result("resources", page, next))
             }
-            Some(result.map(|resources| serde_json::json!({ "resources": resources })))
+            .await;
+            Some(result)
         }
         methods::RESOURCES_TEMPLATES_LIST => {
             tracing::debug!("Listing available resource templates");
-            let result = handler.list_resource_templates(ctx).await;
-            match &result {
-                Ok(templates) => {
-                    tracing::debug!(count = templates.len(), "Listed resource templates");
-                }
-                Err(e) => tracing::warn!(error = %e, "Failed to list resource templates"),
+            let result = async {
+                let templates = handler.list_resource_templates(ctx).await?;
+                let (page, next) = paginate(
+                    templates,
+                    list_cursor(params),
+                    page_size,
+                    methods::RESOURCES_TEMPLATES_LIST,
+                )?;
+                tracing::debug!(count = page.len(), "Listed resource templates");
+                Ok(list_result("resourceTemplates", page, next))
             }
-            Some(result.map(|templates| serde_json::json!({ "resourceTemplates": templates })))
+            .await;
+            Some(result)
         }
         methods::RESOURCES_READ => {
             let result = async {
@@ -680,16 +717,24 @@ pub async fn route_prompts(
     method: &str,
     params: Option<&serde_json::Value>,
     ctx: &Context<'_>,
+    page_size: Option<usize>,
 ) -> Option<Result<serde_json::Value, McpError>> {
     match method {
         methods::PROMPTS_LIST => {
             tracing::debug!("Listing available prompts");
-            let result = handler.list_prompts(ctx).await;
-            match &result {
-                Ok(prompts) => tracing::debug!(count = prompts.len(), "Listed prompts"),
-                Err(e) => tracing::warn!(error = %e, "Failed to list prompts"),
+            let result = async {
+                let prompts = handler.list_prompts(ctx).await?;
+                let (page, next) = paginate(
+                    prompts,
+                    list_cursor(params),
+                    page_size,
+                    methods::PROMPTS_LIST,
+                )?;
+                tracing::debug!(count = page.len(), "Listed prompts");
+                Ok(list_result("prompts", page, next))
             }
-            Some(result.map(|prompts| serde_json::json!({ "prompts": prompts })))
+            .await;
+            Some(result)
         }
         methods::PROMPTS_GET => {
             let result = async {
@@ -1361,5 +1406,79 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn route_tools_paginates_tools_list() {
+        use crate::context::NoOpPeer;
+        use crate::handler::ToolHandler;
+        use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+        use mcpkit_core::protocol::RequestId;
+        use mcpkit_core::protocol_version::ProtocolVersion;
+        use mcpkit_core::types::{Tool, ToolOutput};
+
+        struct Tools;
+        impl ToolHandler for Tools {
+            async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+                Ok(vec![Tool::new("a"), Tool::new("b"), Tool::new("c")])
+            }
+            async fn call_tool(
+                &self,
+                _name: &str,
+                _args: Value,
+                _ctx: &Context<'_>,
+            ) -> Result<ToolOutput, McpError> {
+                Ok(ToolOutput::text("x"))
+            }
+        }
+
+        let handler = Tools;
+        let request_id = RequestId::Number(1);
+        let client_caps = ClientCapabilities::default();
+        let server_caps = ServerCapabilities::default();
+        let peer = NoOpPeer;
+        let ctx = Context::new(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            ProtocolVersion::LATEST,
+            &peer,
+        );
+
+        // Page 1 of size 2 -> two tools plus a nextCursor.
+        let page1 = route_tools(&handler, methods::TOOLS_LIST, None, &ctx, Some(2))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(page1["tools"].as_array().unwrap().len(), 2);
+        let cursor = page1["nextCursor"]
+            .as_str()
+            .expect("nextCursor")
+            .to_string();
+
+        // Page 2 via the cursor -> the last tool, no further cursor.
+        let params = serde_json::json!({ "cursor": cursor });
+        let page2 = route_tools(&handler, methods::TOOLS_LIST, Some(&params), &ctx, Some(2))
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(page2["tools"].as_array().unwrap().len(), 1);
+        assert!(page2.get("nextCursor").is_none());
+
+        // Pagination disabled (None) -> all three, no cursor.
+        let all = route_tools(&handler, methods::TOOLS_LIST, None, &ctx, None)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(all["tools"].as_array().unwrap().len(), 3);
+        assert!(all.get("nextCursor").is_none());
+
+        // An invalid cursor is a routed error.
+        let bad = serde_json::json!({ "cursor": "not-a-cursor" });
+        let err = route_tools(&handler, methods::TOOLS_LIST, Some(&bad), &ctx, Some(2))
+            .await
+            .unwrap();
+        assert!(err.is_err());
     }
 }

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -1179,18 +1179,19 @@ where
         if method == "ping" {
             return Ok(serde_json::json!({}));
         }
+        let page_size = self.list_page_size;
         if let Some(handler) = self.tools.as_tool_handler() {
-            if let Some(result) = route_tools(handler, method, params, ctx).await {
+            if let Some(result) = route_tools(handler, method, params, ctx, page_size).await {
                 return result;
             }
         }
         if let Some(handler) = self.resources.as_resource_handler() {
-            if let Some(result) = route_resources(handler, method, params, ctx).await {
+            if let Some(result) = route_resources(handler, method, params, ctx, page_size).await {
                 return result;
             }
         }
         if let Some(handler) = self.prompts.as_prompt_handler() {
-            if let Some(result) = route_prompts(handler, method, params, ctx).await {
+            if let Some(result) = route_prompts(handler, method, params, ctx, page_size).await {
                 return result;
             }
         }

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -261,7 +261,9 @@ where
         }
         _ => {
             // Try routing to tools
-            if let Some(result) = route_tools(state.handler.as_ref(), method, params, &ctx).await {
+            if let Some(result) =
+                route_tools(state.handler.as_ref(), method, params, &ctx, None).await
+            {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
                     Err(e) => Response::error(request.id.clone(), e.into()),
@@ -270,7 +272,7 @@ where
 
             // Try routing to resources
             if let Some(result) =
-                route_resources(state.handler.as_ref(), method, params, &ctx).await
+                route_resources(state.handler.as_ref(), method, params, &ctx, None).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -279,7 +281,8 @@ where
             }
 
             // Try routing to prompts
-            if let Some(result) = route_prompts(state.handler.as_ref(), method, params, &ctx).await
+            if let Some(result) =
+                route_prompts(state.handler.as_ref(), method, params, &ctx, None).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),


### PR DESCRIPTION
First of a small series for #78. **Server-side pagination mechanism + ServerRuntime config.** Design vetted against a second-agent review (opaque versioned cursor, cover `resources/templates/list`, keep handler traits) — incorporated.

## What

- **`mcpkit_core::pagination`**: an opaque, **versioned** base64url cursor (`{"v":1,"offset":N}` — a client MUST treat it as opaque; invalid → `Invalid params`) + a routing-layer `paginate(items, cursor, page_size, method)` helper.
- **`route_tools`/`route_resources`/`route_prompts`** gain a `page_size: Option<usize>` and page the handler's `Vec`, emitting `nextCursor`. Covers `tools/list`, `resources/list`, **`resources/templates/list`**, and `prompts/list`.
- **`Server::list_page_size(n)`** enables paging on the `ServerRuntime` path. **Default: disabled** (lists return everything with no `nextCursor` — unchanged behavior); a size of 0 is treated as disabled.

## Decisions (as agreed)

- **Routing-layer paging, handler traits unchanged** — no break to the public handler traits, macro-generated handlers, examples, or adapters (option A over the breaking handler-controlled option B).
- **Opt-in** — on-by-default would silently truncate existing clients that ignore `nextCursor`.
- Evolved `route_*` in place (adding the param) rather than parallel `*_with_pagination` variants — consistent with the pre-1.0 `route_*` reshape in #117, no permanent API cruft.

## Caveat (documented)

Cursors are offset-based: a list that changes between page requests can skip or repeat entries. Fine for the mostly-static tool/prompt lists; noted as a limitation for dynamic resource lists.

## Follow-ups (noted)

- **PR2:** adapter (axum/actix/warp/rocket) `list_page_size` config on `McpState` (they currently pass `None`).
- **PR3:** client `list_tools()`/`list_resources()`/`list_prompts()` follow `nextCursor` to exhaustion (keeping `*_paginated` single-page) — needed so an mcpkit client doesn't silently truncate against a paginating server.

## Test plan

- Core: cursor round-trip + opacity, invalid-cursor → error, disabled-returns-all, multi-page + `nextCursor`, offset-past-end.
- Routing: `route_tools` end-to-end paging (page 1 + cursor → page 2 → done; disabled → all; invalid cursor → error).
- `fmt` / `clippy -D warnings` / `cargo test --workspace --all-features --locked` / `doc -D warnings` all green.

Spec: https://modelcontextprotocol.io/specification/2025-11-25/server/utilities/pagination