### PR TITLE
chore(deps): bump anyhow to 1.0.103 for RUSTSEC-2026-0190

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -274,9 +274,9 @@ checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "assert-json-diff"


### PR DESCRIPTION
`anyhow` v1.0.100 (pulled transitively via `prost-derive` → `prost` → `mcpkit-transport`) is affected by [RUSTSEC-2026-0190](https://rustsec.org/advisories/RUSTSEC-2026-0190) — unsoundness in `Error::downcast_mut()`. This turns the **Cargo Deny** CI job red on every branch as the advisory is now published.

v1.0.103 patches it. `Cargo.lock`-only change (no manifest edit; `anyhow` is a transitive dep). Verified locally: `cargo deny check advisories` → `advisories ok`.