### PR TITLE
feat(transport): redaction hook for LoggingLayer content logging (#84)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Redaction hook for transport content logging (`mcpkit-transport`). When
+  `LoggingLayer::with_contents(true)` logs full messages, secrets could leak into
+  logs. `LoggingLayer` gains `redact_keys(keys)` (recursively masks object values
+  under case-insensitively-matching keys with `<redacted>`), `redact_with(fn)` (a
+  custom hook returning the JSON to log), and `with_redacted_contents()` (enables
+  content logging with the new `LoggingLayer::DEFAULT_REDACT_KEYS` denylist
+  applied). Redaction only affects the logged representation — the forwarded
+  message is never modified — and is skipped entirely when content logging is off;
+  a serialization failure logs a placeholder rather than the raw message. Default
+  behaviour is unchanged (no redactor unless configured)
+  ([#84](https://github.com/praxiomlabs/mcpkit/issues/84)).
 - Opt-in tool I/O schema validation (`mcpkit-server`, feature
   `schema-validation`, off by default). A new `ValidatingToolHandler<H>` decorator
   validates `tools/call` arguments against each tool's `inputSchema` and

--- a/crates/mcpkit-transport/src/middleware/logging.rs
+++ b/crates/mcpkit-transport/src/middleware/logging.rs
@@ -6,37 +6,161 @@
 use crate::middleware::TransportLayer;
 use crate::traits::{Transport, TransportMetadata};
 use mcpkit_core::protocol::Message;
+use serde_json::Value;
+use std::collections::HashSet;
+use std::fmt;
+use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 use tracing::{Level, debug, trace};
 
+/// A redaction hook: given a message, returns the sanitized JSON value to log.
+///
+/// Only invoked when content logging is enabled; the message forwarded to the
+/// inner transport is never modified.
+type Redactor = Arc<dyn Fn(&Message) -> Value + Send + Sync>;
+
 /// A layer that adds logging to a transport.
 ///
-/// Logs all sent and received messages at the configured level.
-#[derive(Debug, Clone)]
+/// Logs all sent and received messages at the configured level. When content
+/// logging is enabled, configure a redactor ([`redact_keys`](Self::redact_keys)
+/// or [`redact_with`](Self::redact_with)) to avoid leaking secrets into logs.
+#[derive(Clone)]
 pub struct LoggingLayer {
     /// The log level to use.
     level: Level,
     /// Whether to log message contents.
     log_contents: bool,
+    /// Optional redaction applied to logged content (never to the forwarded
+    /// message).
+    redactor: Option<Redactor>,
+}
+
+impl fmt::Debug for LoggingLayer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LoggingLayer")
+            .field("level", &self.level)
+            .field("log_contents", &self.log_contents)
+            .field("redactor", &self.redactor.as_ref().map(|_| "<fn>"))
+            .finish()
+    }
 }
 
 impl LoggingLayer {
+    /// A recommended denylist of object keys whose values commonly carry
+    /// secrets. Pass to [`redact_keys`](Self::redact_keys), or use
+    /// [`with_redacted_contents`](Self::with_redacted_contents) to apply it.
+    pub const DEFAULT_REDACT_KEYS: &'static [&'static str] = &[
+        "authorization",
+        "cookie",
+        "set-cookie",
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "client_secret",
+        "api_key",
+        "apikey",
+        "key",
+        "private_key",
+        "credential",
+        "credentials",
+    ];
+
     /// Create a new logging layer with the specified log level.
     #[must_use]
     pub const fn new(level: Level) -> Self {
         Self {
             level,
             log_contents: false,
+            redactor: None,
         }
     }
 
     /// Configure whether to log full message contents.
     ///
-    /// Warning: This may log sensitive data!
+    /// Warning: without a redactor this may log sensitive data. Prefer
+    /// [`with_redacted_contents`](Self::with_redacted_contents), or pair this
+    /// with [`redact_keys`](Self::redact_keys) / [`redact_with`](Self::redact_with).
     #[must_use]
     pub const fn with_contents(mut self, log_contents: bool) -> Self {
         self.log_contents = log_contents;
         self
+    }
+
+    /// Enable content logging with the [`DEFAULT_REDACT_KEYS`](Self::DEFAULT_REDACT_KEYS)
+    /// denylist applied — the safe one-call path.
+    #[must_use]
+    pub fn with_redacted_contents(self) -> Self {
+        self.with_contents(true)
+            .redact_keys(Self::DEFAULT_REDACT_KEYS.iter().copied())
+    }
+
+    /// Redact logged content by masking object values whose key matches (case-
+    /// insensitively) any key in `keys`, recursively, with `"<redacted>"`.
+    ///
+    /// Only affects the logged representation; the forwarded message is
+    /// unchanged. Has no effect unless content logging is enabled.
+    #[must_use]
+    pub fn redact_keys<I, S>(mut self, keys: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let keys: HashSet<String> = keys
+            .into_iter()
+            .map(|k| k.into().to_ascii_lowercase())
+            .collect();
+        self.redactor = Some(Arc::new(move |msg: &Message| redact_message(msg, &keys)));
+        self
+    }
+
+    /// Redact logged content with a custom hook returning the JSON value to log.
+    ///
+    /// Only affects the logged representation; the forwarded message is
+    /// unchanged. Has no effect unless content logging is enabled.
+    #[must_use]
+    pub fn redact_with<F>(mut self, redactor: F) -> Self
+    where
+        F: Fn(&Message) -> Value + Send + Sync + 'static,
+    {
+        self.redactor = Some(Arc::new(redactor));
+        self
+    }
+}
+
+/// Serialize `msg` and mask values under sensitive keys. On the (near-
+/// impossible) serialization failure, returns a placeholder rather than
+/// exposing the raw message.
+fn redact_message(msg: &Message, keys: &HashSet<String>) -> Value {
+    match serde_json::to_value(msg) {
+        Ok(mut value) => {
+            redact_in_place(&mut value, keys);
+            value
+        }
+        Err(_) => Value::String("<redaction failed>".to_string()),
+    }
+}
+
+fn redact_in_place(value: &mut Value, keys: &HashSet<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, val) in map.iter_mut() {
+                if keys.contains(&key.to_ascii_lowercase()) {
+                    *val = Value::String("<redacted>".to_string());
+                } else {
+                    redact_in_place(val, keys);
+                }
+            }
+        }
+        Value::Array(items) => {
+            for item in items.iter_mut() {
+                redact_in_place(item, keys);
+            }
+        }
+        _ => {}
     }
 }
 
@@ -54,6 +178,7 @@ impl<T: Transport> TransportLayer<T> for LoggingLayer {
             inner,
             level: self.level,
             log_contents: self.log_contents,
+            redactor: self.redactor.clone(),
             messages_sent: AtomicU64::new(0),
             messages_received: AtomicU64::new(0),
         }
@@ -65,6 +190,7 @@ pub struct LoggingTransport<T> {
     inner: T,
     level: Level,
     log_contents: bool,
+    redactor: Option<Redactor>,
     messages_sent: AtomicU64,
     messages_received: AtomicU64,
 }
@@ -88,10 +214,20 @@ impl<T: Transport> Transport for LoggingTransport<T> {
         let count = self.messages_sent.fetch_add(1, Ordering::Relaxed) + 1;
 
         if self.log_contents {
-            match self.level {
-                Level::TRACE => trace!(count, ?msg, "sending message"),
-                Level::DEBUG => debug!(count, ?msg, "sending message"),
-                _ => debug!(count, "sending message"),
+            match &self.redactor {
+                Some(redact) => {
+                    let redacted = redact(&msg);
+                    match self.level {
+                        Level::TRACE => trace!(count, ?redacted, "sending message"),
+                        Level::DEBUG => debug!(count, ?redacted, "sending message"),
+                        _ => debug!(count, "sending message"),
+                    }
+                }
+                None => match self.level {
+                    Level::TRACE => trace!(count, ?msg, "sending message"),
+                    Level::DEBUG => debug!(count, ?msg, "sending message"),
+                    _ => debug!(count, "sending message"),
+                },
             }
         } else {
             let method = msg.method().unwrap_or("<response>");
@@ -112,10 +248,20 @@ impl<T: Transport> Transport for LoggingTransport<T> {
             let count = self.messages_received.fetch_add(1, Ordering::Relaxed) + 1;
 
             if self.log_contents {
-                match self.level {
-                    Level::TRACE => trace!(count, ?msg, "received message"),
-                    Level::DEBUG => debug!(count, ?msg, "received message"),
-                    _ => debug!(count, "received message"),
+                match &self.redactor {
+                    Some(redact) => {
+                        let redacted = redact(msg);
+                        match self.level {
+                            Level::TRACE => trace!(count, ?redacted, "received message"),
+                            Level::DEBUG => debug!(count, ?redacted, "received message"),
+                            _ => debug!(count, "received message"),
+                        }
+                    }
+                    None => match self.level {
+                        Level::TRACE => trace!(count, ?msg, "received message"),
+                        Level::DEBUG => debug!(count, ?msg, "received message"),
+                        _ => debug!(count, "received message"),
+                    },
                 }
             } else {
                 let method = msg.method().unwrap_or("<response>");
@@ -151,13 +297,115 @@ impl<T: Transport> Transport for LoggingTransport<T> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::memory::MemoryTransport;
+    use mcpkit_core::protocol::{Request, RequestId};
+    use serde_json::json;
+    use std::sync::atomic::AtomicBool;
+
+    fn request_with(params: Value) -> Message {
+        Message::Request(Request::with_params(
+            "tools/call".to_string(),
+            RequestId::Number(1),
+            params,
+        ))
+    }
 
     #[test]
     fn test_logging_layer_creation() {
         let layer = LoggingLayer::new(Level::DEBUG);
         assert!(!layer.log_contents);
+        assert!(layer.redactor.is_none());
 
         let layer = layer.with_contents(true);
         assert!(layer.log_contents);
+    }
+
+    #[test]
+    fn redact_keys_masks_nested_secrets_case_insensitively() {
+        let keys: HashSet<String> = LoggingLayer::DEFAULT_REDACT_KEYS
+            .iter()
+            .map(|k| (*k).to_string())
+            .collect();
+        let msg = request_with(json!({
+            "Authorization": "Bearer abc",
+            "arguments": {
+                "PASSWORD": "hunter2",
+                "nested": { "access_token": "xyz", "safe": "keep" }
+            },
+            "list": [ { "token": "t1" }, { "ok": "v" } ]
+        }));
+
+        let redacted = redact_message(&msg, &keys);
+        let s = serde_json::to_string(&redacted).expect("serialize");
+
+        // Secrets gone (case-insensitive, nested, and inside arrays).
+        assert!(!s.contains("Bearer abc"), "{s}");
+        assert!(!s.contains("hunter2"), "{s}");
+        assert!(!s.contains("xyz"), "{s}");
+        assert!(!s.contains("t1"), "{s}");
+        assert!(s.contains("<redacted>"), "{s}");
+        // Non-sensitive values preserved.
+        assert!(s.contains("keep"), "{s}");
+        assert!(s.contains("\"ok\":\"v\""), "{s}");
+    }
+
+    #[test]
+    fn redact_with_uses_custom_hook() {
+        let layer = LoggingLayer::new(Level::DEBUG)
+            .with_contents(true)
+            .redact_with(|_msg| json!("CUSTOM"));
+        let redactor = layer.redactor.as_ref().expect("redactor set");
+        assert_eq!(redactor(&request_with(json!({}))), json!("CUSTOM"));
+    }
+
+    #[test]
+    fn with_redacted_contents_enables_and_sets_redactor() {
+        let layer = LoggingLayer::new(Level::DEBUG).with_redacted_contents();
+        assert!(layer.log_contents);
+        assert!(layer.redactor.is_some());
+    }
+
+    #[tokio::test]
+    async fn log_contents_false_never_invokes_redactor() {
+        let called = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&called);
+        let (a, _b) = MemoryTransport::pair();
+        // Content logging is off by default: the redactor must not run.
+        let transport = LoggingLayer::new(Level::DEBUG)
+            .redact_with(move |_| {
+                flag.store(true, Ordering::SeqCst);
+                Value::Null
+            })
+            .layer(a);
+        transport
+            .send(request_with(json!({ "token": "secret" })))
+            .await
+            .expect("send");
+        assert!(
+            !called.load(Ordering::SeqCst),
+            "redactor must not run when log_contents is false"
+        );
+    }
+
+    #[tokio::test]
+    async fn log_contents_true_invokes_redactor() {
+        let called = Arc::new(AtomicBool::new(false));
+        let flag = Arc::clone(&called);
+        let (a, _b) = MemoryTransport::pair();
+        let transport = LoggingLayer::new(Level::DEBUG)
+            .with_contents(true)
+            .redact_with(move |_| {
+                flag.store(true, Ordering::SeqCst);
+                Value::Null
+            })
+            .layer(a);
+        transport
+            .send(request_with(json!({ "token": "secret" })))
+            .await
+            .expect("send");
+        assert!(
+            called.load(Ordering::SeqCst),
+            "redactor must run when log_contents is true"
+        );
     }
 }


### PR DESCRIPTION
Closes #84. `LoggingLayer::with_contents(true)` logs full JSON-RPC messages (tool args, auth payloads) with no way to mask secrets. Adds opt-in redaction (synthesized from two review passes).

## API
- `redact_keys(keys)` — recursively masks object values whose key matches (case-insensitively) any given key, with `"<redacted>"` (the same token the OAuth `Debug` impls already use).
- `redact_with(fn)` — custom `Fn(&Message) -> serde_json::Value` hook returning what to log.
- `with_redacted_contents()` — safe one-call path: content logging on + `DEFAULT_REDACT_KEYS` applied. Not a behavior change (new constructor; existing `with_contents` untouched).
- `LoggingLayer::DEFAULT_REDACT_KEYS` — recommended denylist (authorization, cookie, set-cookie, password, passwd, secret, token, access_token, refresh_token, id_token, client_secret, api_key, apikey, key, private_key, credential, credentials).

## Guarantees
- Redaction affects **only** the logged representation — the message forwarded to the inner transport is never modified.
- Skipped entirely when content logging is off (proven by a runtime test).
- A serialization failure logs a placeholder, never the raw message.
- **No silent behavior change:** no default denylist is applied to bare `with_contents(true)`; redaction is strictly opt-in.

## Design notes
- Single redactor stored as `Option<Arc<dyn Fn(&Message) -> Value + Send + Sync>>`; only `LoggingLayer` needed a manual `Debug` (`LoggingTransport` derives nothing). JSON Pointer masking was deliberately deferred — sensitive values live in arbitrary tool params/arrays, so recursive key-masking + the closure escape hatch is the better first primitive.

## Tests
Nested + case-insensitive masking (`Authorization`, `access_token`, nested `PASSWORD`, inside arrays) with non-secret values preserved; custom hook applied; `with_redacted_contents` sets both; and runtime proof that the redactor runs only when content logging is on.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace` all green.