### PR TITLE
feat(core)!: tool-augmented sampling content + request surface (#110 phase A)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Tool-augmented sampling — content + request surface (#110, phase A). New core
+  `ToolUseContent`/`ToolResultContent` content blocks, a `SamplingContent` union
+  (Text/Image/Audio/ToolUse/ToolResult — the spec's `SamplingMessageContentBlock`,
+  kept separate from the general `Content`/`ContentBlock`), an `OneOrMany<T>`
+  helper, and `ToolChoice`. `SamplingMessage.content` and
+  `CreateMessageResult.content` become `OneOrMany<SamplingContent>` (a message can
+  now carry a text block plus tool_use, and results can carry parallel tool
+  calls); `SamplingMessage` gains `_meta`. `CreateMessageRequest` gains `tools`,
+  `toolChoice`, and `_meta`. `SamplingCapability` gains `context`/`tools`
+  sub-capabilities with `with_sampling_tools()`/`has_sampling_tools()` (and the
+  `context` equivalents). **Fixed:** `StopReason` was a closed lowercase enum
+  (`end_turn`), but the spec is an *open* camelCase string — it's now
+  `endTurn`/`stopSequence`/`maxTokens`/`toolUse` plus an `Other(String)` passthrough.
+  **Breaking:** the sampling content type changes and `StopReason` representation.
+  Task-augmented sampling (the `task` request field + its alternate
+  `CreateTaskResult` response path) is deferred to
+  [#143](https://github.com/praxiomlabs/mcpkit/issues/143)
+  ([#110](https://github.com/praxiomlabs/mcpkit/issues/110)).
 - Roots as first-class protocol types (#111). `Root` moves into `mcpkit-core`
   with serde derives (`name` omitted when absent, fixing the previous `name: null`
   on the wire) and is re-exported from `mcpkit_client::handler` for compatibility.

--- a/crates/mcpkit-client/src/handler.rs
+++ b/crates/mcpkit-client/src/handler.rs
@@ -246,6 +246,9 @@ mod tests {
                 max_tokens: 100,
                 stop_sequences: None,
                 metadata: None,
+                tools: None,
+                tool_choice: None,
+                meta: None,
             })
             .await;
         assert!(result.is_err());

--- a/crates/mcpkit-core/src/capability.rs
+++ b/crates/mcpkit-core/src/capability.rs
@@ -244,8 +244,29 @@ impl ClientCapabilities {
 
     /// Enable sampling support.
     #[must_use]
-    pub const fn with_sampling(mut self) -> Self {
-        self.sampling = Some(SamplingCapability {});
+    pub fn with_sampling(mut self) -> Self {
+        self.sampling = Some(SamplingCapability::default());
+        self
+    }
+
+    /// Enable sampling with tool-use support (declares `sampling.tools`).
+    #[must_use]
+    pub fn with_sampling_tools(mut self) -> Self {
+        let sampling = self
+            .sampling
+            .get_or_insert_with(SamplingCapability::default);
+        sampling.tools = Some(serde_json::json!({}));
+        self
+    }
+
+    /// Enable sampling with context-inclusion support (declares
+    /// `sampling.context`).
+    #[must_use]
+    pub fn with_sampling_context(mut self) -> Self {
+        let sampling = self
+            .sampling
+            .get_or_insert_with(SamplingCapability::default);
+        sampling.context = Some(serde_json::json!({}));
         self
     }
 
@@ -310,6 +331,20 @@ impl ClientCapabilities {
     #[must_use]
     pub const fn has_sampling(&self) -> bool {
         self.sampling.is_some()
+    }
+
+    /// Whether the client declared tool-use support in sampling
+    /// (`sampling.tools`).
+    #[must_use]
+    pub const fn has_sampling_tools(&self) -> bool {
+        matches!(&self.sampling, Some(s) if s.tools.is_some())
+    }
+
+    /// Whether the client declared context-inclusion support in sampling
+    /// (`sampling.context`).
+    #[must_use]
+    pub const fn has_sampling_context(&self) -> bool {
+        matches!(&self.sampling, Some(s) if s.context.is_some())
     }
 
     /// Check if elicitation is supported.
@@ -400,7 +435,14 @@ pub struct RootsCapability {
 
 /// Sampling capability flags.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct SamplingCapability {}
+pub struct SamplingCapability {
+    /// Declared support for context inclusion (the `includeContext` parameter).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<serde_json::Value>,
+    /// Declared support for tool use in sampling requests.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<serde_json::Value>,
+}
 
 /// Elicitation capability flags.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/crates/mcpkit-core/src/types/content.rs
+++ b/crates/mcpkit-core/src/types/content.rs
@@ -198,6 +198,45 @@ pub struct ResourceLinkContent {
     pub annotations: Option<ContentAnnotations>,
 }
 
+/// A tool call the model wants to make, in a sampling message
+/// (`type: "tool_use"`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolUseContent {
+    /// Unique id correlating this call with its later `tool_result`.
+    pub id: String,
+    /// The name of the tool to call.
+    pub name: String,
+    /// The tool arguments.
+    pub input: serde_json::Value,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<super::meta::Meta>,
+}
+
+/// The result of a tool call, fed back into a sampling message
+/// (`type: "tool_result"`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolResultContent {
+    /// The id of the `tool_use` this result corresponds to.
+    #[serde(rename = "toolUseId")]
+    pub tool_use_id: String,
+    /// The unstructured result content (normal content blocks).
+    pub content: Vec<Content>,
+    /// Optional structured result.
+    #[serde(
+        rename = "structuredContent",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub structured_content: Option<serde_json::Value>,
+    /// Whether the tool call ended in an error.
+    #[serde(rename = "isError", skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<super::meta::Meta>,
+}
+
 /// Annotations that can be attached to content.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct ContentAnnotations {

--- a/crates/mcpkit-core/src/types/sampling.rs
+++ b/crates/mcpkit-core/src/types/sampling.rs
@@ -4,17 +4,88 @@
 //! This enables agentic workflows where servers can leverage
 //! the client's AI capabilities.
 
-use super::content::{Content, Role};
+use super::content::{
+    AudioContent, ImageContent, Role, TextContent, ToolResultContent, ToolUseContent,
+};
 use super::meta::Meta;
+use super::tool::Tool;
 use serde::{Deserialize, Serialize};
+
+/// A value that may be a single item or an array of items, matching the spec's
+/// `T | T[]` unions (e.g. sampling message content).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum OneOrMany<T> {
+    /// A single item.
+    One(T),
+    /// An array of items.
+    Many(Vec<T>),
+}
+
+/// A content block allowed in a sampling message (the spec's
+/// `SamplingMessageContentBlock`): text/image/audio, plus tool-use loop blocks.
+///
+/// Note this is *not* the general [`Content`](super::content::Content)
+/// (`ContentBlock`) — sampling excludes resource links/embeds and adds
+/// `tool_use`/`tool_result`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "lowercase")]
+pub enum SamplingContent {
+    /// Plain text.
+    Text(TextContent),
+    /// Image content.
+    Image(ImageContent),
+    /// Audio content.
+    Audio(AudioContent),
+    /// A tool call the model wants to make.
+    #[serde(rename = "tool_use")]
+    ToolUse(ToolUseContent),
+    /// The result of a tool call, fed back to the model.
+    #[serde(rename = "tool_result")]
+    ToolResult(ToolResultContent),
+}
+
+impl SamplingContent {
+    /// Create a text content block.
+    #[must_use]
+    pub fn text(text: impl Into<String>) -> Self {
+        Self::Text(TextContent {
+            text: text.into(),
+            annotations: None,
+        })
+    }
+}
+
+/// How the model may use tools during sampling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolChoiceMode {
+    /// The model decides whether to use tools.
+    Auto,
+    /// The model must use at least one tool.
+    Required,
+    /// The model must not use tools.
+    None,
+}
+
+/// Controls tool selection for a sampling request.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ToolChoice {
+    /// The tool-use mode; absent means the model decides.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mode: Option<ToolChoiceMode>,
+}
 
 /// A message in a sampling conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SamplingMessage {
     /// The role of the message sender.
     pub role: Role,
-    /// The message content.
-    pub content: Content,
+    /// The message content (one block or an array of blocks).
+    pub content: OneOrMany<SamplingContent>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl SamplingMessage {
@@ -23,7 +94,8 @@ impl SamplingMessage {
     pub fn user(text: impl Into<String>) -> Self {
         Self {
             role: Role::User,
-            content: Content::text(text),
+            content: OneOrMany::One(SamplingContent::text(text)),
+            meta: None,
         }
     }
 
@@ -32,14 +104,19 @@ impl SamplingMessage {
     pub fn assistant(text: impl Into<String>) -> Self {
         Self {
             role: Role::Assistant,
-            content: Content::text(text),
+            content: OneOrMany::One(SamplingContent::text(text)),
+            meta: None,
         }
     }
 
     /// Create a message with custom content.
     #[must_use]
-    pub const fn with_content(role: Role, content: Content) -> Self {
-        Self { role, content }
+    pub const fn with_content(role: Role, content: OneOrMany<SamplingContent>) -> Self {
+        Self {
+            role,
+            content,
+            meta: None,
+        }
     }
 }
 
@@ -143,6 +220,15 @@ pub struct CreateMessageRequest {
     /// Additional metadata.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+    /// Tools the model may call during sampling (2025-11-25).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<Tool>>,
+    /// Controls whether/how the model may call `tools`.
+    #[serde(rename = "toolChoice", skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<ToolChoice>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl CreateMessageRequest {
@@ -158,6 +244,9 @@ impl CreateMessageRequest {
             temperature: None,
             stop_sequences: None,
             metadata: None,
+            tools: None,
+            tool_choice: None,
+            meta: None,
         }
     }
 
@@ -224,8 +313,8 @@ pub enum IncludeContext {
 pub struct CreateMessageResult {
     /// The role of the response (always assistant).
     pub role: Role,
-    /// The generated content.
-    pub content: Content,
+    /// The generated content (one block or an array — e.g. parallel tool calls).
+    pub content: OneOrMany<SamplingContent>,
     /// The model used.
     pub model: String,
     /// Stop reason.
@@ -237,16 +326,23 @@ pub struct CreateMessageResult {
 }
 
 impl CreateMessageResult {
-    /// Get the text content if this is a text response.
+    /// Get the text if this is a single text-content response.
     #[must_use]
     pub fn as_text(&self) -> Option<&str> {
-        self.content.as_text()
+        match &self.content {
+            OneOrMany::One(SamplingContent::Text(t)) => Some(&t.text),
+            _ => None,
+        }
     }
 }
 
 /// Reason why sampling stopped.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+///
+/// An **open** string in the spec: the known values are `endTurn`,
+/// `stopSequence`, `maxTokens`, and `toolUse`, but implementations may report
+/// others (preserved as [`Other`](StopReason::Other)).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "String", into = "String")]
 pub enum StopReason {
     /// Hit the end of the response.
     EndTurn,
@@ -254,21 +350,57 @@ pub enum StopReason {
     StopSequence,
     /// Hit the max token limit.
     MaxTokens,
+    /// The model stopped to call a tool.
+    ToolUse,
+    /// An implementation-specific stop reason.
+    Other(String),
+}
+
+impl StopReason {
+    /// The wire string for this stop reason.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::EndTurn => "endTurn",
+            Self::StopSequence => "stopSequence",
+            Self::MaxTokens => "maxTokens",
+            Self::ToolUse => "toolUse",
+            Self::Other(s) => s,
+        }
+    }
+}
+
+impl From<String> for StopReason {
+    fn from(s: String) -> Self {
+        match s.as_str() {
+            "endTurn" => Self::EndTurn,
+            "stopSequence" => Self::StopSequence,
+            "maxTokens" => Self::MaxTokens,
+            "toolUse" => Self::ToolUse,
+            _ => Self::Other(s),
+        }
+    }
+}
+
+impl From<StopReason> for String {
+    fn from(reason: StopReason) -> Self {
+        match reason {
+            StopReason::Other(s) => s,
+            other => other.as_str().to_string(),
+        }
+    }
 }
 
 impl std::fmt::Display for StopReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::EndTurn => write!(f, "end_turn"),
-            Self::StopSequence => write!(f, "stop_sequence"),
-            Self::MaxTokens => write!(f, "max_tokens"),
-        }
+        f.write_str(self.as_str())
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::Content;
 
     #[test]
     fn test_sampling_message() {
@@ -315,5 +447,102 @@ mod tests {
         let json = serde_json::to_string(&request)?;
         assert!(json.contains("\"maxTokens\":100"));
         Ok(())
+    }
+
+    #[test]
+    fn stop_reason_uses_camelcase_and_preserves_unknown() {
+        use serde_json::json;
+        assert_eq!(
+            serde_json::to_value(StopReason::EndTurn).unwrap(),
+            json!("endTurn")
+        );
+        assert_eq!(
+            serde_json::to_value(StopReason::ToolUse).unwrap(),
+            json!("toolUse")
+        );
+        // Unknown values round-trip through `Other`.
+        let parsed: StopReason = serde_json::from_value(json!("guardrail")).unwrap();
+        assert_eq!(parsed, StopReason::Other("guardrail".into()));
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), json!("guardrail"));
+        assert_eq!(
+            serde_json::from_value::<StopReason>(json!("maxTokens")).unwrap(),
+            StopReason::MaxTokens
+        );
+    }
+
+    #[test]
+    fn sampling_content_tool_blocks_round_trip() {
+        use serde_json::json;
+
+        let tool_use = SamplingContent::ToolUse(ToolUseContent {
+            id: "call-1".into(),
+            name: "search".into(),
+            input: json!({ "q": "rust" }),
+            meta: None,
+        });
+        assert_eq!(
+            serde_json::to_value(&tool_use).unwrap(),
+            json!({ "type": "tool_use", "id": "call-1", "name": "search", "input": { "q": "rust" } })
+        );
+
+        let tool_result = SamplingContent::ToolResult(ToolResultContent {
+            tool_use_id: "call-1".into(),
+            content: vec![Content::text("42")],
+            structured_content: None,
+            is_error: None,
+            meta: None,
+        });
+        let wire = serde_json::to_value(&tool_result).unwrap();
+        assert_eq!(wire["type"], json!("tool_result"));
+        assert_eq!(wire["toolUseId"], json!("call-1"));
+        // Round-trips back to the same variant.
+        let back: SamplingContent = serde_json::from_value(wire).unwrap();
+        assert!(matches!(back, SamplingContent::ToolResult(_)));
+    }
+
+    #[test]
+    fn one_or_many_serializes_single_and_array() {
+        use serde_json::json;
+        // Single block -> object; array -> array.
+        let one = SamplingMessage::user("hi");
+        assert_eq!(
+            serde_json::to_value(&one.content).unwrap(),
+            json!({ "type": "text", "text": "hi" })
+        );
+        let many: OneOrMany<SamplingContent> =
+            OneOrMany::Many(vec![SamplingContent::text("a"), SamplingContent::text("b")]);
+        assert!(serde_json::to_value(&many).unwrap().is_array());
+        // Both forms parse back.
+        assert!(matches!(
+            serde_json::from_value::<OneOrMany<SamplingContent>>(
+                json!({ "type": "text", "text": "x" })
+            )
+            .unwrap(),
+            OneOrMany::One(_)
+        ));
+        assert!(matches!(
+            serde_json::from_value::<OneOrMany<SamplingContent>>(
+                json!([{ "type": "text", "text": "x" }])
+            )
+            .unwrap(),
+            OneOrMany::Many(_)
+        ));
+    }
+
+    #[test]
+    fn request_carries_tools_and_tool_choice() {
+        let request = CreateMessageRequest {
+            tools: Some(vec![]),
+            tool_choice: Some(ToolChoice {
+                mode: Some(ToolChoiceMode::Required),
+            }),
+            ..CreateMessageRequest::simple("hi", 10)
+        };
+        let wire = serde_json::to_value(&request).unwrap();
+        assert!(wire.get("tools").is_some());
+        assert_eq!(
+            wire["toolChoice"],
+            serde_json::json!({ "mode": "required" })
+        );
     }
 }

--- a/crates/mcpkit-macros-tests/tests/expand/client_full.rs
+++ b/crates/mcpkit-macros-tests/tests/expand/client_full.rs
@@ -3,7 +3,7 @@
 use mcpkit::mcp_client;
 use mcpkit::types::{
     CreateMessageRequest, CreateMessageResult, ElicitRequest, ElicitResult,
-    Role, TaskId, TaskProgress, Content, StopReason,
+    Role, TaskId, TaskProgress, OneOrMany, SamplingContent, StopReason,
 };
 use mcpkit::client::handler::Root;
 use mcpkit::error::McpError;
@@ -22,7 +22,7 @@ impl FullHandler {
         Ok(CreateMessageResult {
             model: "gpt-4".to_string(),
             role: Role::Assistant,
-            content: Content::text("Response"),
+            content: OneOrMany::One(SamplingContent::text("Response")),
             stop_reason: Some(StopReason::EndTurn),
             meta: None,
         })

--- a/crates/mcpkit-macros-tests/tests/expand/client_sampling.rs
+++ b/crates/mcpkit-macros-tests/tests/expand/client_sampling.rs
@@ -1,7 +1,7 @@
 //! Test: Client with sampling handler expands correctly
 
 use mcpkit::mcp_client;
-use mcpkit::types::{CreateMessageRequest, CreateMessageResult, Role, Content, StopReason};
+use mcpkit::types::{CreateMessageRequest, CreateMessageResult, OneOrMany, Role, SamplingContent, StopReason};
 use mcpkit::error::McpError;
 
 struct SamplingHandler;
@@ -13,7 +13,7 @@ impl SamplingHandler {
         Ok(CreateMessageResult {
             model: "test-model".to_string(),
             role: Role::Assistant,
-            content: Content::text("Hello!"),
+            content: OneOrMany::One(SamplingContent::text("Hello!")),
             stop_reason: Some(StopReason::EndTurn),
             meta: None,
         })

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -574,7 +574,9 @@ where
         // are released so we can push new background work.
         enum Step {
             Message(Option<Message>),
-            Progress(Option<BackgroundExec>),
+            // Boxed: `BackgroundExec` is large (it owns a `ContextData`), so an
+            // unboxed variant makes `Step` lopsided (`clippy::large_enum_variant`).
+            Progress(Option<Box<BackgroundExec>>),
         }
 
         let max = self.config.max_concurrent_requests.max(1);
@@ -611,14 +613,14 @@ where
                 match select(recv, progress).await {
                     Either::Left((Ok(opt), _)) => Step::Message(opt),
                     Either::Left((Err(e), _)) => break Err(e.into()),
-                    Either::Right((maybe_exec, _)) => Step::Progress(maybe_exec),
+                    Either::Right((maybe_exec, _)) => Step::Progress(maybe_exec.map(Box::new)),
                 }
             };
 
             // Borrows on the future sets are released here, so we may push work.
             match step {
                 Step::Progress(Some(exec)) => {
-                    background.push(self.run_task(exec));
+                    background.push(self.run_task(*exec));
                 }
                 Step::Progress(None) => {}
                 Step::Message(Some(Message::Request(request))) => {
@@ -1314,7 +1316,7 @@ mod tests {
 
     use mcpkit_core::capability::{ClientCapabilities, ServerInfo};
     use mcpkit_core::protocol::RequestId;
-    use mcpkit_core::types::content::{Content, Role};
+    use mcpkit_core::types::content::Role;
     use mcpkit_core::types::elicitation::ElicitRequest;
     use mcpkit_core::types::sampling::{CreateMessageRequest, CreateMessageResult};
     use mcpkit_transport::MemoryTransport;
@@ -1965,7 +1967,9 @@ mod tests {
         // Reply as the client with a generated message.
         let result = CreateMessageResult {
             role: Role::Assistant,
-            content: Content::text("a summary"),
+            content: mcpkit_core::types::OneOrMany::One(mcpkit_core::types::SamplingContent::text(
+                "a summary",
+            )),
             model: "test-model".to_string(),
             stop_reason: None,
             meta: None,

--- a/mcpkit/tests/capability_negotiation_compatibility.rs
+++ b/mcpkit/tests/capability_negotiation_compatibility.rs
@@ -562,7 +562,7 @@ fn test_completion_capability_serialization() -> Result<(), Box<dyn std::error::
 
 #[test]
 fn test_sampling_capability_serialization() -> Result<(), Box<dyn std::error::Error>> {
-    let cap = SamplingCapability {};
+    let cap = SamplingCapability::default();
 
     let json_str = serde_json::to_string(&cap)?;
 
@@ -931,7 +931,7 @@ fn test_empty_capability_structs_serialize_to_empty_object()
     // Per MCP spec, empty capability objects should be {}
     assert_eq!(serde_json::to_string(&LoggingCapability {})?, "{}");
     assert_eq!(serde_json::to_string(&CompletionCapability {})?, "{}");
-    assert_eq!(serde_json::to_string(&SamplingCapability {})?, "{}");
+    assert_eq!(serde_json::to_string(&SamplingCapability::default())?, "{}");
     assert_eq!(
         serde_json::to_string(&ElicitationCapability::default())?,
         "{}"


### PR DESCRIPTION
Final audit-queue issue, and the biggest. **Phase A** = the tool-use content + request surface; **Phase B** (task-augmented sampling) is deferred to #143. Design settled across three review passes (which corrected my initial call — see below).

## Verified against schema.ts (2025-11-25)
- `SamplingMessage.content` **and** `CreateMessageResult.content` are both `SamplingMessageContentBlock | SamplingMessageContentBlock[]` (that union = Text/Image/Audio/ToolUse/ToolResult — **not** resource links). Because *both* must change type, the separate `SamplingContent` union (spec-pure) has no extra breaking cost over polluting the shared `Content`.
- `StopReason` is an **open** string with camelCase values (`endTurn`/`stopSequence`/`maxTokens`/`toolUse`|string) — mcpkit's closed lowercase enum was off-spec.
- The `sampling` capability has `{ context?, tools? }` sub-fields; mcpkit's was empty `{}`.

## Added
- `ToolUseContent { id, name, input, _meta? }`, `ToolResultContent { toolUseId, content: Vec<Content>, structuredContent?, isError?, _meta? }`, `ToolChoice { mode? }`.
- `SamplingContent` union + `OneOrMany<T>`. `SamplingMessage.content`/`CreateMessageResult.content` → `OneOrMany<SamplingContent>`; `SamplingMessage._meta`.
- `CreateMessageRequest`: `tools?`, `toolChoice?`, `_meta?`.
- `SamplingCapability { context?, tools? }` + `with_sampling_tools()`/`has_sampling_tools()` (+ `context` variants).

## Fixed
- `StopReason` now serializes camelCase, adds `toolUse`, and preserves unknown values via `Other(String)`.

## Breaking
Sampling content types (`SamplingMessage`/`CreateMessageResult` content is now `OneOrMany<SamplingContent>`), the new `CreateMessageRequest` fields, and the `StopReason` representation. (0.7.0 pre-1.0.)

## Deferred → #143
The `task` field changes the response shape (`CreateMessageResult` → `CreateTaskResult`) and needs a `ClientHandler` API change — not a simple optional field. Not added here, and **not silently accepted**.

## Tests
`StopReason` camelCase + unknown passthrough; `tool_use`/`tool_result` content tag round-trips; `OneOrMany` single-object *and* array serialization/parse; request carrying `tools`/`toolChoice`; capability helpers.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --locked` all green.