### PR TITLE
feat(adapters): list_page_size config on HTTP adapters (#78 PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   invalid cursor is an `Invalid params` error. Handler traits are unchanged
   (routing-layer paging). Cursors are offset-based, so a list that changes
   between page requests may skip or repeat entries — fine for static tool/prompt
-  lists, a documented caveat for dynamic resource lists. Adapter (axum/actix/
-  warp/rocket) page-size configuration and client "list all" cursor-following
-  follow in subsequent PRs
+  lists, a documented caveat for dynamic resource lists. The HTTP adapters
+  (axum/actix/warp/rocket) expose the same configuration via
+  `McpRouter::list_page_size(n)` (and
+  `McpState::with_list_page_size(n)`); client "list all" cursor-following follows
+  in a subsequent PR
   ([#78](https://github.com/praxiomlabs/mcpkit/issues/78)).
 - URL-mode elicitation (2025-11-25), core + server. `ElicitRequest` gains an
   optional `mode` (absent = form); new `UrlElicitRequest`

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -227,8 +227,14 @@ where
         }
         _ => {
             // Try routing to tools
-            if let Some(result) =
-                route_tools(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_tools(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -237,8 +243,14 @@ where
             }
 
             // Try routing to resources
-            if let Some(result) =
-                route_resources(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_resources(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -247,8 +259,14 @@ where
             }
 
             // Try routing to prompts
-            if let Some(result) =
-                route_prompts(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_prompts(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-actix/src/router.rs
+++ b/crates/mcpkit-actix/src/router.rs
@@ -70,6 +70,14 @@ where
         }
     }
 
+    /// Set the page size for `*/list` results. `None` (the default) disables
+    /// pagination; a size of `0` is treated as disabled.
+    #[must_use]
+    pub const fn list_page_size(mut self, page_size: usize) -> Self {
+        self.state.list_page_size = Some(page_size);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     ///
     /// For production, you should configure CORS manually with custom settings.

--- a/crates/mcpkit-actix/src/state.rs
+++ b/crates/mcpkit-actix/src/state.rs
@@ -39,6 +39,8 @@ pub struct McpState<H> {
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
+    /// Page size for `*/list` results; `None` disables pagination.
+    pub list_page_size: Option<usize>,
 }
 
 impl<H> McpState<H>
@@ -54,6 +56,7 @@ where
             sse_sessions: Arc::new(SessionManager::new()),
             server_info,
             origin_validator: Arc::new(OriginValidator::default()),
+            list_page_size: None,
         }
     }
 
@@ -66,6 +69,7 @@ where
             sessions: Arc::new(sessions),
             sse_sessions: Arc::new(sse_sessions),
             origin_validator: Arc::new(OriginValidator::default()),
+            list_page_size: None,
         }
     }
 }
@@ -78,6 +82,7 @@ impl<H> Clone for McpState<H> {
             sse_sessions: Arc::clone(&self.sse_sessions),
             server_info: self.server_info.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
+            list_page_size: self.list_page_size,
         }
     }
 }
@@ -97,5 +102,17 @@ impl OAuthState {
     #[must_use]
     pub const fn new(metadata: ProtectedResourceMetadata) -> Self {
         Self { metadata }
+    }
+}
+
+impl<H> McpState<H> {
+    /// Enable pagination of `*/list` results at the given page size.
+    ///
+    /// By default pagination is disabled (lists return everything with no
+    /// `nextCursor`). A size of `0` is treated as disabled.
+    #[must_use]
+    pub const fn with_list_page_size(mut self, page_size: usize) -> Self {
+        self.list_page_size = Some(page_size);
+        self
     }
 }

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -256,8 +256,14 @@ where
         }
         _ => {
             // Try routing to tools
-            if let Some(result) =
-                route_tools(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_tools(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -266,8 +272,14 @@ where
             }
 
             // Try routing to resources
-            if let Some(result) =
-                route_resources(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_resources(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -276,8 +288,14 @@ where
             }
 
             // Try routing to prompts
-            if let Some(result) =
-                route_prompts(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_prompts(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -67,6 +67,14 @@ where
         }
     }
 
+    /// Set the page size for `*/list` results. `None` (the default) disables
+    /// pagination; a size of `0` is treated as disabled.
+    #[must_use]
+    pub const fn list_page_size(mut self, page_size: usize) -> Self {
+        self.state.list_page_size = Some(page_size);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     ///
     /// For production, you should use `with_cors_layer` with a custom configuration.

--- a/crates/mcpkit-axum/src/state.rs
+++ b/crates/mcpkit-axum/src/state.rs
@@ -26,6 +26,8 @@ pub struct McpState<H> {
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
+    /// Page size for `*/list` results; `None` disables pagination.
+    pub list_page_size: Option<usize>,
 }
 
 // Manual Clone implementation to avoid requiring H: Clone
@@ -37,6 +39,7 @@ impl<H> Clone for McpState<H> {
             sessions: Arc::clone(&self.sessions),
             sse_sessions: Arc::clone(&self.sse_sessions),
             origin_validator: Arc::clone(&self.origin_validator),
+            list_page_size: self.list_page_size,
         }
     }
 }
@@ -50,6 +53,7 @@ impl<H> fmt::Debug for McpState<H> {
             .field("sessions", &self.sessions)
             .field("sse_sessions", &format_args!("Arc<SessionManager>"))
             .field("origin_validator", &self.origin_validator)
+            .field("list_page_size", &self.list_page_size)
             .finish()
     }
 }
@@ -67,6 +71,7 @@ impl<H> McpState<H> {
             sessions: Arc::new(SessionStore::with_default_timeout()),
             sse_sessions: Arc::new(SessionManager::new()),
             origin_validator: Arc::new(OriginValidator::default()),
+            list_page_size: None,
         }
     }
 
@@ -82,6 +87,7 @@ impl<H> McpState<H> {
             sessions: Arc::new(sessions),
             sse_sessions: Arc::new(sse_sessions),
             origin_validator: Arc::new(OriginValidator::default()),
+            list_page_size: None,
         }
     }
 }
@@ -117,5 +123,17 @@ impl OAuthState {
     #[must_use]
     pub const fn new(metadata: ProtectedResourceMetadata) -> Self {
         Self { metadata }
+    }
+}
+
+impl<H> McpState<H> {
+    /// Enable pagination of `*/list` results at the given page size.
+    ///
+    /// By default pagination is disabled (lists return everything with no
+    /// `nextCursor`). A size of `0` is treated as disabled.
+    #[must_use]
+    pub const fn with_list_page_size(mut self, page_size: usize) -> Self {
+        self.list_page_size = Some(page_size);
+        self
     }
 }

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -378,8 +378,14 @@ where
         }
         _ => {
             // Try routing to tools
-            if let Some(result) =
-                route_tools(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_tools(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -388,8 +394,14 @@ where
             }
 
             // Try routing to resources
-            if let Some(result) =
-                route_resources(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_resources(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -398,8 +410,14 @@ where
             }
 
             // Try routing to prompts
-            if let Some(result) =
-                route_prompts(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_prompts(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -51,6 +51,14 @@ where
         }
     }
 
+    /// Set the page size for `*/list` results. `None` (the default) disables
+    /// pagination; a size of `0` is treated as disabled.
+    #[must_use]
+    pub const fn list_page_size(mut self, page_size: usize) -> Self {
+        self.state.list_page_size = Some(page_size);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     #[must_use]
     pub const fn with_cors(mut self) -> Self {

--- a/crates/mcpkit-rocket/src/state.rs
+++ b/crates/mcpkit-rocket/src/state.rs
@@ -31,6 +31,8 @@ pub struct McpState<H> {
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
+    /// Page size for `*/list` results; `None` disables pagination.
+    pub list_page_size: Option<usize>,
 }
 
 impl<H> McpState<H>
@@ -46,6 +48,7 @@ where
             sessions: SessionStore::new(),
             sse_sessions: SessionStore::new(),
             origin_validator: Arc::new(OriginValidator::default()),
+            list_page_size: None,
         }
     }
 
@@ -67,7 +70,20 @@ impl<H> Clone for McpState<H> {
             sessions: self.sessions.clone(),
             sse_sessions: self.sse_sessions.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
+            list_page_size: self.list_page_size,
         }
+    }
+}
+
+impl<H> McpState<H> {
+    /// Enable pagination of `*/list` results at the given page size.
+    ///
+    /// By default pagination is disabled (lists return everything with no
+    /// `nextCursor`). A size of `0` is treated as disabled.
+    #[must_use]
+    pub const fn with_list_page_size(mut self, page_size: usize) -> Self {
+        self.list_page_size = Some(page_size);
+        self
     }
 }
 

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -261,8 +261,14 @@ where
         }
         _ => {
             // Try routing to tools
-            if let Some(result) =
-                route_tools(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_tools(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -271,8 +277,14 @@ where
             }
 
             // Try routing to resources
-            if let Some(result) =
-                route_resources(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_resources(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),
@@ -281,8 +293,14 @@ where
             }
 
             // Try routing to prompts
-            if let Some(result) =
-                route_prompts(state.handler.as_ref(), method, params, &ctx, None).await
+            if let Some(result) = route_prompts(
+                state.handler.as_ref(),
+                method,
+                params,
+                &ctx,
+                state.list_page_size,
+            )
+            .await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -93,6 +93,17 @@ where
         self
     }
 
+    /// Set the page size for `*/list` results. `None` (the default) disables
+    /// pagination; a size of `0` is treated as disabled.
+    #[must_use]
+    pub fn list_page_size(mut self, page_size: usize) -> Self {
+        // The builder owns the only reference to the state at this point.
+        if let Some(state) = Arc::get_mut(&mut self.state) {
+            state.list_page_size = Some(page_size);
+        }
+        self
+    }
+
     fn set_origin_validator(&mut self, validator: OriginValidator) {
         // The builder owns the only reference to the state at this point, so
         // `get_mut` succeeds.

--- a/crates/mcpkit-warp/src/state.rs
+++ b/crates/mcpkit-warp/src/state.rs
@@ -31,6 +31,8 @@ pub struct McpState<H> {
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
+    /// Page size for `*/list` results; `None` disables pagination.
+    pub list_page_size: Option<usize>,
 }
 
 impl<H> McpState<H>
@@ -46,6 +48,7 @@ where
             sessions: SessionStore::new(),
             sse_sessions: SessionStore::new(),
             origin_validator: Arc::new(OriginValidator::default()),
+            list_page_size: None,
         }
     }
 
@@ -67,7 +70,20 @@ impl<H> Clone for McpState<H> {
             sessions: self.sessions.clone(),
             sse_sessions: self.sse_sessions.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
+            list_page_size: self.list_page_size,
         }
+    }
+}
+
+impl<H> McpState<H> {
+    /// Enable pagination of `*/list` results at the given page size.
+    ///
+    /// By default pagination is disabled (lists return everything with no
+    /// `nextCursor`). A size of `0` is treated as disabled.
+    #[must_use]
+    pub const fn with_list_page_size(mut self, page_size: usize) -> Self {
+        self.list_page_size = Some(page_size);
+        self
     }
 }
 


### PR DESCRIPTION
Part 2 of #78 (list pagination). Threads the routing-layer pagination config, added to the core server in #128 (PR1), through all four HTTP adapters.

## What
- `McpState<H>` (axum/actix/warp/rocket) gains a `list_page_size: Option<usize>` field, carried through `Clone`/`Debug`/constructors.
- Two ways to configure, mirroring `Server::list_page_size`:
  - `McpRouter::list_page_size(n)` — the primary builder entry point.
  - `McpState::with_list_page_size(n)` — for adapters constructed from raw state.
- The 12 adapter `route_tools`/`route_resources`/`route_prompts` call sites now pass `state.list_page_size` instead of hardcoded `None`.

## Behaviour
Default is unchanged: pagination disabled, `*/list` returns everything with no `nextCursor`. `0` is treated as disabled.

## Not in this PR
Client "list all" cursor-following (PR3) — so an mcpkit client doesn't silently truncate against a paginating server.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `test --workspace --all-features --locked`, and `RUSTDOCFLAGS=-D warnings cargo doc` all green.