### PR TITLE
feat(server): opt-in tool I/O schema validation (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Opt-in tool I/O schema validation (`mcpkit-server`, feature
+  `schema-validation`, off by default). A new `ValidatingToolHandler<H>` decorator
+  validates `tools/call` arguments against each tool's `inputSchema` and
+  structured results against its `outputSchema`, resolving schemas from the inner
+  handler's `list_tools` at call time (no cache). Enable it on the builder with
+  `ServerBuilder::validate_tool_io()` (or the granular `validate_tool_inputs()` /
+  `validate_tool_outputs()`); HTTP-adapter users can wrap their handler directly
+  (the decorator transparently forwards `ServerHandler`/`ResourceHandler`/
+  `PromptHandler`). Per the Tools spec's error handling, arguments that fail the
+  `inputSchema` yield an `isError: true` result (not a `-32602` protocol error,
+  which stays reserved for malformed envelopes and unknown tools); an
+  `outputSchema` violation is logged as a server bug, the invalid
+  `structuredContent` is dropped, and the call returns `isError: true`. The
+  generic `ToolHandler::call_tool` path remains an unchecked escape hatch unless
+  wrapped. String `format` assertions are not enforced. A standalone
+  `validate_json` helper is also exported
+  ([#85](https://github.com/praxiomlabs/mcpkit/issues/85)).
 - List pagination (opt-in). A new `mcpkit_core::pagination` module provides an
   opaque, versioned base64url cursor codec and a `paginate` helper. The server
   now honours the inbound `cursor` and returns a `nextCursor` for `tools/list`,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -52,7 +52,7 @@ dependencies = [
  "derive_more",
  "encoding_rs",
  "flate2",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "h2 0.3.27",
  "http 0.2.12",
@@ -167,7 +167,7 @@ dependencies = [
  "cookie 0.16.2",
  "derive_more",
  "encoding_rs",
- "foldhash",
+ "foldhash 0.1.5",
  "futures-core",
  "futures-util",
  "impl-more",
@@ -228,6 +228,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -250,6 +264,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -682,6 +702,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -707,6 +733,12 @@ name = "bumpalo"
 version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1418,6 +1450,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,6 +1502,17 @@ checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1538,6 +1590,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1548,6 +1611,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-types"
@@ -1571,6 +1640,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -1855,7 +1934,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -1863,6 +1942,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "headers"
@@ -2365,6 +2449,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.46.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24fc8535da347b994f6d2fab0a84b74e3b31ad08ebe4204d95f3e755db7af49b"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
 name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2675,6 +2786,7 @@ dependencies = [
  "chrono",
  "event-listener",
  "futures",
+ "jsonschema",
  "mcpkit-core",
  "mcpkit-transport",
  "serde",
@@ -2763,6 +2875,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
 
 [[package]]
 name = "miette"
@@ -2935,6 +3053,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2961,6 +3093,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2982,6 +3129,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3145,6 +3303,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "owo-colors"
@@ -3838,6 +4002,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.46.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c8dceb372b46fecd006be48ca335468b49ad887a7f0150cabd6098fa4fc500f"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3851,9 +4032,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -5379,6 +5560,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5457,6 +5644,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5473,6 +5670,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/mcpkit-server/Cargo.toml
+++ b/crates/mcpkit-server/Cargo.toml
@@ -21,6 +21,10 @@ event-listener = "5.4"
 tokio = { version = "1", features = ["sync", "rt"], optional = true }
 tracing = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
+# Optional JSON Schema validator for opt-in tool I/O validation. `default-features
+# = false` deliberately drops network/file `$ref` resolution (a tool schema must
+# not trigger outbound fetches).
+jsonschema = { version = "0.46", default-features = false, optional = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["full", "test-util"] }
@@ -28,6 +32,8 @@ tokio = { version = "1", features = ["full", "test-util"] }
 [features]
 default = ["tokio-runtime"]
 tokio-runtime = ["tokio", "mcpkit-transport/tokio-runtime"]
+# Opt-in JSON Schema validation of tool inputs/outputs (see `validation` module).
+schema-validation = ["dep:jsonschema"]
 
 [lints]
 workspace = true

--- a/crates/mcpkit-server/src/builder.rs
+++ b/crates/mcpkit-server/src/builder.rs
@@ -169,6 +169,64 @@ where
     }
 }
 
+// Opt-in tool I/O schema validation (feature `schema-validation`). Wrapping the
+// registered tool handler covers every dispatch path (normal `tools/call`,
+// task-augmented execution, and the HTTP adapters) because they all go through
+// `ToolHandler::call_tool`.
+#[cfg(feature = "schema-validation")]
+impl<H, TH, R, P, K> ServerBuilder<H, Registered<TH>, R, P, K>
+where
+    H: ServerHandler,
+    TH: ToolHandler,
+{
+    /// Validate both `tools/call` arguments against each tool's `inputSchema`
+    /// and structured results against its `outputSchema`.
+    ///
+    /// Arguments that fail the `inputSchema` yield an `isError: true` result (per
+    /// the Tools spec's error handling); an `outputSchema` violation is logged as
+    /// a server bug, the invalid `structuredContent` is dropped, and the call
+    /// returns `isError: true`. See [`crate::validation`].
+    #[must_use]
+    pub fn validate_tool_io(
+        self,
+    ) -> ServerBuilder<H, Registered<crate::validation::ValidatingToolHandler<TH>>, R, P, K> {
+        self.wrap_tool_validation(crate::validation::ValidationMode::both())
+    }
+
+    /// Validate only `tools/call` arguments against each tool's `inputSchema`.
+    #[must_use]
+    pub fn validate_tool_inputs(
+        self,
+    ) -> ServerBuilder<H, Registered<crate::validation::ValidatingToolHandler<TH>>, R, P, K> {
+        self.wrap_tool_validation(crate::validation::ValidationMode::inputs_only())
+    }
+
+    /// Validate only structured results against each tool's `outputSchema`.
+    #[must_use]
+    pub fn validate_tool_outputs(
+        self,
+    ) -> ServerBuilder<H, Registered<crate::validation::ValidatingToolHandler<TH>>, R, P, K> {
+        self.wrap_tool_validation(crate::validation::ValidationMode::outputs_only())
+    }
+
+    fn wrap_tool_validation(
+        self,
+        mode: crate::validation::ValidationMode,
+    ) -> ServerBuilder<H, Registered<crate::validation::ValidatingToolHandler<TH>>, R, P, K> {
+        ServerBuilder {
+            handler: self.handler,
+            tools: Registered(crate::validation::ValidatingToolHandler::new(
+                self.tools.0,
+                mode,
+            )),
+            resources: self.resources,
+            prompts: self.prompts,
+            tasks: self.tasks,
+            capabilities: self.capabilities,
+        }
+    }
+}
+
 // Resource handler registration (only when resources are not yet registered)
 impl<H, T, P, K> ServerBuilder<H, T, NotRegistered, P, K>
 where

--- a/crates/mcpkit-server/src/handler.rs
+++ b/crates/mcpkit-server/src/handler.rs
@@ -102,6 +102,14 @@ pub trait ToolHandler: Send + Sync {
 
     /// Call a tool with the given arguments.
     ///
+    /// `args` is passed through **unvalidated**: this generic path does not check
+    /// `args` against the tool's `inputSchema`, nor the returned
+    /// `structuredContent` against its `outputSchema`. Enable the
+    /// `schema-validation` feature and wrap the handler with
+    /// [`ServerBuilder::validate_tool_io`](crate::builder::ServerBuilder::validate_tool_io)
+    /// (or [`ValidatingToolHandler`](crate::validation::ValidatingToolHandler) for
+    /// adapter users) to enforce those schemas.
+    ///
     /// # Arguments
     ///
     /// * `name` - The name of the tool to call

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -67,6 +67,8 @@ pub mod metrics;
 pub mod router;
 pub mod server;
 pub mod state;
+#[cfg(feature = "schema-validation")]
+pub mod validation;
 
 // Re-export commonly used types
 pub use builder::{FullServer, MinimalServer, NotRegistered, Registered, Server, ServerBuilder};
@@ -83,6 +85,8 @@ pub use router::{route_prompts, route_resources, route_tools};
 pub use server::{
     RequestRouter, RuntimeConfig, ServerNotifier, ServerRuntime, ServerState, TransportPeer,
 };
+#[cfg(feature = "schema-validation")]
+pub use validation::{ValidatingToolHandler, ValidationMode, validate_json};
 
 /// Prelude module for convenient imports.
 pub mod prelude {

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -2231,4 +2231,115 @@ mod tests {
         drop(client);
         let _ = timeout(Duration::from_secs(2), handle).await;
     }
+
+    /// The validation decorator must also cover the *task* path: a
+    /// task-augmented `tools/call` whose arguments violate the `inputSchema`
+    /// must resolve to an `isError` result rather than running the tool body.
+    /// This exercises `Server::call_tool_json` (background execution), a
+    /// different call site than `route_tools`.
+    #[cfg(feature = "schema-validation")]
+    #[tokio::test]
+    async fn task_path_validates_input_via_decorator() {
+        use crate::builder::ServerBuilder;
+        use crate::handler::{ServerHandler, ToolHandler};
+        use mcpkit_core::protocol::Request;
+        use mcpkit_core::types::{TaskSupport, Tool, ToolOutput};
+
+        struct H;
+        impl ServerHandler for H {
+            fn server_info(&self) -> ServerInfo {
+                ServerInfo::new("t", "1.0.0")
+            }
+        }
+        impl ToolHandler for H {
+            async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+                Ok(vec![
+                    Tool::new("slow")
+                        .task_support(TaskSupport::Optional)
+                        .input_schema(serde_json::json!({
+                            "type": "object",
+                            "properties": { "n": { "type": "number" } },
+                            "required": ["n"]
+                        })),
+                ])
+            }
+            async fn call_tool(
+                &self,
+                name: &str,
+                _args: serde_json::Value,
+                _ctx: &Context<'_>,
+            ) -> Result<ToolOutput, McpError> {
+                Ok(ToolOutput::text(format!("done:{name}")))
+            }
+        }
+
+        let request = |id: u64, method: &'static str, params: serde_json::Value| {
+            Message::Request(Request {
+                jsonrpc: "2.0".into(),
+                id: RequestId::Number(id),
+                method: method.into(),
+                params: Some(params),
+            })
+        };
+
+        let (client, server_tr) = MemoryTransport::pair();
+        // `validate_tool_io()` wraps the tool handler; background task execution
+        // must still route through it.
+        let built = ServerBuilder::new(H)
+            .with_tools(H)
+            .validate_tool_io()
+            .build();
+        let runtime = ServerRuntime::new(built, server_tr);
+        runtime.state().set_initialized();
+        let handle = tokio::spawn(async move { runtime.run().await });
+
+        // Task-augmented call with input that violates the schema (missing "n").
+        client
+            .send(request(
+                1,
+                "tools/call",
+                serde_json::json!({ "name": "slow", "arguments": {}, "task": {} }),
+            ))
+            .await
+            .expect("send");
+        let resp = next_response(&client).await;
+        let task_id = resp.result.expect("create result")["task"]["taskId"]
+            .as_str()
+            .expect("taskId")
+            .to_string();
+
+        let mut payload = None;
+        for attempt in 0..100u64 {
+            client
+                .send(request(
+                    100 + attempt,
+                    "tasks/result",
+                    serde_json::json!({ "taskId": task_id }),
+                ))
+                .await
+                .expect("send");
+            let r = next_response(&client).await;
+            if r.error.is_none() {
+                payload = r.result;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        let payload = payload.expect("task completed with a payload");
+        assert_eq!(
+            payload["isError"],
+            serde_json::json!(true),
+            "task path must validate input: {payload}"
+        );
+        assert!(
+            !payload["content"][0]["text"]
+                .as_str()
+                .unwrap_or_default()
+                .contains("done:slow"),
+            "the tool body must not have run: {payload}"
+        );
+
+        drop(client);
+        let _ = timeout(Duration::from_secs(2), handle).await;
+    }
 }

--- a/crates/mcpkit-server/src/validation.rs
+++ b/crates/mcpkit-server/src/validation.rs
@@ -1,0 +1,561 @@
+//! Opt-in JSON Schema validation of tool inputs and outputs.
+//!
+//! The MCP Tools spec requires servers to validate `tools/call` arguments
+//! against each tool's `inputSchema`, and—when a tool declares an
+//! `outputSchema`—to return `structuredContent` conforming to it. mcpkit's
+//! generic [`ToolHandler`] path is an unchecked escape hatch: it receives raw
+//! JSON and returns arbitrary JSON. This module provides an **opt-in**
+//! [`ValidatingToolHandler`] decorator that enforces those schemas.
+//!
+//! Because it wraps the [`ToolHandler`] itself, it covers every dispatch path
+//! uniformly—normal `tools/call`, task-augmented background execution, and the
+//! HTTP adapters—since they all funnel through [`ToolHandler::call_tool`].
+//!
+//! Per the spec's error-handling section, arguments that fail a tool's
+//! `inputSchema` are reported as a tool-execution error (`isError: true`), not a
+//! JSON-RPC protocol error; malformed request envelopes and unknown tools remain
+//! protocol errors and are handled upstream. An `outputSchema` violation is a
+//! server-side bug: it is logged, the invalid `structuredContent` is dropped, and
+//! the call returns `isError: true`.
+//!
+//! This module is gated behind the `schema-validation` feature.
+
+use crate::context::Context;
+use crate::handler::{PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    CallToolResult, GetPromptResult, Prompt, Resource, ResourceContents, ResourceTemplate, Tool,
+    ToolOutput,
+};
+use serde_json::Value;
+use std::future::Future;
+
+/// Which directions [`ValidatingToolHandler`] enforces.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ValidationMode {
+    /// Validate `tools/call` arguments against each tool's `inputSchema`.
+    pub inputs: bool,
+    /// Validate structured results against each tool's `outputSchema`.
+    pub outputs: bool,
+}
+
+impl ValidationMode {
+    /// Validate both inputs and outputs.
+    #[must_use]
+    pub const fn both() -> Self {
+        Self {
+            inputs: true,
+            outputs: true,
+        }
+    }
+
+    /// Validate inputs only.
+    #[must_use]
+    pub const fn inputs_only() -> Self {
+        Self {
+            inputs: true,
+            outputs: false,
+        }
+    }
+
+    /// Validate outputs only.
+    #[must_use]
+    pub const fn outputs_only() -> Self {
+        Self {
+            inputs: false,
+            outputs: true,
+        }
+    }
+}
+
+/// A [`ToolHandler`] decorator that validates tool inputs and/or outputs against
+/// their declared JSON Schemas.
+///
+/// Wrap a tool handler with [`ServerBuilder::validate_tool_io`] (or construct
+/// directly with [`ValidatingToolHandler::new`] for adapter users who don't build
+/// through [`Server`]). Schemas are resolved from the inner handler's
+/// [`list_tools`](ToolHandler::list_tools) at call time; there is no cache, so a
+/// dynamic tool list is always seen correctly.
+///
+/// [`ServerBuilder::validate_tool_io`]: crate::builder::ServerBuilder::validate_tool_io
+/// [`Server`]: crate::builder::Server
+pub struct ValidatingToolHandler<H> {
+    inner: H,
+    mode: ValidationMode,
+}
+
+impl<H> ValidatingToolHandler<H> {
+    /// Wrap `inner`, enforcing the directions selected by `mode`.
+    #[must_use]
+    pub const fn new(inner: H, mode: ValidationMode) -> Self {
+        Self { inner, mode }
+    }
+
+    /// Unwrap, returning the inner handler.
+    pub fn into_inner(self) -> H {
+        self.inner
+    }
+}
+
+/// Validate `instance` against JSON Schema `schema`, returning the list of
+/// violation messages (empty `Ok` means valid).
+///
+/// The schema's draft is auto-detected, defaulting to 2020-12 when no `$schema`
+/// is present (matching MCP). String `format` assertions are **not** enforced
+/// (the default for this validator). If `schema` itself cannot be compiled,
+/// validation is skipped and `Ok(())` is returned after logging a warning—a
+/// malformed schema is a server configuration bug and must not break tool calls.
+///
+/// # Errors
+///
+/// Returns the collected violation messages when `instance` does not conform.
+pub fn validate_json(schema: &Value, instance: &Value) -> Result<(), Vec<String>> {
+    match collect_errors(schema, instance) {
+        None => Ok(()),
+        Some(errors) => Err(errors),
+    }
+}
+
+/// `None` = valid (or schema uncompilable → skipped); `Some` = violations.
+fn collect_errors(schema: &Value, instance: &Value) -> Option<Vec<String>> {
+    let validator = match jsonschema::validator_for(schema) {
+        Ok(validator) => validator,
+        Err(error) => {
+            tracing::warn!(%error, "tool schema failed to compile; skipping validation");
+            return None;
+        }
+    };
+    let errors: Vec<String> = validator
+        .iter_errors(instance)
+        .map(|e| e.to_string())
+        .collect();
+    if errors.is_empty() {
+        None
+    } else {
+        Some(errors)
+    }
+}
+
+impl<H: ToolHandler> ToolHandler for ValidatingToolHandler<H> {
+    async fn list_tools(&self, ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        self.inner.list_tools(ctx).await
+    }
+
+    async fn call_tool(
+        &self,
+        name: &str,
+        args: Value,
+        ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        // Resolve this tool's declared schemas. If the list can't be fetched or
+        // the tool isn't found, skip validation and let the inner handler decide
+        // (an unknown tool stays a protocol error upstream).
+        let tool = match self.inner.list_tools(ctx).await {
+            Ok(tools) => tools.into_iter().find(|t| t.name == name),
+            Err(error) => {
+                tracing::warn!(%error, tool = name, "could not list tools; skipping validation");
+                None
+            }
+        };
+
+        if self.mode.inputs {
+            if let Some(tool) = &tool {
+                if let Some(errors) = collect_errors(&tool.input_schema, &args) {
+                    let message = format!(
+                        "Input does not conform to the tool's inputSchema:\n{}",
+                        errors.join("\n")
+                    );
+                    return Ok(ToolOutput::Success(CallToolResult::error(message)));
+                }
+            }
+        }
+
+        let output = self.inner.call_tool(name, args, ctx).await?;
+
+        if self.mode.outputs {
+            if let (Some(tool), ToolOutput::Success(result)) = (&tool, &output) {
+                if let (Some(schema), Some(structured)) =
+                    (&tool.output_schema, &result.structured_content)
+                {
+                    if let Some(errors) = collect_errors(schema, structured) {
+                        tracing::error!(
+                            tool = name,
+                            ?errors,
+                            "tool output violates its declared outputSchema (server bug); \
+                             dropping structuredContent"
+                        );
+                        let message = format!(
+                            "The tool produced structured output that does not conform to its \
+                             declared outputSchema:\n{}",
+                            errors.join("\n")
+                        );
+                        return Ok(ToolOutput::Success(CallToolResult::error(message)));
+                    }
+                }
+            }
+        }
+
+        Ok(output)
+    }
+
+    async fn on_tools_changed(&self) {
+        self.inner.on_tools_changed().await;
+    }
+}
+
+// Transparent forwarding of the other handler traits, so a single combined
+// handler wrapped in `ValidatingToolHandler` remains a drop-in for the HTTP
+// adapters (which require `ServerHandler + ToolHandler + ResourceHandler +
+// PromptHandler` on one type). Only `ToolHandler` is intercepted above.
+
+impl<H: ServerHandler> ServerHandler for ValidatingToolHandler<H> {
+    fn server_info(&self) -> ServerInfo {
+        self.inner.server_info()
+    }
+
+    fn capabilities(&self) -> ServerCapabilities {
+        self.inner.capabilities()
+    }
+
+    fn instructions(&self) -> Option<String> {
+        self.inner.instructions()
+    }
+
+    fn on_initialized(&self, ctx: &Context<'_>) -> impl Future<Output = ()> + Send {
+        self.inner.on_initialized(ctx)
+    }
+
+    fn on_shutdown(&self) -> impl Future<Output = ()> + Send {
+        self.inner.on_shutdown()
+    }
+}
+
+impl<H: ResourceHandler> ResourceHandler for ValidatingToolHandler<H> {
+    fn list_resources(
+        &self,
+        ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<Vec<Resource>, McpError>> + Send {
+        self.inner.list_resources(ctx)
+    }
+
+    fn list_resource_templates(
+        &self,
+        ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<Vec<ResourceTemplate>, McpError>> + Send {
+        self.inner.list_resource_templates(ctx)
+    }
+
+    fn read_resource(
+        &self,
+        uri: &str,
+        ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<Vec<ResourceContents>, McpError>> + Send {
+        self.inner.read_resource(uri, ctx)
+    }
+
+    fn subscribe(
+        &self,
+        uri: &str,
+        ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<bool, McpError>> + Send {
+        self.inner.subscribe(uri, ctx)
+    }
+
+    fn unsubscribe(
+        &self,
+        uri: &str,
+        ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<bool, McpError>> + Send {
+        self.inner.unsubscribe(uri, ctx)
+    }
+}
+
+impl<H: PromptHandler> PromptHandler for ValidatingToolHandler<H> {
+    fn list_prompts(
+        &self,
+        ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<Vec<Prompt>, McpError>> + Send {
+        self.inner.list_prompts(ctx)
+    }
+
+    fn get_prompt(
+        &self,
+        name: &str,
+        args: Option<serde_json::Map<String, Value>>,
+        ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<GetPromptResult, McpError>> + Send {
+        self.inner.get_prompt(name, args, ctx)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::context::NoOpPeer;
+    use crate::router::route_tools;
+    use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+    use mcpkit_core::protocol::RequestId;
+    use mcpkit_core::protocol_version::ProtocolVersion;
+    use serde_json::json;
+
+    /// A tool "add" declaring an inputSchema (`{ n: number }`, required) and an
+    /// outputSchema (`{ doubled: number }`, required). `call_tool` echoes back a
+    /// configurable `structuredContent` so tests can drive output validation.
+    struct SchemaHandler {
+        structured: Value,
+    }
+
+    impl ToolHandler for SchemaHandler {
+        async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+            Ok(vec![
+                Tool::new("add")
+                    .input_schema(json!({
+                        "type": "object",
+                        "properties": { "n": { "type": "number" } },
+                        "required": ["n"]
+                    }))
+                    .output_schema(json!({
+                        "type": "object",
+                        "properties": { "doubled": { "type": "number" } },
+                        "required": ["doubled"]
+                    })),
+            ])
+        }
+
+        async fn call_tool(
+            &self,
+            _name: &str,
+            _args: Value,
+            _ctx: &Context<'_>,
+        ) -> Result<ToolOutput, McpError> {
+            Ok(ToolOutput::Success(
+                CallToolResult::text("ok").with_structured_content(self.structured.clone()),
+            ))
+        }
+    }
+
+    /// Run `f` with a throwaway `Context`.
+    async fn with_ctx<F, Fut, T>(f: F) -> T
+    where
+        F: FnOnce(Context<'static>) -> Fut,
+        Fut: std::future::Future<Output = T>,
+    {
+        let request_id = RequestId::Number(1);
+        let client_caps = ClientCapabilities::default();
+        let server_caps = ServerCapabilities::default();
+        let peer = NoOpPeer;
+        // Leak the borrows for the duration of the test: simplest way to hand a
+        // `Context` into an async closure without lifetime gymnastics.
+        let request_id: &'static RequestId = Box::leak(Box::new(request_id));
+        let client_caps: &'static ClientCapabilities = Box::leak(Box::new(client_caps));
+        let server_caps: &'static ServerCapabilities = Box::leak(Box::new(server_caps));
+        let peer: &'static NoOpPeer = Box::leak(Box::new(peer));
+        let ctx = Context::new(
+            request_id,
+            None,
+            client_caps,
+            server_caps,
+            ProtocolVersion::LATEST,
+            peer,
+        );
+        f(ctx).await
+    }
+
+    #[tokio::test]
+    async fn input_failure_is_a_tool_error_not_protocol_error() {
+        let handler = SchemaHandler {
+            structured: json!({ "doubled": 84 }),
+        };
+        let validating = ValidatingToolHandler::new(handler, ValidationMode::both());
+        let out = with_ctx(|ctx| async move {
+            // Missing required "n" -> fails inputSchema.
+            validating
+                .call_tool("add", json!({}), &ctx)
+                .await
+                .expect("input failure is Ok(isError), not a protocol Err")
+        })
+        .await;
+        match out {
+            ToolOutput::Success(result) => assert!(result.is_error(), "expected isError: true"),
+            other => panic!("expected a Success(isError) result, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn valid_input_and_output_pass_through_untouched() {
+        let handler = SchemaHandler {
+            structured: json!({ "doubled": 84 }),
+        };
+        let validating = ValidatingToolHandler::new(handler, ValidationMode::both());
+        let out = with_ctx(|ctx| async move {
+            validating
+                .call_tool("add", json!({ "n": 42 }), &ctx)
+                .await
+                .expect("routed")
+        })
+        .await;
+        match out {
+            ToolOutput::Success(result) => {
+                assert!(!result.is_error());
+                assert_eq!(result.structured_content, Some(json!({ "doubled": 84 })));
+            }
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn output_schema_violation_drops_structured_content() {
+        let handler = SchemaHandler {
+            // `doubled` must be a number; a string violates the outputSchema.
+            structured: json!({ "doubled": "not a number" }),
+        };
+        let validating = ValidatingToolHandler::new(handler, ValidationMode::both());
+        let out = with_ctx(|ctx| async move {
+            validating
+                .call_tool("add", json!({ "n": 42 }), &ctx)
+                .await
+                .expect("routed")
+        })
+        .await;
+        match out {
+            ToolOutput::Success(result) => {
+                assert!(result.is_error(), "output violation must be isError: true");
+                assert!(
+                    result.structured_content.is_none(),
+                    "invalid structuredContent must be dropped"
+                );
+            }
+            other => panic!("expected success(isError), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn inputs_only_mode_ignores_bad_output() {
+        let handler = SchemaHandler {
+            structured: json!({ "doubled": "not a number" }),
+        };
+        let validating = ValidatingToolHandler::new(handler, ValidationMode::inputs_only());
+        let out = with_ctx(|ctx| async move {
+            validating
+                .call_tool("add", json!({ "n": 42 }), &ctx)
+                .await
+                .expect("routed")
+        })
+        .await;
+        match out {
+            // outputs are not validated in inputs-only mode: bad structured passes.
+            ToolOutput::Success(result) => assert!(!result.is_error()),
+            other => panic!("expected success, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn normal_tools_call_path_through_route_tools_is_validated() {
+        let handler = SchemaHandler {
+            structured: json!({ "doubled": 84 }),
+        };
+        let validating = ValidatingToolHandler::new(handler, ValidationMode::both());
+        let result = with_ctx(|ctx| async move {
+            route_tools(
+                &validating,
+                "tools/call",
+                Some(&json!({ "name": "add", "arguments": {} })),
+                &ctx,
+                None,
+            )
+            .await
+            .expect("tools/call is routed")
+            .expect("ok result")
+        })
+        .await;
+        assert_eq!(result["isError"], json!(true));
+    }
+
+    #[test]
+    fn wrapped_combined_handler_satisfies_adapter_bounds() {
+        // Compile-time proof of the adapter escape hatch: the HTTP adapters bound
+        // a single handler on `ServerHandler + ToolHandler + ResourceHandler +
+        // PromptHandler`. Wrapping such a handler must still satisfy that bound,
+        // so `McpState::new(ValidatingToolHandler::new(h, mode))` type-checks.
+        use crate::handler::{PromptHandler, ResourceHandler, ServerHandler};
+        use mcpkit_core::types::{GetPromptResult, Prompt, Resource, ResourceContents};
+
+        fn adapter_bound<H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler>(_h: &H) {
+        }
+
+        struct Combined;
+        impl ServerHandler for Combined {
+            fn server_info(&self) -> ServerInfo {
+                ServerInfo::new("t", "1.0.0")
+            }
+        }
+        impl ToolHandler for Combined {
+            async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+                Ok(vec![])
+            }
+            async fn call_tool(
+                &self,
+                _name: &str,
+                _args: Value,
+                _ctx: &Context<'_>,
+            ) -> Result<ToolOutput, McpError> {
+                Ok(ToolOutput::text("x"))
+            }
+        }
+        impl ResourceHandler for Combined {
+            async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+                Ok(vec![])
+            }
+            async fn read_resource(
+                &self,
+                _uri: &str,
+                _ctx: &Context<'_>,
+            ) -> Result<Vec<ResourceContents>, McpError> {
+                Ok(vec![])
+            }
+        }
+        impl PromptHandler for Combined {
+            async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+                Ok(vec![])
+            }
+            async fn get_prompt(
+                &self,
+                _name: &str,
+                _args: Option<serde_json::Map<String, Value>>,
+                _ctx: &Context<'_>,
+            ) -> Result<GetPromptResult, McpError> {
+                Ok(GetPromptResult {
+                    description: None,
+                    messages: vec![],
+                })
+            }
+        }
+
+        let wrapped = ValidatingToolHandler::new(Combined, ValidationMode::both());
+        adapter_bound(&wrapped);
+    }
+
+    #[tokio::test]
+    async fn unwrapped_handler_does_not_validate() {
+        // The escape hatch: without the decorator, bad input is not rejected.
+        // Proves validation is strictly opt-in (feature compiled in, not applied).
+        let handler = SchemaHandler {
+            structured: json!({ "doubled": 84 }),
+        };
+        let result = with_ctx(|ctx| async move {
+            route_tools(
+                &handler,
+                "tools/call",
+                Some(&json!({ "name": "add", "arguments": {} })),
+                &ctx,
+                None,
+            )
+            .await
+            .expect("tools/call is routed")
+            .expect("ok result")
+        })
+        .await;
+        assert_ne!(result.get("isError"), Some(&json!(true)));
+    }
+}

--- a/deny.toml
+++ b/deny.toml
@@ -46,6 +46,7 @@ version = 2
 # v2: all licenses denied by default except those in allow list
 allow = [
     "MIT",
+    "MIT-0",
     "Apache-2.0",
     "Apache-2.0 WITH LLVM-exception",
     "BSD-2-Clause",


### PR DESCRIPTION
Closes #85. Opt-in JSON Schema validation of tool inputs/outputs, implemented as a `ToolHandler` decorator so every dispatch path is covered from one enforcement point.

## Design (synthesized from two review passes)
- **Feature-gated** `schema-validation` (off by default) → new optional `jsonschema` dep (`default-features = false`, so tool schemas can't trigger network/file `$ref` fetches).
- **`ValidatingToolHandler<H>` decorator** at `ToolHandler::call_tool` — the single choke point through which normal `tools/call` (`route_tools`), task-augmented execution (`Server::call_tool_json`), and the HTTP adapters all pass. No per-adapter config threading, no missed task path.
- Schemas resolved from the inner handler's `list_tools` **at call time** (no cache — a dynamic tool list is always seen correctly; `on_tools_changed` is not wired as an invalidation signal, so no cache is deliberately correct for v1).

## Semantics (per the Tools spec's Error Handling section)
- Arguments failing `inputSchema` → `isError: true` tool result (**not** `-32602`; protocol errors stay reserved for malformed envelopes / unknown tools, handled upstream).
- `outputSchema` violation → logged as a server bug, invalid `structuredContent` dropped, `isError: true` returned. (`structuredContent` present-but-invalid is validated; a *missing* one is not forced.)
- String `format` assertions are not enforced (validator default).
- Typed/macro path keeps its serde deserialize; the generic `call_tool` is documented as an unchecked escape hatch.

## API
- `ServerBuilder::validate_tool_io()` / `validate_tool_inputs()` / `validate_tool_outputs()`.
- Adapter escape hatch: `ValidatingToolHandler` is exported and transparently forwards `ServerHandler`/`ResourceHandler`/`PromptHandler`, so `McpState::new(ValidatingToolHandler::new(h, mode))` type-checks against the adapters' combined-handler bound.
- Standalone `validate_json(schema, instance)` helper.

## Tests
Normal `route_tools` path; **task path** via `call_tool_json` (background execution); generic input failure → `isError`; output-schema violation drops `structuredContent`; granular `inputs_only` mode; adapter-bound compile proof; and an unwrapped handler is *not* validated (opt-in proof).

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `test --workspace --all-features --locked`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features` all green.

> Note: `Semver Check`/`CI Success` are the known pre-existing `cookie`-dep reds. `Cargo Deny` may also be red on a **pre-existing, unrelated** advisory (RUSTSEC-2026-0190, `anyhow` via `prost`/`mcpkit-transport`) — not introduced here (this PR adds `jsonschema`, not `anyhow`).