### PR TITLE
feat(server): wire resources/subscribe + typed request types (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Resource subscription request types + wiring (#107). New core
+  `SubscribeRequest`/`UnsubscribeRequest` (`{ uri }`), and the server now actually
+  dispatches `resources/subscribe`/`resources/unsubscribe` to
+  `ResourceHandler::subscribe`/`unsubscribe` (added to the object-safe dispatch
+  layer). **Fixed:** these methods previously fell through routing and returned
+  `method not found` despite the advertised `resources.subscribe` capability. A
+  handler returning `true` yields the spec's empty result; `false` is an error
+  (the subscription was not established) rather than a false success. The client's
+  `subscribe_resource`/`unsubscribe_resource` now use the typed requests
+  ([#107](https://github.com/praxiomlabs/mcpkit/issues/107)).
 - Typed progress/cancelled notification params (`mcpkit-core`, #112).
   `ProgressNotificationParams { progressToken, progress: f64, total?, message?,
   _meta? }` and `CancelledNotificationParams { requestId?, reason?, _meta? }`

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -26,8 +26,8 @@ use mcpkit_core::types::{
     CompletionArgument, CompletionRef, CreateMessageRequest, ElicitRequestParams, GetPromptRequest,
     GetPromptResult, GetTaskRequest, ListPromptsResult, ListResourceTemplatesResult,
     ListResourcesResult, ListTasksRequest, ListTasksResult, ListToolsResult, Prompt,
-    ReadResourceRequest, ReadResourceResult, Resource, ResourceContents, ResourceTemplate, Task,
-    TaskStatus, Tool,
+    ReadResourceRequest, ReadResourceResult, Resource, ResourceContents, ResourceTemplate,
+    SubscribeRequest, Task, TaskStatus, Tool, UnsubscribeRequest,
 };
 use mcpkit_transport::Transport;
 use std::collections::HashMap;
@@ -940,8 +940,10 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             });
         }
 
-        let params = serde_json::json!({ "uri": uri.into() });
-        let _: serde_json::Value = self.request("resources/subscribe", Some(params)).await?;
+        let request = SubscribeRequest { uri: uri.into() };
+        let _: serde_json::Value = self
+            .request("resources/subscribe", Some(serde_json::to_value(request)?))
+            .await?;
         Ok(())
     }
 
@@ -961,8 +963,13 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             });
         }
 
-        let params = serde_json::json!({ "uri": uri.into() });
-        let _: serde_json::Value = self.request("resources/unsubscribe", Some(params)).await?;
+        let request = UnsubscribeRequest { uri: uri.into() };
+        let _: serde_json::Value = self
+            .request(
+                "resources/unsubscribe",
+                Some(serde_json::to_value(request)?),
+            )
+            .await?;
         Ok(())
     }
 

--- a/crates/mcpkit-core/src/types/resource.rs
+++ b/crates/mcpkit-core/src/types/resource.rs
@@ -341,6 +341,20 @@ pub struct ReadResourceResult {
     pub meta: Option<Meta>,
 }
 
+/// Request parameters for `resources/subscribe`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SubscribeRequest {
+    /// URI of the resource to subscribe to for update notifications.
+    pub uri: String,
+}
+
+/// Request parameters for `resources/unsubscribe`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UnsubscribeRequest {
+    /// URI of the resource to stop receiving update notifications for.
+    pub uri: String,
+}
+
 /// Notification that a resource has changed.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResourceUpdatedNotification {
@@ -418,5 +432,20 @@ mod tests {
                 .contains("\"name\"")
         );
         Ok(())
+    }
+
+    #[test]
+    fn subscribe_requests_round_trip() {
+        let wire = serde_json::to_value(SubscribeRequest {
+            uri: "file:///x".into(),
+        })
+        .unwrap();
+        assert_eq!(wire, serde_json::json!({ "uri": "file:///x" }));
+        let back: SubscribeRequest = serde_json::from_value(wire).unwrap();
+        assert_eq!(back.uri, "file:///x");
+
+        let back: UnsubscribeRequest =
+            serde_json::from_value(serde_json::json!({ "uri": "file:///y" })).unwrap();
+        assert_eq!(back.uri, "file:///y");
     }
 }

--- a/crates/mcpkit-server/src/dispatch.rs
+++ b/crates/mcpkit-server/src/dispatch.rs
@@ -76,6 +76,18 @@ pub trait DynResourceHandler: Send + Sync {
         uri: &'a str,
         ctx: &'a Context<'_>,
     ) -> BoxFut<'a, Result<Vec<ResourceContents>, McpError>>;
+    /// See [`ResourceHandler::subscribe`].
+    fn subscribe<'a>(
+        &'a self,
+        uri: &'a str,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<bool, McpError>>;
+    /// See [`ResourceHandler::unsubscribe`].
+    fn unsubscribe<'a>(
+        &'a self,
+        uri: &'a str,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<bool, McpError>>;
 }
 
 impl<R: ResourceHandler> DynResourceHandler for R {
@@ -97,6 +109,20 @@ impl<R: ResourceHandler> DynResourceHandler for R {
         ctx: &'a Context<'_>,
     ) -> BoxFut<'a, Result<Vec<ResourceContents>, McpError>> {
         Box::pin(ResourceHandler::read_resource(self, uri, ctx))
+    }
+    fn subscribe<'a>(
+        &'a self,
+        uri: &'a str,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<bool, McpError>> {
+        Box::pin(ResourceHandler::subscribe(self, uri, ctx))
+    }
+    fn unsubscribe<'a>(
+        &'a self,
+        uri: &'a str,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<bool, McpError>> {
+        Box::pin(ResourceHandler::unsubscribe(self, uri, ctx))
     }
 }
 

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -511,7 +511,7 @@ fn parse_list_params(params: Option<&Value>) -> ListParams {
 use crate::context::Context;
 use crate::dispatch::{DynPromptHandler, DynResourceHandler, DynTaskHandler, DynToolHandler};
 use mcpkit_core::pagination::paginate;
-use mcpkit_core::types::{CallToolResult, TaskId};
+use mcpkit_core::types::{CallToolResult, SubscribeRequest, TaskId, UnsubscribeRequest};
 
 /// Build a paginated list result: the items under `key` plus an optional
 /// `nextCursor`.
@@ -691,6 +691,50 @@ pub async fn route_resources(
 
                 let contents = contents?;
                 Ok(serde_json::json!({ "contents": contents }))
+            }
+            .await;
+            Some(result)
+        }
+        methods::RESOURCES_SUBSCRIBE => {
+            let result = async {
+                let params = params.ok_or_else(|| {
+                    McpError::invalid_params(methods::RESOURCES_SUBSCRIBE, "missing params")
+                })?;
+                let req: SubscribeRequest =
+                    serde_json::from_value(params.clone()).map_err(|_| {
+                        McpError::invalid_params(methods::RESOURCES_SUBSCRIBE, "missing uri")
+                    })?;
+                tracing::info!(uri = %req.uri, "Subscribing to resource");
+                if handler.subscribe(&req.uri, ctx).await? {
+                    Ok(serde_json::json!({}))
+                } else {
+                    Err(McpError::internal(format!(
+                        "subscription not established for {}",
+                        req.uri
+                    )))
+                }
+            }
+            .await;
+            Some(result)
+        }
+        methods::RESOURCES_UNSUBSCRIBE => {
+            let result = async {
+                let params = params.ok_or_else(|| {
+                    McpError::invalid_params(methods::RESOURCES_UNSUBSCRIBE, "missing params")
+                })?;
+                let req: UnsubscribeRequest =
+                    serde_json::from_value(params.clone()).map_err(|_| {
+                        McpError::invalid_params(methods::RESOURCES_UNSUBSCRIBE, "missing uri")
+                    })?;
+                tracing::info!(uri = %req.uri, "Unsubscribing from resource");
+                if handler.unsubscribe(&req.uri, ctx).await? {
+                    Ok(serde_json::json!({}))
+                } else {
+                    Err(McpError::internal(format!(
+                        "unsubscribe not honored for {}",
+                        req.uri
+                    )))
+                }
             }
             .await;
             Some(result)
@@ -1480,5 +1524,105 @@ mod tests {
             .await
             .unwrap();
         assert!(err.is_err());
+    }
+
+    #[tokio::test]
+    async fn route_resources_dispatches_subscribe_and_unsubscribe() {
+        use crate::context::NoOpPeer;
+        use crate::handler::ResourceHandler;
+        use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+        use mcpkit_core::protocol::RequestId;
+        use mcpkit_core::protocol_version::ProtocolVersion;
+        use mcpkit_core::types::{Resource, ResourceContents};
+
+        struct Res {
+            ok: bool,
+        }
+        impl ResourceHandler for Res {
+            async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+                Ok(vec![])
+            }
+            async fn read_resource(
+                &self,
+                _uri: &str,
+                _ctx: &Context<'_>,
+            ) -> Result<Vec<ResourceContents>, McpError> {
+                Ok(vec![])
+            }
+            async fn subscribe(&self, _uri: &str, _ctx: &Context<'_>) -> Result<bool, McpError> {
+                Ok(self.ok)
+            }
+            async fn unsubscribe(&self, _uri: &str, _ctx: &Context<'_>) -> Result<bool, McpError> {
+                Ok(self.ok)
+            }
+        }
+
+        let request_id = RequestId::Number(1);
+        let client_caps = ClientCapabilities::default();
+        let server_caps = ServerCapabilities::default();
+        let peer = NoOpPeer;
+        let ctx = Context::new(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            ProtocolVersion::LATEST,
+            &peer,
+        );
+        let params = serde_json::json!({ "uri": "file:///x" });
+
+        // subscribe -> Ok(true) yields an empty result (no longer method-not-found).
+        let ok = route_resources(
+            &Res { ok: true },
+            methods::RESOURCES_SUBSCRIBE,
+            Some(&params),
+            &ctx,
+            None,
+        )
+        .await
+        .expect("subscribe is routed")
+        .expect("ok");
+        assert_eq!(ok, serde_json::json!({}));
+
+        // subscribe -> Ok(false) is an error, not a fake success.
+        assert!(
+            route_resources(
+                &Res { ok: false },
+                methods::RESOURCES_SUBSCRIBE,
+                Some(&params),
+                &ctx,
+                None,
+            )
+            .await
+            .expect("routed")
+            .is_err()
+        );
+
+        // Missing uri -> invalid params.
+        assert!(
+            route_resources(
+                &Res { ok: true },
+                methods::RESOURCES_SUBSCRIBE,
+                Some(&serde_json::json!({})),
+                &ctx,
+                None,
+            )
+            .await
+            .expect("routed")
+            .is_err()
+        );
+
+        // unsubscribe -> Ok(true) yields an empty result.
+        let ok = route_resources(
+            &Res { ok: true },
+            methods::RESOURCES_UNSUBSCRIBE,
+            Some(&params),
+            &ctx,
+            None,
+        )
+        .await
+        .expect("unsubscribe is routed")
+        .expect("ok");
+        assert_eq!(ok, serde_json::json!({}));
     }
 }


### PR DESCRIPTION
Third spec-fidelity PR. #107 turned out to be a **functional bug**, not just missing types.

## The bug
`resources.subscribe` is advertised and `ResourceHandler::subscribe`/`unsubscribe` exist, but `route_resources` (the real dispatch path) handled list/templates/read then `_ => None` — so `resources/subscribe`/`unsubscribe` fell through to **`method not found`**. The handler's `subscribe` was never called. (The `parse_request`/`ParsedRequest::ResourcesSubscribe` layer that *does* parse subscribe is test-only.)

## Fix
- New core `SubscribeRequest`/`UnsubscribeRequest` (`{ uri }`).
- `subscribe`/`unsubscribe` added to the object-safe `DynResourceHandler` + blanket impl (they were missing there, so the router couldn't call them).
- `route_resources` now dispatches both methods:
  - `Ok(true)` → `{}` (the spec's empty result),
  - `Ok(false)` → `internal_error` ("subscription not established for `<uri>`") — a declined subscription isn't a fake success (`invalid_params` would be wrong: the `uri` was valid),
  - missing/invalid `uri` → `invalid_params`.
- Client `subscribe_resource`/`unsubscribe_resource` use the typed requests.

## Naming
The schema calls these `SubscribeRequestParams`; mcpkit's established convention names all 14 request-params types `*Request`, so `SubscribeRequest`/`UnsubscribeRequest` keep the API consistent. A repo-wide `*Request → *RequestParams` rename (for 1:1 schema-name mirroring) is tracked separately in #138. The **wire is spec-correct** either way.

## Left alone
The test-only `parse_request`/`ParsedRequest` subscribe layer (separate dead-code cleanup, not this PR).

## Tests
`SubscribeRequest`/`UnsubscribeRequest` round-trip; `route_resources` regression proving subscribe no longer returns method-not-found — `true` → `{}`, `false` → error, missing `uri` → invalid params, unsubscribe likewise.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --locked` all green.