### PR TITLE
feat(server)!: implement the logging utility (#108)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Logging utility, now functional (#108). New core types `LoggingLevel` (the
+  eight syslog levels, ordered by severity), `SetLevelRequest`, and
+  `LoggingMessageNotificationParams { level, logger?, data, _meta? }`. Inbound
+  `logging/setLevel` is now dispatched to a new `ServerHandler::set_log_level`
+  (default no-op), but only when the `logging` capability is advertised; outbound
+  logs are emitted via `ServerNotifier::log(level, logger, data)` and the
+  `Context::log(..)` convenience (both serialize the typed params). **Fixed:** the
+  advertised `logging` capability was entirely non-functional — `logging/setLevel`
+  returned method-not-found and there was no way to emit `notifications/message`.
+  **Breaking:** the orphaned `LoggingHandler` trait is removed (its `set_level`
+  moved onto `ServerHandler` as `set_log_level`), and `mcpkit_server::LogLevel` is
+  now a re-export of the core `LoggingLevel`
+  ([#108](https://github.com/praxiomlabs/mcpkit/issues/108)).
 - Resource subscription request types + wiring (#107). New core
   `SubscribeRequest`/`UnsubscribeRequest` (`{ uri }`), and the server now actually
   dispatches `resources/subscribe`/`resources/unsubscribe` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Logging utility, now functional (#108). New core types `LoggingLevel` (the
   eight syslog levels, ordered by severity), `SetLevelRequest`, and
   `LoggingMessageNotificationParams { level, logger?, data, _meta? }`. Inbound
-  `logging/setLevel` is now dispatched to a new `ServerHandler::set_log_level`
-  (default no-op), but only when the `logging` capability is advertised; outbound
+  `logging/setLevel` is now dispatched (via a shared `route_logging` helper, so it
+  works the same in the runtime router *and* the four HTTP adapters) to a new
+  `ServerHandler::set_log_level` (default no-op), but only when the `logging`
+  capability is advertised; outbound
   logs are emitted via `ServerNotifier::log(level, logger, data)` and the
   `Context::log(..)` convenience (both serialize the typed params). **Fixed:** the
   advertised `logging` capability was entirely non-functional — `logging/setLevel`

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -12,8 +12,8 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_prompts, route_resources,
-    route_tools,
+    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_logging, route_prompts,
+    route_resources, route_tools,
 };
 use std::time::Duration;
 use tracing::{debug, info, warn};
@@ -265,6 +265,22 @@ where
                 params,
                 &ctx,
                 state.list_page_size,
+            )
+            .await
+            {
+                return match result {
+                    Ok(value) => Response::success(request.id.clone(), value),
+                    Err(e) => Response::error(request.id.clone(), e.into()),
+                };
+            }
+
+            // Try routing logging/setLevel (gated on the advertised capability)
+            if let Some(result) = route_logging(
+                state.handler.as_ref(),
+                &state.handler.capabilities(),
+                method,
+                params,
+                &ctx,
             )
             .await
             {

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -29,8 +29,8 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_prompts, route_resources,
-    route_tools,
+    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_logging, route_prompts,
+    route_resources, route_tools,
 };
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -294,6 +294,22 @@ where
                 params,
                 &ctx,
                 state.list_page_size,
+            )
+            .await
+            {
+                return match result {
+                    Ok(value) => Response::success(request.id.clone(), value),
+                    Err(e) => Response::error(request.id.clone(), e.into()),
+                };
+            }
+
+            // Try routing logging/setLevel (gated on the advertised capability)
+            if let Some(result) = route_logging(
+                state.handler.as_ref(),
+                &state.handler.capabilities(),
+                method,
+                params,
+                &ctx,
             )
             .await
             {

--- a/crates/mcpkit-axum/tests/logging_setlevel.rs
+++ b/crates/mcpkit-axum/tests/logging_setlevel.rs
@@ -1,0 +1,97 @@
+//! Regression test for #108: `logging/setLevel` must work through the HTTP
+//! adapter, not just the stdio runtime router. The adapters dispatch by calling
+//! the shared `route_*` helpers directly, so this guards against the adapter
+//! "routing split" forgetting to route logging.
+
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use mcpkit_axum::McpState;
+use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    GetPromptResult, LoggingLevel, Prompt, Resource, ResourceContents, Tool, ToolOutput,
+};
+use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use std::sync::{Arc, Mutex};
+
+struct H(Arc<Mutex<Option<LoggingLevel>>>);
+
+impl ServerHandler for H {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("t", "1.0.0")
+    }
+    fn capabilities(&self) -> ServerCapabilities {
+        ServerCapabilities::new().with_logging()
+    }
+    async fn set_log_level(&self, level: LoggingLevel, _ctx: &Context<'_>) -> Result<(), McpError> {
+        *self.0.lock().unwrap() = Some(level);
+        Ok(())
+    }
+}
+impl ToolHandler for H {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![])
+    }
+    async fn call_tool(
+        &self,
+        _name: &str,
+        _args: serde_json::Value,
+        _ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        Ok(ToolOutput::text("x"))
+    }
+}
+impl ResourceHandler for H {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for H {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        _name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Ok(GetPromptResult {
+            description: None,
+            messages: vec![],
+            meta: None,
+        })
+    }
+}
+
+#[tokio::test]
+async fn logging_set_level_works_through_axum_adapter() {
+    let seen = Arc::new(Mutex::new(None));
+    let state = McpState::new(H(Arc::clone(&seen)));
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "logging/setLevel",
+        "params": { "level": "warning" }
+    })
+    .to_string();
+
+    let response = mcpkit_axum::handle_mcp_post(State(state), HeaderMap::new(), None, body)
+        .await
+        .into_response();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+
+    assert_eq!(json["result"], serde_json::json!({}), "response: {json}");
+    assert_eq!(*seen.lock().unwrap(), Some(LoggingLevel::Warning));
+}

--- a/crates/mcpkit-core/src/capability.rs
+++ b/crates/mcpkit-core/src/capability.rs
@@ -132,6 +132,12 @@ impl ServerCapabilities {
         self.completions.is_some()
     }
 
+    /// Check if logging is supported.
+    #[must_use]
+    pub const fn has_logging(&self) -> bool {
+        self.logging.is_some()
+    }
+
     /// Check if resource subscriptions are supported.
     #[must_use]
     pub fn has_resource_subscribe(&self) -> bool {

--- a/crates/mcpkit-core/src/types/logging.rs
+++ b/crates/mcpkit-core/src/types/logging.rs
@@ -1,0 +1,125 @@
+//! MCP logging utility types (`logging/setLevel`, `notifications/message`).
+
+use super::meta::Meta;
+use serde::{Deserialize, Serialize};
+
+/// Logging severity, ordered least → most severe (the syslog levels the MCP
+/// spec uses). `Ord` reflects severity, so `level >= min` filters messages.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LoggingLevel {
+    /// Debug-level, most verbose.
+    Debug,
+    /// Informational messages.
+    #[default]
+    Info,
+    /// Normal but significant conditions.
+    Notice,
+    /// Warning conditions.
+    Warning,
+    /// Error conditions.
+    Error,
+    /// Critical conditions.
+    Critical,
+    /// Action must be taken immediately.
+    Alert,
+    /// System is unusable, most severe.
+    Emergency,
+}
+
+impl std::fmt::Display for LoggingLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::Debug => "debug",
+            Self::Info => "info",
+            Self::Notice => "notice",
+            Self::Warning => "warning",
+            Self::Error => "error",
+            Self::Critical => "critical",
+            Self::Alert => "alert",
+            Self::Emergency => "emergency",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Request parameters for `logging/setLevel`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetLevelRequest {
+    /// The minimum severity the client wants to receive.
+    pub level: LoggingLevel,
+}
+
+/// Params for `notifications/message` — a log message emitted by the server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LoggingMessageNotificationParams {
+    /// Severity of this message.
+    pub level: LoggingLevel,
+    /// Optional name of the logger issuing the message.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub logger: Option<String>,
+    /// The log payload (any JSON value — string, object, etc.).
+    pub data: serde_json::Value,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+}
+
+impl LoggingMessageNotificationParams {
+    /// Create log params at `level` with `data` (no logger name).
+    #[must_use]
+    pub const fn new(level: LoggingLevel, data: serde_json::Value) -> Self {
+        Self {
+            level,
+            logger: None,
+            data,
+            meta: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn level_serializes_lowercase_and_orders_by_severity() {
+        assert_eq!(
+            serde_json::to_value(LoggingLevel::Warning).unwrap(),
+            json!("warning")
+        );
+        let back: LoggingLevel = serde_json::from_value(json!("emergency")).unwrap();
+        assert_eq!(back, LoggingLevel::Emergency);
+        assert!(LoggingLevel::Debug < LoggingLevel::Error);
+        assert!(LoggingLevel::Emergency > LoggingLevel::Alert);
+    }
+
+    #[test]
+    fn set_level_request_round_trips() {
+        let wire = serde_json::to_value(SetLevelRequest {
+            level: LoggingLevel::Notice,
+        })
+        .unwrap();
+        assert_eq!(wire, json!({ "level": "notice" }));
+        let back: SetLevelRequest = serde_json::from_value(wire).unwrap();
+        assert_eq!(back.level, LoggingLevel::Notice);
+    }
+
+    #[test]
+    fn message_params_omit_absent_logger_and_meta() {
+        let params = LoggingMessageNotificationParams::new(LoggingLevel::Info, json!("hello"));
+        let wire = serde_json::to_value(&params).unwrap();
+        assert_eq!(wire, json!({ "level": "info", "data": "hello" }));
+
+        let with_logger = LoggingMessageNotificationParams {
+            logger: Some("db".into()),
+            ..LoggingMessageNotificationParams::new(LoggingLevel::Error, json!({ "code": 5 }))
+        };
+        let wire = serde_json::to_value(&with_logger).unwrap();
+        assert_eq!(
+            wire,
+            json!({ "level": "error", "logger": "db", "data": { "code": 5 } })
+        );
+    }
+}

--- a/crates/mcpkit-core/src/types/mod.rs
+++ b/crates/mcpkit-core/src/types/mod.rs
@@ -18,6 +18,7 @@
 pub mod completion;
 pub mod content;
 pub mod elicitation;
+pub mod logging;
 pub mod meta;
 pub mod metadata;
 pub mod notifications;
@@ -31,6 +32,7 @@ pub mod tool;
 pub use completion::*;
 pub use content::*;
 pub use elicitation::*;
+pub use logging::*;
 pub use meta::*;
 pub use metadata::*;
 pub use notifications::*;

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -8,8 +8,8 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_prompts, route_resources,
-    route_tools,
+    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_logging, route_prompts,
+    route_resources, route_tools,
 };
 use rocket::http::{ContentType, Header, Status};
 use rocket::request::{FromRequest, Outcome, Request};
@@ -416,6 +416,22 @@ where
                 params,
                 &ctx,
                 state.list_page_size,
+            )
+            .await
+            {
+                return match result {
+                    Ok(value) => Response::success(request.id.clone(), value),
+                    Err(e) => Response::error(request.id.clone(), e.into()),
+                };
+            }
+
+            // Try routing logging/setLevel (gated on the advertised capability)
+            if let Some(result) = route_logging(
+                state.handler.as_ref(),
+                &state.handler.capabilities(),
+                method,
+                params,
+                &ctx,
             )
             .await
             {

--- a/crates/mcpkit-server/README.md
+++ b/crates/mcpkit-server/README.md
@@ -48,7 +48,7 @@ The server uses composable handler traits:
 | `SamplingHandler` | Handle server-initiated LLM requests |
 | `ElicitationHandler` | Handle structured user input requests |
 | `CompletionHandler` | Handle argument completion requests |
-| `LoggingHandler` | Handle log level changes |
+| `ServerHandler::set_log_level` | Handle `logging/setLevel` (log verbosity) |
 
 ## Context
 

--- a/crates/mcpkit-server/src/context.rs
+++ b/crates/mcpkit-server/src/context.rs
@@ -48,6 +48,7 @@ use mcpkit_core::error::McpError;
 use mcpkit_core::protocol::{Notification, ProgressToken, RequestId, Response};
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_core::types::elicitation::{ElicitRequest, ElicitResult, UrlElicitRequest};
+use mcpkit_core::types::logging::{LoggingLevel, LoggingMessageNotificationParams};
 use mcpkit_core::types::notifications::ProgressNotificationParams;
 use mcpkit_core::types::sampling::{CreateMessageRequest, CreateMessageResult};
 use std::borrow::Cow;
@@ -338,6 +339,26 @@ impl<'a> Context<'a> {
             Some(serde_json::to_value(params)?),
         )
         .await
+    }
+
+    /// Emit a `notifications/message` log to the client at `level`, optionally
+    /// tagged with a `logger` name and carrying arbitrary JSON `data`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the notification could not be sent.
+    pub async fn log(
+        &self,
+        level: LoggingLevel,
+        logger: Option<&str>,
+        data: serde_json::Value,
+    ) -> Result<(), McpError> {
+        let params = LoggingMessageNotificationParams {
+            logger: logger.map(String::from),
+            ..LoggingMessageNotificationParams::new(level, data)
+        };
+        self.notify("notifications/message", Some(serde_json::to_value(params)?))
+            .await
     }
 
     /// Send a request to the client and await its response.

--- a/crates/mcpkit-server/src/handler.rs
+++ b/crates/mcpkit-server/src/handler.rs
@@ -86,6 +86,17 @@ pub trait ServerHandler: Send + Sync {
     fn on_shutdown(&self) -> impl Future<Output = ()> + Send {
         async {}
     }
+
+    /// Handle a `logging/setLevel` request: the client's requested minimum log
+    /// severity. Only reached when the server advertises the `logging`
+    /// capability. The default is a no-op.
+    fn set_log_level(
+        &self,
+        _level: LogLevel,
+        _ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<(), McpError>> + Send {
+        async { Ok(()) }
+    }
 }
 
 /// Handler for tool-related operations.
@@ -252,50 +263,11 @@ pub trait CompletionHandler: Send + Sync {
     ) -> impl Future<Output = Result<Vec<String>, McpError>> + Send;
 }
 
-/// Handler for logging operations.
+/// The MCP logging severity, re-exported from core.
 ///
-/// Implement this trait to handle log messages from the client.
-pub trait LoggingHandler: Send + Sync {
-    /// Set the current logging level.
-    fn set_level(&self, level: LogLevel) -> impl Future<Output = Result<(), McpError>> + Send;
-}
-
-/// Log levels for MCP logging.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub enum LogLevel {
-    /// Debug level - most verbose.
-    Debug,
-    /// Info level.
-    #[default]
-    Info,
-    /// Notice level.
-    Notice,
-    /// Warning level.
-    Warning,
-    /// Error level.
-    Error,
-    /// Critical level.
-    Critical,
-    /// Alert level.
-    Alert,
-    /// Emergency level - most severe.
-    Emergency,
-}
-
-impl std::fmt::Display for LogLevel {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::Debug => write!(f, "debug"),
-            Self::Info => write!(f, "info"),
-            Self::Notice => write!(f, "notice"),
-            Self::Warning => write!(f, "warning"),
-            Self::Error => write!(f, "error"),
-            Self::Critical => write!(f, "critical"),
-            Self::Alert => write!(f, "alert"),
-            Self::Emergency => write!(f, "emergency"),
-        }
-    }
-}
+/// Inbound `logging/setLevel` is handled by [`ServerHandler::set_log_level`];
+/// outbound `notifications/message` is emitted via the server's `log` helpers.
+pub use mcpkit_core::types::LoggingLevel as LogLevel;
 
 // =============================================================================
 // Blanket implementations for Arc<T>
@@ -451,12 +423,6 @@ impl<T: CompletionHandler> CompletionHandler for Arc<T> {
         ctx: &Context<'_>,
     ) -> impl Future<Output = Result<Vec<String>, McpError>> + Send {
         (**self).complete_prompt_arg(prompt_name, arg_name, partial_value, ctx)
-    }
-}
-
-impl<T: LoggingHandler> LoggingHandler for Arc<T> {
-    fn set_level(&self, level: LogLevel) -> impl Future<Output = Result<(), McpError>> + Send {
-        (**self).set_level(level)
     }
 }
 

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -74,8 +74,8 @@ pub mod validation;
 pub use builder::{FullServer, MinimalServer, NotRegistered, Registered, Server, ServerBuilder};
 pub use context::{CancellationToken, CancelledFuture, Context, ContextData, NoOpPeer, Peer};
 pub use handler::{
-    CompletionHandler, LogLevel, LoggingHandler, PromptHandler, ResourceHandler, ServerHandler,
-    TaskHandler, ToolHandler,
+    CompletionHandler, LogLevel, PromptHandler, ResourceHandler, ServerHandler, TaskHandler,
+    ToolHandler,
 };
 pub use health::{
     ComponentHealth, HealthChecker, HealthReport, HealthStatus, LivenessResponse, ReadinessResponse,
@@ -97,8 +97,8 @@ pub mod prelude {
         CancellationToken, CancelledFuture, Context, ContextData, NoOpPeer, Peer,
     };
     pub use crate::handler::{
-        CompletionHandler, LogLevel, LoggingHandler, PromptHandler, ResourceHandler, ServerHandler,
-        TaskHandler, ToolHandler,
+        CompletionHandler, LogLevel, PromptHandler, ResourceHandler, ServerHandler, TaskHandler,
+        ToolHandler,
     };
     pub use crate::metrics::{MethodStats, MetricsSnapshot, ServerMetrics};
 }

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -81,7 +81,7 @@ pub use health::{
     ComponentHealth, HealthChecker, HealthReport, HealthStatus, LivenessResponse, ReadinessResponse,
 };
 pub use metrics::{MethodStats, MetricsSnapshot, ServerMetrics};
-pub use router::{route_prompts, route_resources, route_tools};
+pub use router::{route_logging, route_prompts, route_resources, route_tools};
 pub use server::{
     RequestRouter, RuntimeConfig, ServerNotifier, ServerRuntime, ServerState, TransportPeer,
 };

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -872,6 +872,35 @@ pub async fn route_tasks(
     }
 }
 
+/// Route `logging/setLevel` to the base handler's
+/// [`set_log_level`](crate::handler::ServerHandler::set_log_level), but only when
+/// the server advertises the `logging` capability.
+///
+/// Returns `None` for any other method (or when logging is not advertised) so the
+/// caller falls through to its normal not-found handling. Shared by the runtime
+/// router and the HTTP adapters so `logging/setLevel` behaves the same on every
+/// surface.
+pub async fn route_logging<H: crate::handler::ServerHandler>(
+    handler: &H,
+    server_caps: &mcpkit_core::capability::ServerCapabilities,
+    method: &str,
+    params: Option<&serde_json::Value>,
+    ctx: &Context<'_>,
+) -> Option<Result<serde_json::Value, McpError>> {
+    if method != methods::LOGGING_SET_LEVEL || !server_caps.has_logging() {
+        return None;
+    }
+    let result = async {
+        let params = params.ok_or_else(|| McpError::invalid_params(method, "missing params"))?;
+        let req: mcpkit_core::types::SetLevelRequest = serde_json::from_value(params.clone())
+            .map_err(|_| McpError::invalid_params(method, "invalid or missing level"))?;
+        handler.set_log_level(req.level, ctx).await?;
+        Ok(serde_json::json!({}))
+    }
+    .await;
+    Some(result)
+}
+
 /// Extract a required `taskId` parameter.
 fn parse_task_id(
     params: Option<&serde_json::Value>,

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -1229,19 +1229,13 @@ where
                 return result;
             }
         }
-        // `logging/setLevel` is handled by the base handler, but only when the
-        // `logging` capability is advertised (otherwise it is not a method we
-        // honor).
-        if method == crate::router::methods::LOGGING_SET_LEVEL
-            && self.capabilities().logging.is_some()
+        // `logging/setLevel` is handled by the base handler when the `logging`
+        // capability is advertised (shared with the HTTP adapters).
+        if let Some(result) =
+            crate::router::route_logging(self.handler(), self.capabilities(), method, params, ctx)
+                .await
         {
-            let params =
-                params.ok_or_else(|| McpError::invalid_params(method, "missing params"))?;
-            let req: mcpkit_core::types::SetLevelRequest =
-                serde_json::from_value(params.clone())
-                    .map_err(|_| McpError::invalid_params(method, "invalid or missing level"))?;
-            self.handler().set_log_level(req.level, ctx).await?;
-            return Ok(serde_json::json!({}));
+            return result;
         }
         Err(McpError::method_not_found(method))
     }

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -363,6 +363,29 @@ impl ServerNotifier {
         self.peer.notify(notification).await
     }
 
+    /// Emit a `notifications/message` log to the client at `level`, optionally
+    /// tagged with a `logger` name and carrying arbitrary JSON `data`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the notification could not be sent.
+    pub async fn log(
+        &self,
+        level: mcpkit_core::types::LoggingLevel,
+        logger: Option<&str>,
+        data: serde_json::Value,
+    ) -> Result<(), McpError> {
+        let params = mcpkit_core::types::LoggingMessageNotificationParams {
+            logger: logger.map(String::from),
+            ..mcpkit_core::types::LoggingMessageNotificationParams::new(level, data)
+        };
+        self.notify(
+            crate::router::notifications::MESSAGE,
+            Some(serde_json::to_value(params)?),
+        )
+        .await
+    }
+
     /// Notify the client that the available tool list has changed.
     ///
     /// # Errors
@@ -1205,6 +1228,20 @@ where
             if let Some(result) = route_tasks(handler, method, params, ctx).await {
                 return result;
             }
+        }
+        // `logging/setLevel` is handled by the base handler, but only when the
+        // `logging` capability is advertised (otherwise it is not a method we
+        // honor).
+        if method == crate::router::methods::LOGGING_SET_LEVEL
+            && self.capabilities().logging.is_some()
+        {
+            let params =
+                params.ok_or_else(|| McpError::invalid_params(method, "missing params"))?;
+            let req: mcpkit_core::types::SetLevelRequest =
+                serde_json::from_value(params.clone())
+                    .map_err(|_| McpError::invalid_params(method, "invalid or missing level"))?;
+            self.handler().set_log_level(req.level, ctx).await?;
+            return Ok(serde_json::json!({}));
         }
         Err(McpError::method_not_found(method))
     }
@@ -2345,5 +2382,134 @@ mod tests {
 
         drop(client);
         let _ = timeout(Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn logging_set_level_dispatches_when_advertised_else_method_not_found() {
+        use crate::builder::ServerBuilder;
+        use crate::context::NoOpPeer;
+        use crate::handler::ServerHandler;
+        use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+        use mcpkit_core::protocol::RequestId;
+        use mcpkit_core::protocol_version::ProtocolVersion;
+        use mcpkit_core::types::LoggingLevel;
+        use std::sync::Mutex;
+
+        struct H(Arc<Mutex<Option<LoggingLevel>>>);
+        impl ServerHandler for H {
+            fn server_info(&self) -> ServerInfo {
+                ServerInfo::new("t", "1.0.0")
+            }
+            async fn set_log_level(
+                &self,
+                level: LoggingLevel,
+                _ctx: &Context<'_>,
+            ) -> Result<(), McpError> {
+                *self.0.lock().unwrap() = Some(level);
+                Ok(())
+            }
+        }
+
+        let request_id = RequestId::Number(1);
+        let client_caps = ClientCapabilities::default();
+        let server_caps = ServerCapabilities::default();
+        let peer = NoOpPeer;
+        let ctx = Context::new(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            ProtocolVersion::LATEST,
+            &peer,
+        );
+
+        // Advertised -> dispatched to the base handler, empty result.
+        let seen = Arc::new(Mutex::new(None));
+        let server = ServerBuilder::new(H(Arc::clone(&seen)))
+            .capabilities(ServerCapabilities::new().with_logging())
+            .build();
+        let out = server
+            .route(
+                "logging/setLevel",
+                Some(&serde_json::json!({ "level": "warning" })),
+                &ctx,
+            )
+            .await
+            .expect("setLevel dispatched");
+        assert_eq!(out, serde_json::json!({}));
+        assert_eq!(*seen.lock().unwrap(), Some(LoggingLevel::Warning));
+
+        // Invalid level -> invalid params.
+        assert!(
+            server
+                .route(
+                    "logging/setLevel",
+                    Some(&serde_json::json!({ "level": "loud" })),
+                    &ctx,
+                )
+                .await
+                .is_err()
+        );
+
+        // Not advertised -> method not found.
+        let plain = ServerBuilder::new(H(Arc::new(Mutex::new(None)))).build();
+        let err = plain
+            .route(
+                "logging/setLevel",
+                Some(&serde_json::json!({ "level": "info" })),
+                &ctx,
+            )
+            .await
+            .expect_err("no logging capability -> method not found");
+        assert!(matches!(err, McpError::MethodNotFound { .. }));
+    }
+
+    #[tokio::test]
+    async fn context_log_emits_message_notification() {
+        use crate::context::Peer;
+        use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+        use mcpkit_core::protocol::RequestId;
+        use mcpkit_core::protocol_version::ProtocolVersion;
+        use mcpkit_core::types::LoggingLevel;
+        use std::pin::Pin;
+        use std::sync::Mutex;
+
+        struct RecPeer(Arc<Mutex<Vec<Notification>>>);
+        impl Peer for RecPeer {
+            fn notify(
+                &self,
+                notification: Notification,
+            ) -> Pin<Box<dyn std::future::Future<Output = Result<(), McpError>> + Send + '_>>
+            {
+                self.0.lock().unwrap().push(notification);
+                Box::pin(async { Ok(()) })
+            }
+        }
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let peer = RecPeer(Arc::clone(&seen));
+        let request_id = RequestId::Number(1);
+        let client_caps = ClientCapabilities::default();
+        let server_caps = ServerCapabilities::default();
+        let ctx = Context::new(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            ProtocolVersion::LATEST,
+            &peer,
+        );
+
+        ctx.log(LoggingLevel::Error, Some("db"), serde_json::json!("boom"))
+            .await
+            .expect("log sent");
+
+        let seen = seen.lock().unwrap();
+        assert_eq!(seen.len(), 1);
+        assert_eq!(seen[0].method.as_ref(), "notifications/message");
+        let params = seen[0].params.as_ref().expect("params");
+        assert_eq!(params["level"], serde_json::json!("error"));
+        assert_eq!(params["logger"], serde_json::json!("db"));
+        assert_eq!(params["data"], serde_json::json!("boom"));
     }
 }

--- a/crates/mcpkit-server/src/validation.rs
+++ b/crates/mcpkit-server/src/validation.rs
@@ -229,6 +229,14 @@ impl<H: ServerHandler> ServerHandler for ValidatingToolHandler<H> {
     fn on_shutdown(&self) -> impl Future<Output = ()> + Send {
         self.inner.on_shutdown()
     }
+
+    fn set_log_level(
+        &self,
+        level: crate::handler::LogLevel,
+        ctx: &Context<'_>,
+    ) -> impl Future<Output = Result<(), McpError>> + Send {
+        self.inner.set_log_level(level, ctx)
+    }
 }
 
 impl<H: ResourceHandler> ResourceHandler for ValidatingToolHandler<H> {

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -9,8 +9,8 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_prompts, route_resources,
-    route_tools,
+    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_logging, route_prompts,
+    route_resources, route_tools,
 };
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -299,6 +299,22 @@ where
                 params,
                 &ctx,
                 state.list_page_size,
+            )
+            .await
+            {
+                return match result {
+                    Ok(value) => Response::success(request.id.clone(), value),
+                    Err(e) => Response::error(request.id.clone(), e.into()),
+                };
+            }
+
+            // Try routing logging/setLevel (gated on the advertised capability)
+            if let Some(result) = route_logging(
+                state.handler.as_ref(),
+                &state.handler.capabilities(),
+                method,
+                params,
+                &ctx,
             )
             .await
             {

--- a/mcpkit/src/lib.rs
+++ b/mcpkit/src/lib.rs
@@ -85,8 +85,8 @@ pub mod error {
 // Re-export server types
 pub use mcpkit_server::{
     CancellationToken, CancelledFuture, CompletionHandler, Context, ContextData, LogLevel,
-    LoggingHandler, NoOpPeer, Peer, PromptHandler, ResourceHandler, Server, ServerBuilder,
-    ServerHandler, TaskHandler, ToolHandler,
+    NoOpPeer, Peer, PromptHandler, ResourceHandler, Server, ServerBuilder, ServerHandler,
+    TaskHandler, ToolHandler,
 };
 
 // Re-export transport types

--- a/mcpkit/src/prelude.rs
+++ b/mcpkit/src/prelude.rs
@@ -47,8 +47,8 @@ pub use mcpkit_core::prelude::*;
 
 // Server types
 pub use mcpkit_server::{
-    CompletionHandler, Context, ContextData, LogLevel, LoggingHandler, PromptHandler,
-    ResourceHandler, Server, ServerBuilder, ServerHandler, TaskHandler, ToolHandler,
+    CompletionHandler, Context, ContextData, LogLevel, PromptHandler, ResourceHandler, Server,
+    ServerBuilder, ServerHandler, TaskHandler, ToolHandler,
 };
 
 // Transport types


### PR DESCRIPTION
Fourth spec-fidelity PR — another advertised-but-non-functional capability, made real. Design **C** (per two review passes): fold inbound `setLevel` into the base `ServerHandler` rather than a 6th typestate slot.

## The gap
`logging` was advertised, and a `LoggingHandler` + `LogLevel` existed, but they were **completely disconnected**: no dispatch slot, no builder registration, `logging/setLevel` parsed only in the test-only path → **method-not-found**, and no way to emit `notifications/message`. None of the core wire types existed.

## Added
- Core `LoggingLevel` (8 syslog levels, `Ord` by severity, lowercase serde), `SetLevelRequest { level }`, `LoggingMessageNotificationParams { level, logger?, data, _meta? }`.
- **Inbound:** `ServerHandler::set_log_level(&self, level, ctx)` (default no-op). `route()` dispatches `logging/setLevel` to it **only when the `logging` capability is advertised** (else method-not-found — we don't honor an unadvertised method); invalid level → invalid params; success → empty result.
- **Outbound:** `ServerNotifier::log(level, logger, data)` (the existing out-of-request handle) + `Context::log(..)` convenience (matching `Context::progress`/`elicit`), both serializing the typed params.

## Breaking
- The orphaned `LoggingHandler` trait is removed; its `set_level` is now `ServerHandler::set_log_level`.
- `mcpkit_server::LogLevel` is now a **re-export** of the core `LoggingLevel` (name preserved; type unified).

## Not here
Completion is a separate not-runtime-wired capability (it has core types + a `CompletionService`, so it's less orphaned) — tracked separately (overlaps #113).

## Tests
Core round-trips (level lowercase + ordering, `SetLevelRequest`, message-params omission); `route()` dispatch — advertised → `{}` + handler saw the level, invalid level → invalid params, **not advertised → method-not-found**; and `Context::log` emits a `notifications/message` with the right `level`/`logger`/`data`.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --locked` all green.