### PR TITLE
feat(core)!: protocol _meta foundation (#109)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Protocol `_meta` foundation (`mcpkit-core`). A new `Meta` type (an open,
+  string-keyed map, `types::meta`) models the MCP `_meta` object, with typed
+  `progress_token`/`with_progress_token` accessors bridging `ProgressToken` and a
+  `Meta::progress_token_from_params` helper (the server's hand-rolled progress-
+  token extraction now delegates to it). Concrete result structs
+  (`CallToolResult`, `GetPromptResult`, `ListToolsResult`, the other `*Result`
+  types, `InitializeResult`, `PingResult`) and `Task` gain an optional
+  `meta: Option<Meta>` field, serialized as `_meta` and omitted when absent. A
+  generic `Request<T>` refactor was deliberately avoided; request-param `_meta`
+  beyond `progressToken` is handled at the boundary rather than per-struct.
+  **Breaking:** the new field means struct-literal construction of these result
+  types now requires `meta` (use the existing constructors, `..Default::default()`
+  where derived, or `meta: None`)
+  ([#109](https://github.com/praxiomlabs/mcpkit/issues/109)).
 - Redaction hook for transport content logging (`mcpkit-transport`). When
   `LoggingLayer::with_contents(true)` logs full messages, secrets could leak into
   logs. `LoggingLayer` gains `redact_keys(keys)` (recursively masks object values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Meta::progress_token_from_params` helper (the server's hand-rolled progress-
   token extraction now delegates to it). Concrete result structs
   (`CallToolResult`, `GetPromptResult`, `ListToolsResult`, the other `*Result`
-  types, `InitializeResult`, `PingResult`) and `Task` gain an optional
-  `meta: Option<Meta>` field, serialized as `_meta` and omitted when absent. A
-  generic `Request<T>` refactor was deliberately avoided; request-param `_meta`
-  beyond `progressToken` is handled at the boundary rather than per-struct.
+  types, `InitializeResult`, `PingResult`) gain an optional `meta: Option<Meta>`
+  field, serialized as `_meta` and omitted when absent. The base `Task` is left
+  spec-pure (no `_meta`); task-get/cancel result and status-notification `_meta`
+  (spec `Result & Task`) is deferred to
+  [#136](https://github.com/praxiomlabs/mcpkit/issues/136) to avoid contaminating
+  nested `Task` values. A generic `Request<T>` refactor was deliberately avoided;
+  request-param `_meta` beyond `progressToken` is handled at the boundary rather
+  than per-struct.
   **Breaking:** the new field means struct-literal construction of these result
   types now requires `meta` (use the existing constructors, `..Default::default()`
   where derived, or `meta: None`)

--- a/crates/mcpkit-actix/src/router.rs
+++ b/crates/mcpkit-actix/src/router.rs
@@ -331,6 +331,7 @@ mod tests {
             _ctx: &Context<'_>,
         ) -> Result<GetPromptResult, McpError> {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("Test prompt".to_string()),
                 messages: vec![],
             })

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -297,6 +297,7 @@ mod tests {
             _ctx: &Context<'_>,
         ) -> Result<GetPromptResult, McpError> {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("Test prompt".to_string()),
                 messages: vec![],
             })

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -1295,6 +1295,7 @@ mod tests {
             capabilities: ServerCapabilities::new(),
             server_info: ServerInfo::new("test-server", "1.0.0"),
             instructions: None,
+            meta: None,
         }
     }
 
@@ -1518,6 +1519,7 @@ mod tests {
             capabilities: ServerCapabilities::new().with_tools(),
             server_info: ServerInfo::new("test-server", "1.0.0"),
             instructions: None,
+            meta: None,
         }
     }
 

--- a/crates/mcpkit-core/src/capability.rs
+++ b/crates/mcpkit-core/src/capability.rs
@@ -5,6 +5,7 @@
 
 use crate::extension::ExtensionRegistry;
 use crate::types::Icon;
+use crate::types::meta::Meta;
 use serde::{Deserialize, Serialize};
 
 /// Server capabilities advertised during initialization.
@@ -563,6 +564,9 @@ pub struct InitializeResult {
     /// Optional instructions for using this server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl InitializeResult {
@@ -574,6 +578,7 @@ impl InitializeResult {
             capabilities,
             server_info,
             instructions: None,
+            meta: None,
         }
     }
 
@@ -773,7 +778,11 @@ pub struct PingRequest {}
 
 /// Ping response.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct PingResult {}
+pub struct PingResult {
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/mcpkit-core/src/types/completion.rs
+++ b/crates/mcpkit-core/src/types/completion.rs
@@ -3,6 +3,7 @@
 //! This module provides types for the completion capability
 //! which enables auto-completion of arguments.
 
+use super::meta::Meta;
 use serde::{Deserialize, Serialize};
 
 /// Reference to a prompt or resource for completion context.
@@ -92,6 +93,9 @@ pub struct Completion {
 pub struct CompleteResult {
     /// The completion data.
     pub completion: Completion,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 #[cfg(test)]

--- a/crates/mcpkit-core/src/types/elicitation.rs
+++ b/crates/mcpkit-core/src/types/elicitation.rs
@@ -4,6 +4,7 @@
 //! through the client. This enables interactive workflows where servers
 //! can gather user preferences, confirmations, or data.
 
+use super::meta::Meta;
 use serde::{Deserialize, Serialize};
 
 /// The mode of an elicitation request.
@@ -368,6 +369,9 @@ pub struct ElicitResult {
     /// The content provided (if accepted).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<serde_json::Map<String, serde_json::Value>>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl ElicitResult {
@@ -377,6 +381,7 @@ impl ElicitResult {
         Self {
             action: ElicitAction::Accept,
             content: Some(content),
+            meta: None,
         }
     }
 
@@ -386,6 +391,7 @@ impl ElicitResult {
         Self {
             action: ElicitAction::Decline,
             content: None,
+            meta: None,
         }
     }
 
@@ -395,6 +401,7 @@ impl ElicitResult {
         Self {
             action: ElicitAction::Cancel,
             content: None,
+            meta: None,
         }
     }
 

--- a/crates/mcpkit-core/src/types/meta.rs
+++ b/crates/mcpkit-core/src/types/meta.rs
@@ -45,6 +45,11 @@ impl Meta {
         self.0.get(key)
     }
 
+    /// Iterate over the `(key, value)` metadata entries.
+    pub fn iter(&self) -> impl Iterator<Item = (&String, &Value)> {
+        self.0.iter()
+    }
+
     /// Insert a raw metadata entry, returning the previous value if any.
     pub fn insert(&mut self, key: impl Into<String>, value: Value) -> Option<Value> {
         self.0.insert(key.into(), value)
@@ -135,6 +140,14 @@ mod tests {
     fn empty_meta_is_empty() {
         assert!(Meta::new().is_empty());
         assert!(!Meta::new().with("k", json!(1)).is_empty());
+    }
+
+    #[test]
+    fn iter_yields_entries() {
+        let meta = Meta::new().with("a", json!(1)).with("b", json!(2));
+        let mut keys: Vec<&str> = meta.iter().map(|(k, _)| k.as_str()).collect();
+        keys.sort_unstable();
+        assert_eq!(keys, ["a", "b"]);
     }
 
     #[test]

--- a/crates/mcpkit-core/src/types/meta.rs
+++ b/crates/mcpkit-core/src/types/meta.rs
@@ -1,0 +1,161 @@
+//! Protocol `_meta` metadata.
+//!
+//! The MCP 2025-11-25 schema attaches an optional `_meta` object to request
+//! params, notification params, and results. It is an open, string-keyed map for
+//! protocol- and implementation-defined metadata. This module provides the
+//! [`Meta`] type plus helpers for the one well-known key, `progressToken`.
+
+use crate::protocol::ProgressToken;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+/// The well-known request `_meta` key carrying a progress token.
+const PROGRESS_TOKEN_KEY: &str = "progressToken";
+
+/// The `_meta` field carried by MCP requests, notifications, and results.
+///
+/// `_meta` is an open, string-keyed map. Keys beginning with
+/// `modelcontextprotocol.io/` (and the bare `modelcontextprotocol.io` label) are
+/// reserved by the MCP spec; namespace your own keys (e.g. by a domain you
+/// control) to avoid collisions.
+///
+/// On a **request**, `_meta.progressToken` associates progress notifications
+/// with the call — see [`with_progress_token`](Self::with_progress_token) and
+/// [`progress_token`](Self::progress_token).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct Meta(pub Map<String, Value>);
+
+impl Meta {
+    /// Create an empty `_meta` map.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Map::new())
+    }
+
+    /// Whether there are no metadata entries.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Get a raw metadata value by key.
+    #[must_use]
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.0.get(key)
+    }
+
+    /// Insert a raw metadata entry, returning the previous value if any.
+    pub fn insert(&mut self, key: impl Into<String>, value: Value) -> Option<Value> {
+        self.0.insert(key.into(), value)
+    }
+
+    /// Insert a raw metadata entry, returning `self` for chaining.
+    #[must_use]
+    pub fn with(mut self, key: impl Into<String>, value: Value) -> Self {
+        self.0.insert(key.into(), value);
+        self
+    }
+
+    /// The request progress token (`_meta.progressToken`), if present and valid.
+    #[must_use]
+    pub fn progress_token(&self) -> Option<ProgressToken> {
+        self.0
+            .get(PROGRESS_TOKEN_KEY)
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+
+    /// Set the progress token.
+    pub fn set_progress_token(&mut self, token: ProgressToken) {
+        // `ProgressToken` serializes to a string or number, so this is infallible.
+        if let Ok(value) = serde_json::to_value(token) {
+            self.0.insert(PROGRESS_TOKEN_KEY.to_string(), value);
+        }
+    }
+
+    /// Set the progress token, returning `self` for chaining.
+    #[must_use]
+    pub fn with_progress_token(mut self, token: ProgressToken) -> Self {
+        self.set_progress_token(token);
+        self
+    }
+
+    /// Extract a request's progress token directly from raw params
+    /// (`params._meta.progressToken`) without deserializing the whole `_meta`.
+    ///
+    /// This is the typed replacement for hand-parsing progress tokens out of raw
+    /// request params.
+    #[must_use]
+    pub fn progress_token_from_params(params: &Value) -> Option<ProgressToken> {
+        params
+            .get("_meta")?
+            .get(PROGRESS_TOKEN_KEY)
+            .and_then(|v| serde_json::from_value(v.clone()).ok())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn progress_token_round_trips() {
+        let meta = Meta::new().with_progress_token(ProgressToken::String("abc".into()));
+        let wire = serde_json::to_value(&meta).unwrap();
+        assert_eq!(wire, json!({ "progressToken": "abc" }));
+        let back: Meta = serde_json::from_value(wire).unwrap();
+        assert_eq!(
+            back.progress_token(),
+            Some(ProgressToken::String("abc".into()))
+        );
+    }
+
+    #[test]
+    fn numeric_progress_token_round_trips() {
+        let meta = Meta::new().with_progress_token(ProgressToken::Number(7));
+        assert_eq!(meta.progress_token(), Some(ProgressToken::Number(7)));
+    }
+
+    #[test]
+    fn extracts_progress_token_from_raw_params() {
+        let params = json!({ "name": "t", "_meta": { "progressToken": 42 } });
+        assert_eq!(
+            Meta::progress_token_from_params(&params),
+            Some(ProgressToken::Number(42))
+        );
+        // No _meta -> None.
+        assert_eq!(
+            Meta::progress_token_from_params(&json!({ "name": "t" })),
+            None
+        );
+    }
+
+    #[test]
+    fn empty_meta_is_empty() {
+        assert!(Meta::new().is_empty());
+        assert!(!Meta::new().with("k", json!(1)).is_empty());
+    }
+
+    #[test]
+    fn result_meta_serializes_as_underscore_meta_and_omits_when_none() {
+        use crate::types::CallToolResult;
+
+        // Present -> serialized under `_meta`, and round-trips back.
+        let with_meta = CallToolResult {
+            meta: Some(Meta::new().with("acme.com/trace", json!("id-1"))),
+            ..CallToolResult::text("ok")
+        };
+        let wire = serde_json::to_value(&with_meta).unwrap();
+        assert_eq!(wire["_meta"], json!({ "acme.com/trace": "id-1" }));
+        let back: CallToolResult = serde_json::from_value(wire).unwrap();
+        assert_eq!(
+            back.meta.and_then(|m| m.get("acme.com/trace").cloned()),
+            Some(json!("id-1"))
+        );
+
+        // Absent -> `_meta` omitted from the wire.
+        let no_meta = serde_json::to_value(CallToolResult::text("ok")).unwrap();
+        assert!(no_meta.get("_meta").is_none());
+    }
+}

--- a/crates/mcpkit-core/src/types/mod.rs
+++ b/crates/mcpkit-core/src/types/mod.rs
@@ -18,6 +18,7 @@
 pub mod completion;
 pub mod content;
 pub mod elicitation;
+pub mod meta;
 pub mod metadata;
 pub mod prompt;
 pub mod resource;
@@ -29,6 +30,7 @@ pub mod tool;
 pub use completion::*;
 pub use content::*;
 pub use elicitation::*;
+pub use meta::*;
 pub use metadata::*;
 pub use prompt::*;
 pub use resource::*;

--- a/crates/mcpkit-core/src/types/prompt.rs
+++ b/crates/mcpkit-core/src/types/prompt.rs
@@ -4,6 +4,7 @@
 //! They allow servers to define reusable message patterns with arguments.
 
 use super::content::{Content, Role};
+use super::meta::Meta;
 use super::metadata::Icon;
 use serde::{Deserialize, Serialize};
 
@@ -180,6 +181,9 @@ pub struct GetPromptResult {
     pub description: Option<String>,
     /// The prompt messages.
     pub messages: Vec<PromptMessage>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl GetPromptResult {
@@ -189,6 +193,7 @@ impl GetPromptResult {
         Self {
             description: None,
             messages: vec![PromptMessage::user(text)],
+            meta: None,
         }
     }
 
@@ -198,6 +203,7 @@ impl GetPromptResult {
         Self {
             description: None,
             messages: vec![PromptMessage::assistant(text)],
+            meta: None,
         }
     }
 
@@ -207,6 +213,7 @@ impl GetPromptResult {
         Self {
             description: None,
             messages,
+            meta: None,
         }
     }
 

--- a/crates/mcpkit-core/src/types/resource.rs
+++ b/crates/mcpkit-core/src/types/resource.rs
@@ -4,6 +4,7 @@
 //! They can be files, database entries, API responses, or any other
 //! addressable content.
 
+use super::meta::Meta;
 use super::metadata::Icon;
 use serde::{Deserialize, Serialize};
 
@@ -304,6 +305,9 @@ pub struct ListResourcesResult {
     /// Cursor for the next page.
     #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 /// Response for listing resource templates.
@@ -315,6 +319,9 @@ pub struct ListResourceTemplatesResult {
     /// Cursor for the next page.
     #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 /// Request parameters for reading a resource.
@@ -329,6 +336,9 @@ pub struct ReadResourceRequest {
 pub struct ReadResourceResult {
     /// The resource contents.
     pub contents: Vec<ResourceContents>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 /// Notification that a resource has changed.

--- a/crates/mcpkit-core/src/types/sampling.rs
+++ b/crates/mcpkit-core/src/types/sampling.rs
@@ -5,6 +5,7 @@
 //! the client's AI capabilities.
 
 use super::content::{Content, Role};
+use super::meta::Meta;
 use serde::{Deserialize, Serialize};
 
 /// A message in a sampling conversation.
@@ -230,6 +231,9 @@ pub struct CreateMessageResult {
     /// Stop reason.
     #[serde(rename = "stopReason", skip_serializing_if = "Option::is_none")]
     pub stop_reason: Option<StopReason>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl CreateMessageResult {

--- a/crates/mcpkit-core/src/types/task.rs
+++ b/crates/mcpkit-core/src/types/task.rs
@@ -112,9 +112,6 @@ pub struct Task {
     /// Suggested polling interval, in milliseconds.
     #[serde(rename = "pollInterval", skip_serializing_if = "Option::is_none")]
     pub poll_interval: Option<u64>,
-    /// Optional protocol metadata (`_meta`).
-    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
-    pub meta: Option<Meta>,
 }
 
 impl Task {
@@ -130,7 +127,6 @@ impl Task {
             last_updated_at: now,
             ttl: None,
             poll_interval: None,
-            meta: None,
         }
     }
 
@@ -196,6 +192,16 @@ pub struct CreateTaskResult {
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
 }
+
+// NOTE: Per the spec, `tasks/get`/`tasks/cancel` results and the task-status
+// notification are `Result & Task` / `NotificationParams & Task`, i.e. they may
+// carry a result/notification-level `_meta`. That is intentionally *not* modeled
+// here: the base `Task` has no `_meta` (adding one would leak `_meta` into nested
+// `CreateTaskResult.task` and `ListTasksResult.tasks[]`), and the task handler API
+// returns a bare `Task` with nowhere to supply result-level metadata. Modeling it
+// would need dedicated result wrapper types + a handler-contract change — see
+// issue #136. `CreateTaskResult`/`ListTasksResult` do carry their own
+// result-level `_meta`.
 
 /// Result of `tasks/get` — the task's current state (spec `Result & Task`).
 pub type GetTaskResult = Task;

--- a/crates/mcpkit-core/src/types/task.rs
+++ b/crates/mcpkit-core/src/types/task.rs
@@ -5,6 +5,7 @@
 //! caller polls [`tasks/get`](GetTaskRequest) for status and
 //! [`tasks/result`](GetTaskPayloadRequest) for the eventual payload.
 
+use super::meta::Meta;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -111,6 +112,9 @@ pub struct Task {
     /// Suggested polling interval, in milliseconds.
     #[serde(rename = "pollInterval", skip_serializing_if = "Option::is_none")]
     pub poll_interval: Option<u64>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl Task {
@@ -126,6 +130,7 @@ impl Task {
             last_updated_at: now,
             ttl: None,
             poll_interval: None,
+            meta: None,
         }
     }
 
@@ -187,6 +192,9 @@ pub struct RelatedTaskMetadata {
 pub struct CreateTaskResult {
     /// The created task.
     pub task: Task,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 /// Result of `tasks/get` — the task's current state (spec `Result & Task`).
@@ -215,6 +223,9 @@ pub struct ListTasksResult {
     /// Cursor for the next page, if more tasks exist.
     #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 /// Request parameters for `tasks/get`.
@@ -310,6 +321,7 @@ mod tests {
     fn create_task_result_wraps_task() {
         let res = CreateTaskResult {
             task: Task::new(TaskId::new("abc")),
+            meta: None,
         };
         let j = serde_json::to_value(&res).unwrap();
         assert_eq!(j["task"]["taskId"], "abc");

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -4,6 +4,7 @@
 //! Each tool has a name, description, and JSON Schema defining its input.
 
 use super::content::Content;
+use super::meta::Meta;
 use super::metadata::Icon;
 use serde::{Deserialize, Serialize};
 
@@ -391,6 +392,9 @@ pub struct CallToolResult {
         skip_serializing_if = "Option::is_none"
     )]
     pub structured_content: Option<serde_json::Value>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl CallToolResult {
@@ -401,6 +405,7 @@ impl CallToolResult {
             content: vec![Content::text(text)],
             is_error: None,
             structured_content: None,
+            meta: None,
         }
     }
 
@@ -411,6 +416,7 @@ impl CallToolResult {
             content,
             is_error: None,
             structured_content: None,
+            meta: None,
         }
     }
 
@@ -421,6 +427,7 @@ impl CallToolResult {
             content: vec![Content::text(message)],
             is_error: Some(true),
             structured_content: None,
+            meta: None,
         }
     }
 
@@ -583,6 +590,9 @@ pub struct ListToolsResult {
     /// Cursor for the next page, if more tools exist.
     #[serde(rename = "nextCursor", skip_serializing_if = "Option::is_none")]
     pub next_cursor: Option<String>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 /// Request parameters for calling a tool.

--- a/crates/mcpkit-macros-tests/tests/expand/client_full.rs
+++ b/crates/mcpkit-macros-tests/tests/expand/client_full.rs
@@ -24,6 +24,7 @@ impl FullHandler {
             role: Role::Assistant,
             content: Content::text("Response"),
             stop_reason: Some(StopReason::EndTurn),
+            meta: None,
         })
     }
 

--- a/crates/mcpkit-macros-tests/tests/expand/client_sampling.rs
+++ b/crates/mcpkit-macros-tests/tests/expand/client_sampling.rs
@@ -15,6 +15,7 @@ impl SamplingHandler {
             role: Role::Assistant,
             content: Content::text("Hello!"),
             stop_reason: Some(StopReason::EndTurn),
+            meta: None,
         })
     }
 }

--- a/crates/mcpkit-macros-tests/tests/expand/prompt_only.rs
+++ b/crates/mcpkit-macros-tests/tests/expand/prompt_only.rs
@@ -10,7 +10,7 @@ impl PromptServer {
     /// Generate a greeting prompt
     #[prompt(description = "Generate a personalized greeting")]
     async fn greeting(&self, name: String) -> mcpkit::types::GetPromptResult {
-        mcpkit::types::GetPromptResult {
+        mcpkit::types::GetPromptResult { meta: None,
             description: Some("A greeting prompt".to_string()),
             messages: vec![
                 mcpkit::types::PromptMessage::user(format!("Say hello to {}", name)),

--- a/crates/mcpkit-macros/src/lib.rs
+++ b/crates/mcpkit-macros/src/lib.rs
@@ -277,7 +277,7 @@ pub fn resource(attr: TokenStream, item: TokenStream) -> TokenStream {
 /// ```ignore
 /// #[prompt(description = "Generate a greeting message")]
 /// async fn greeting(&self, name: String) -> GetPromptResult {
-///     GetPromptResult {
+///     GetPromptResult { meta: None,
 ///         description: Some("A friendly greeting".to_string()),
 ///         messages: vec![
 ///             PromptMessage::user(format!("Hello, {}!", name))

--- a/crates/mcpkit-macros/src/prompt.rs
+++ b/crates/mcpkit-macros/src/prompt.rs
@@ -81,7 +81,7 @@ mod tests {
         // Valid method
         let method: ImplItemFn = parse_quote! {
             async fn greeting(&self, name: String) -> GetPromptResult {
-                GetPromptResult {
+                GetPromptResult { meta: None,
                     description: None,
                     messages: vec![],
                 }
@@ -92,7 +92,7 @@ mod tests {
         // Method without self - invalid
         let method: ImplItemFn = parse_quote! {
             async fn greeting(name: String) -> GetPromptResult {
-                GetPromptResult {
+                GetPromptResult { meta: None,
                     description: None,
                     messages: vec![],
                 }

--- a/crates/mcpkit-macros/tests/compile-fail/prompt_missing_description.rs
+++ b/crates/mcpkit-macros/tests/compile-fail/prompt_missing_description.rs
@@ -9,7 +9,7 @@ struct MyServer;
 impl MyServer {
     #[prompt]
     async fn greeting(&self, name: String) -> mcpkit_core::types::GetPromptResult {
-        mcpkit_core::types::GetPromptResult {
+        mcpkit_core::types::GetPromptResult { meta: None,
             description: None,
             messages: vec![],
         }

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -320,6 +320,7 @@ mod tests {
             _ctx: &Context<'_>,
         ) -> Result<GetPromptResult, McpError> {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("Test prompt".to_string()),
                 messages: vec![],
             })

--- a/crates/mcpkit-rocket/src/state.rs
+++ b/crates/mcpkit-rocket/src/state.rs
@@ -150,6 +150,7 @@ mod tests {
             _ctx: &Context<'_>,
         ) -> Result<GetPromptResult, McpError> {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("Test".to_string()),
                 messages: vec![],
             })

--- a/crates/mcpkit-rocket/tests/integration.rs
+++ b/crates/mcpkit-rocket/tests/integration.rs
@@ -100,6 +100,7 @@ impl PromptHandler for TestHandler {
     ) -> Result<GetPromptResult, McpError> {
         if name == "greeting" {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("A friendly greeting".to_string()),
                 messages: vec![],
             })

--- a/crates/mcpkit-server/src/capability/completions.rs
+++ b/crates/mcpkit-server/src/capability/completions.rs
@@ -138,6 +138,7 @@ impl CompletionService {
                     total: Some(total),
                     has_more: Some(false),
                 },
+                meta: None,
             })
         } else {
             // Return empty completions if no handler registered
@@ -147,6 +148,7 @@ impl CompletionService {
                     total: Some(0),
                     has_more: Some(false),
                 },
+                meta: None,
             })
         }
     }

--- a/crates/mcpkit-server/src/capability/prompts.rs
+++ b/crates/mcpkit-server/src/capability/prompts.rs
@@ -254,6 +254,7 @@ impl PromptResultBuilder {
         GetPromptResult {
             description: self.description,
             messages: self.messages,
+            meta: None,
         }
     }
 }

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -771,7 +771,8 @@ where
             .task()
             .unwrap_or_else(|| mcpkit_core::types::Task::new(handle.id().clone()));
         let create_result =
-            serde_json::to_value(mcpkit_core::types::CreateTaskResult { task }).unwrap_or_default();
+            serde_json::to_value(mcpkit_core::types::CreateTaskResult { task, meta: None })
+                .unwrap_or_default();
         if let Err(e) = self
             .transport
             .send(Message::Response(Response::success(
@@ -1268,10 +1269,7 @@ fn panic_message(panic: &(dyn std::any::Any + Send)) -> String {
 }
 
 fn extract_progress_token(params: Option<&serde_json::Value>) -> Option<ProgressToken> {
-    params?
-        .get("_meta")?
-        .get("progressToken")
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
+    params.and_then(mcpkit_core::types::Meta::progress_token_from_params)
 }
 
 #[cfg(test)]
@@ -1934,6 +1932,7 @@ mod tests {
             content: Content::text("a summary"),
             model: "test-model".to_string(),
             stop_reason: None,
+            meta: None,
         };
         client
             .send(Message::Response(Response::success(

--- a/crates/mcpkit-server/src/validation.rs
+++ b/crates/mcpkit-server/src/validation.rs
@@ -528,6 +528,7 @@ mod tests {
                 Ok(GetPromptResult {
                     description: None,
                     messages: vec![],
+                    meta: None,
                 })
             }
         }

--- a/crates/mcpkit-testing/src/mock.rs
+++ b/crates/mcpkit-testing/src/mock.rs
@@ -488,6 +488,7 @@ impl PromptHandler for MockServer {
     ) -> impl Future<Output = Result<GetPromptResult, McpError>> + Send {
         let result = if let Some(prompt) = self.prompts.get(name) {
             Ok(GetPromptResult {
+                meta: None,
                 description: prompt.description.clone(),
                 messages: vec![PromptMessage {
                     role: mcpkit_core::types::Role::User,

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -497,6 +497,7 @@ mod tests {
             _ctx: &Context<'_>,
         ) -> Result<GetPromptResult, McpError> {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("Test prompt".to_string()),
                 messages: vec![],
             })

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -318,6 +318,7 @@ mod tests {
             _ctx: &Context<'_>,
         ) -> Result<GetPromptResult, McpError> {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("Test prompt".to_string()),
                 messages: vec![],
             })

--- a/crates/mcpkit-warp/src/state.rs
+++ b/crates/mcpkit-warp/src/state.rs
@@ -150,6 +150,7 @@ mod tests {
             _ctx: &Context<'_>,
         ) -> Result<GetPromptResult, McpError> {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("Warp Test".to_string()),
                 messages: vec![],
             })

--- a/crates/mcpkit-warp/tests/integration.rs
+++ b/crates/mcpkit-warp/tests/integration.rs
@@ -97,6 +97,7 @@ impl PromptHandler for TestHandler {
     ) -> Result<GetPromptResult, McpError> {
         if name == "greeting" {
             Ok(GetPromptResult {
+                meta: None,
                 description: Some("A friendly greeting".to_string()),
                 messages: vec![],
             })

--- a/examples/database-server/src/main.rs
+++ b/examples/database-server/src/main.rs
@@ -349,6 +349,7 @@ impl DatabaseServer {
             .unwrap_or_default();
 
         GetPromptResult {
+            meta: None,
             description: Some(format!("SELECT query for {}", table_name)),
             messages: vec![
                 PromptMessage::user(format!(
@@ -377,6 +378,7 @@ impl DatabaseServer {
             .unwrap_or_default();
 
         GetPromptResult {
+            meta: None,
             description: Some("Database schema design assistance".to_string()),
             messages: vec![PromptMessage::user(format!(
                 "You are a database architect. Design normalized, efficient schemas. \
@@ -406,6 +408,7 @@ impl DatabaseServer {
             .unwrap_or_default();
 
         GetPromptResult {
+            meta: None,
             description: Some("Query optimization analysis".to_string()),
             messages: vec![PromptMessage::user(format!(
                 "You are a database performance expert. Analyze queries for optimization \

--- a/examples/full-server/src/main.rs
+++ b/examples/full-server/src/main.rs
@@ -129,6 +129,7 @@ impl FullServer {
     async fn code_review(&self, code: String, language: Option<String>) -> GetPromptResult {
         let lang = language.unwrap_or_else(|| "unknown".to_string());
         GetPromptResult {
+            meta: None,
             description: Some("Code review prompt".to_string()),
             messages: vec![PromptMessage::user(format!(
                 "Please review the following {} code for:\n\
@@ -150,6 +151,7 @@ impl FullServer {
             .unwrap_or_else(|| "Keep the summary concise.".to_string());
 
         GetPromptResult {
+            meta: None,
             description: Some("Summarization prompt".to_string()),
             messages: vec![PromptMessage::user(format!(
                 "Please summarize the following text. {}\n\n{}",

--- a/examples/rocket-server/src/main.rs
+++ b/examples/rocket-server/src/main.rs
@@ -210,6 +210,7 @@ impl PromptHandler for RocketHandler {
                     .unwrap_or("User");
 
                 Ok(GetPromptResult {
+                    meta: None,
                     description: Some(format!("Welcome message for {user_name}")),
                     messages: vec![PromptMessage::user(format!(
                         "Please write a warm and friendly welcome message for {user_name} \

--- a/examples/warp-server/src/main.rs
+++ b/examples/warp-server/src/main.rs
@@ -239,6 +239,7 @@ impl PromptHandler for WarpHandler {
                     .unwrap_or("User");
 
                 Ok(GetPromptResult {
+                    meta: None,
                     description: Some(format!("Welcome message for {user_name}")),
                     messages: vec![PromptMessage::user(format!(
                         "Please write a warm and friendly welcome message for {user_name} \

--- a/mcpkit/tests/capability_negotiation_compatibility.rs
+++ b/mcpkit/tests/capability_negotiation_compatibility.rs
@@ -751,6 +751,7 @@ fn test_full_handshake_latest_version() {
     let server_info = ServerInfo::new("test-server", "1.0");
     let server_caps = ServerCapabilities::new().with_tools();
     let result = InitializeResult {
+        meta: None,
         protocol_version: negotiated.to_string(),
         capabilities: server_caps,
         server_info,
@@ -785,6 +786,7 @@ fn test_full_handshake_rmcp_version() -> Result<(), Box<dyn std::error::Error>> 
     let server_caps = ServerCapabilities::new().with_tools().with_resources();
 
     let result = InitializeResult {
+        meta: None,
         protocol_version: negotiated.to_string(),
         capabilities: server_caps,
         server_info,

--- a/mcpkit/tests/initialization_compliance.rs
+++ b/mcpkit/tests/initialization_compliance.rs
@@ -68,6 +68,7 @@ fn test_initialize_result() {
     let capabilities = ServerCapabilities::new().with_tools();
 
     let result = InitializeResult {
+        meta: None,
         protocol_version: PROTOCOL_VERSION.to_string(),
         capabilities,
         server_info,

--- a/mcpkit/tests/tool_schema_compatibility.rs
+++ b/mcpkit/tests/tool_schema_compatibility.rs
@@ -231,6 +231,7 @@ fn test_call_tool_result_error_serialization() -> Result<(), Box<dyn std::error:
 #[test]
 fn test_call_tool_result_is_error_field_casing() -> Result<(), Box<dyn std::error::Error>> {
     let error_result = CallToolResult {
+        meta: None,
         content: vec![Content::text("Error message")],
         is_error: Some(true),
         structured_content: None,
@@ -318,6 +319,7 @@ fn test_tool_output_error_with_suggestion() -> Result<(), Box<dyn std::error::Er
 #[test]
 fn test_list_tools_result_serialization() -> Result<(), Box<dyn std::error::Error>> {
     let result = ListToolsResult {
+        meta: None,
         tools: vec![
             Tool::new("tool_a")
                 .description("Tool A")
@@ -349,6 +351,7 @@ fn test_list_tools_result_serialization() -> Result<(), Box<dyn std::error::Erro
 #[test]
 fn test_list_tools_result_without_cursor() -> Result<(), Box<dyn std::error::Error>> {
     let result = ListToolsResult {
+        meta: None,
         tools: vec![Tool::new("tool").input_schema(json!({"type": "object"}))],
         next_cursor: None,
     };
@@ -587,6 +590,7 @@ fn test_tools_list_response_matches_mcp_spec() -> Result<(), Box<dyn std::error:
     ];
 
     let response = ListToolsResult {
+        meta: None,
         tools,
         next_cursor: None,
     };


### PR DESCRIPTION
First of the schema-audit spec-fidelity PRs. Adds the `_meta` foundation so `#112` (typed progress/cancelled params) and later work build on a shared `Meta` type. Scoped per three review passes (mine + two others) — **not** a sweeping "`_meta` everywhere" or a generic `Request<T>` refactor.

## Added
- **`Meta`** (`mcpkit_core::types::meta`) — an open, string-keyed map (`#[serde(transparent)]`) modeling MCP `_meta`, with:
  - typed `progress_token()` / `with_progress_token()` bridging the existing `ProgressToken`,
  - `Meta::progress_token_from_params(&Value)` — the server's hand-rolled `_meta.progressToken` extraction now **delegates** to this core helper (reusable by client/adapters),
  - `get`/`insert`/`with`/`is_empty` + reserved-prefix docs.
- `meta: Option<Meta>` (serialized as `_meta`, `skip_serializing_if=None`) on the concrete result structs — `CallToolResult`, `GetPromptResult`, `ListToolsResult` and the other `*Result` types, `InitializeResult`, `PingResult` — and on **`Task`** (covers `GetTaskResult`/`CancelTaskResult`/`TaskStatusNotification`, which are `Task` aliases).

## Deliberately left alone
- No generic `Request<T>` refactor; the JSON-RPC envelope stays `Value`-based.
- The 14 `*Request` param structs get no per-struct `_meta` field — request `progressToken` is handled via the boundary helper.
- `GetTaskPayloadResult = Value` (arbitrary payload) — boundary helpers only, no field.

## Breaking
The new field means struct-literal construction of these result types now requires `meta`. Use the existing constructors (`CallToolResult::text`, `GetPromptResult::user`, …), `..Default::default()` where derived, or `meta: None`. (0.7.0 pre-1.0.)

## Tests
`Meta` progress-token round-trip (string + numeric), raw-params extraction, empty-map, and a **result-level** round-trip proving `_meta` serialization + omission-when-None on `CallToolResult`.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --all-features --locked` all green.