### PR TITLE
feat(core): preserve _meta on nested and listed objects (#145)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `_meta` preservation on nested and listed objects (#145). The 2025-11-25 schema
+  gives `_meta` to `TextContent`, `ImageContent`, `AudioContent`, the embedded
+  resource block and its nested `ResourceContents`, `ResourceLink`, and the
+  standalone `Resource`, `ResourceTemplate`, `Tool`, and `Prompt` objects — but
+  mcpkit dropped it on all of them, so metadata on `tools/list`, `resources/list`,
+  `prompts/list`, and content blocks was silently lost on (de)serialize. Each now
+  carries an optional `meta` field. **Wire-compatible, but Rust source-breaking:**
+  these structs are not `#[non_exhaustive]` and do not derive `Default`, so any
+  struct-literal construction (`Tool { .. }`, `Resource { .. }`, etc.) must add
+  `meta: None`; constructors and builders are unaffected. Object-typing of
+  `ToolUseContent.input`/`ToolResultContent.structured_content` (`Value` → object
+  map) is deferred as a separate codebase-wide consistency decision
+  ([#145](https://github.com/praxiomlabs/mcpkit/issues/145)).
 - Tool-augmented sampling — content + request surface (#110, phase A). New core
   `ToolUseContent`/`ToolResultContent` content blocks, a `SamplingContent` union
   (Text/Image/Audio/ToolUse/ToolResult — the spec's `SamplingMessageContentBlock`,

--- a/benches/benches/serialization.rs
+++ b/benches/benches/serialization.rs
@@ -115,6 +115,7 @@ fn tool_definition() -> Tool {
         }),
         execution: None,
         output_schema: None,
+        meta: None,
     }
 }
 

--- a/benches/benches/tool_invocation.rs
+++ b/benches/benches/tool_invocation.rs
@@ -32,6 +32,7 @@ impl ToolHandler {
                 annotations: None,
                 execution: None,
                 output_schema: None,
+                meta: None,
             },
         );
 
@@ -54,6 +55,7 @@ impl ToolHandler {
                 annotations: None,
                 execution: None,
                 output_schema: None,
+                meta: None,
             },
         );
 

--- a/crates/mcpkit-core/src/types/content.rs
+++ b/crates/mcpkit-core/src/types/content.rs
@@ -33,6 +33,7 @@ impl Content {
         Self::Text(TextContent {
             text: text.into(),
             annotations: None,
+            meta: None,
         })
     }
 
@@ -42,6 +43,7 @@ impl Content {
         Self::Text(TextContent {
             text: text.into(),
             annotations: Some(annotations),
+            meta: None,
         })
     }
 
@@ -52,6 +54,7 @@ impl Content {
             data: data.into(),
             mime_type: mime_type.into(),
             annotations: None,
+            meta: None,
         })
     }
 
@@ -62,6 +65,7 @@ impl Content {
             data: data.into(),
             mime_type: mime_type.into(),
             annotations: None,
+            meta: None,
         })
     }
 
@@ -74,8 +78,10 @@ impl Content {
                 mime_type: None,
                 text: None,
                 blob: None,
+                meta: None,
             },
             annotations: None,
+            meta: None,
         })
     }
 
@@ -112,6 +118,7 @@ impl Content {
             description: None,
             mime_type: None,
             annotations: None,
+            meta: None,
         })
     }
 
@@ -139,6 +146,9 @@ pub struct TextContent {
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ContentAnnotations>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<super::meta::Meta>,
 }
 
 /// Image content (base64 encoded).
@@ -152,6 +162,9 @@ pub struct ImageContent {
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ContentAnnotations>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<super::meta::Meta>,
 }
 
 /// Audio content (base64 encoded).
@@ -165,6 +178,9 @@ pub struct AudioContent {
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ContentAnnotations>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<super::meta::Meta>,
 }
 
 /// Embedded resource content.
@@ -178,6 +194,9 @@ pub struct ResourceContent {
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ContentAnnotations>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<super::meta::Meta>,
 }
 
 /// A link to a resource (not embedded inline, just a URI reference).
@@ -196,6 +215,9 @@ pub struct ResourceLinkContent {
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ContentAnnotations>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<super::meta::Meta>,
 }
 
 /// A tool call the model wants to make, in a sampling message
@@ -297,6 +319,52 @@ impl std::fmt::Display for Role {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn content_block_meta_round_trips() -> Result<(), Box<dyn std::error::Error>> {
+        // `_meta` on a content block must survive deserialize -> serialize.
+        for wire in [
+            serde_json::json!({"type":"text","text":"hi","_meta":{"k":"v"}}),
+            serde_json::json!({"type":"image","data":"d","mimeType":"image/png","_meta":{"k":"v"}}),
+            serde_json::json!({"type":"audio","data":"d","mimeType":"audio/wav","_meta":{"k":"v"}}),
+            serde_json::json!({"type":"resource_link","uri":"u","name":"n","_meta":{"k":"v"}}),
+        ] {
+            let c: Content = serde_json::from_value(wire.clone())?;
+            assert_eq!(
+                serde_json::to_value(&c)?["_meta"]["k"],
+                "v",
+                "content block dropped _meta: {wire}"
+            );
+        }
+        // Embedded resource: the outer block and the nested `ResourceContents`
+        // each carry their own `_meta`.
+        let wire = serde_json::json!({
+            "type":"resource",
+            "resource":{"uri":"u","_meta":{"rk":"rv"}},
+            "_meta":{"k":"v"}
+        });
+        let c: Content = serde_json::from_value(wire)?;
+        let back = serde_json::to_value(&c)?;
+        assert_eq!(back["_meta"]["k"], "v");
+        assert_eq!(back["resource"]["_meta"]["rk"], "rv");
+        Ok(())
+    }
+
+    #[test]
+    fn content_block_meta_omitted_when_absent() -> Result<(), Box<dyn std::error::Error>> {
+        // Constructed content has `meta: None` and must not emit an `_meta` key.
+        for c in [
+            Content::text("hi"),
+            Content::image("d", "image/png"),
+            Content::audio("d", "audio/wav"),
+            Content::resource("u"),
+            Content::resource_link("u", "n"),
+        ] {
+            let json = serde_json::to_value(&c)?;
+            assert!(json.get("_meta").is_none(), "unexpected _meta in {json}");
+        }
+        Ok(())
+    }
 
     #[test]
     fn test_text_content() {

--- a/crates/mcpkit-core/src/types/prompt.rs
+++ b/crates/mcpkit-core/src/types/prompt.rs
@@ -28,6 +28,9 @@ pub struct Prompt {
     /// Arguments that the prompt accepts.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<Vec<PromptArgument>>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl Prompt {
@@ -40,6 +43,7 @@ impl Prompt {
             description: None,
             icons: None,
             arguments: None,
+            meta: None,
         }
     }
 
@@ -304,6 +308,18 @@ pub struct PromptListChangedNotification {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn prompt_meta_round_trips_and_omits() -> Result<(), Box<dyn std::error::Error>> {
+        let p: Prompt = serde_json::from_value(serde_json::json!({"name":"n","_meta":{"k":"v"}}))?;
+        assert_eq!(serde_json::to_value(&p)?["_meta"]["k"], "v");
+        assert!(
+            serde_json::to_value(Prompt::new("n"))?
+                .get("_meta")
+                .is_none()
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_prompt_builder() -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/mcpkit-core/src/types/resource.rs
+++ b/crates/mcpkit-core/src/types/resource.rs
@@ -36,6 +36,9 @@ pub struct Resource {
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ResourceAnnotations>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl Resource {
@@ -51,6 +54,7 @@ impl Resource {
             size: None,
             icons: None,
             annotations: None,
+            meta: None,
         }
     }
 
@@ -146,6 +150,9 @@ pub struct ResourceTemplate {
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<ResourceAnnotations>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl ResourceTemplate {
@@ -160,6 +167,7 @@ impl ResourceTemplate {
             mime_type: None,
             icons: None,
             annotations: None,
+            meta: None,
         }
     }
 
@@ -213,6 +221,9 @@ pub struct ResourceContents {
     /// Binary content as base64 (mutually exclusive with text).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blob: Option<String>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl ResourceContents {
@@ -224,6 +235,7 @@ impl ResourceContents {
             mime_type: Some("text/plain".to_string()),
             text: Some(text.into()),
             blob: None,
+            meta: None,
         }
     }
 
@@ -242,6 +254,7 @@ impl ResourceContents {
             mime_type: Some("application/json".to_string()),
             text: Some(json),
             blob: None,
+            meta: None,
         })
     }
 
@@ -254,6 +267,7 @@ impl ResourceContents {
             mime_type: Some(mime_type.into()),
             text: None,
             blob: Some(base64::engine::general_purpose::STANDARD.encode(data)),
+            meta: None,
         }
     }
 
@@ -369,6 +383,43 @@ pub struct ResourceListChangedNotification {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn resource_types_meta_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+        let r: Resource =
+            serde_json::from_value(serde_json::json!({"uri":"u","name":"n","_meta":{"k":"v"}}))?;
+        assert_eq!(serde_json::to_value(&r)?["_meta"]["k"], "v");
+
+        let t: ResourceTemplate = serde_json::from_value(
+            serde_json::json!({"uriTemplate":"u/{id}","name":"n","_meta":{"k":"v"}}),
+        )?;
+        assert_eq!(serde_json::to_value(&t)?["_meta"]["k"], "v");
+
+        let c: ResourceContents =
+            serde_json::from_value(serde_json::json!({"uri":"u","text":"hi","_meta":{"k":"v"}}))?;
+        assert_eq!(serde_json::to_value(&c)?["_meta"]["k"], "v");
+        Ok(())
+    }
+
+    #[test]
+    fn resource_types_meta_omitted_when_absent() -> Result<(), Box<dyn std::error::Error>> {
+        assert!(
+            serde_json::to_value(Resource::new("u", "n"))?
+                .get("_meta")
+                .is_none()
+        );
+        assert!(
+            serde_json::to_value(ResourceTemplate::new("u/{id}", "n"))?
+                .get("_meta")
+                .is_none()
+        );
+        assert!(
+            serde_json::to_value(ResourceContents::text("u", "hi"))?
+                .get("_meta")
+                .is_none()
+        );
+        Ok(())
+    }
 
     #[test]
     fn test_resource_builder() {

--- a/crates/mcpkit-core/src/types/sampling.rs
+++ b/crates/mcpkit-core/src/types/sampling.rs
@@ -52,6 +52,7 @@ impl SamplingContent {
         Self::Text(TextContent {
             text: text.into(),
             annotations: None,
+            meta: None,
         })
     }
 }

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -61,6 +61,9 @@ pub struct Tool {
     /// conform to this schema (MCP structured output).
     #[serde(rename = "outputSchema", skip_serializing_if = "Option::is_none")]
     pub output_schema: Option<serde_json::Value>,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl Tool {
@@ -79,6 +82,7 @@ impl Tool {
             annotations: None,
             execution: None,
             output_schema: None,
+            meta: None,
         }
     }
 
@@ -608,6 +612,16 @@ pub struct CallToolRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tool_meta_round_trips_and_omits() -> Result<(), Box<dyn std::error::Error>> {
+        let t: Tool = serde_json::from_value(
+            serde_json::json!({"name":"n","inputSchema":{"type":"object"},"_meta":{"k":"v"}}),
+        )?;
+        assert_eq!(serde_json::to_value(&t)?["_meta"]["k"], "v");
+        assert!(serde_json::to_value(Tool::new("n"))?.get("_meta").is_none());
+        Ok(())
+    }
 
     #[test]
     fn with_param_coerces_non_object_properties_instead_of_panicking() {

--- a/crates/mcpkit-macros/src/server.rs
+++ b/crates/mcpkit-macros/src/server.rs
@@ -606,6 +606,7 @@ fn generate_tool_handler(tools: &[ToolMethod], self_ty: &syn::Type) -> TokenStre
                     }),
                     execution: #execution,
                     output_schema: #output_schema,
+                    meta: None,
                 }
             }
         })
@@ -687,6 +688,7 @@ fn generate_resource_handler(resources: &[ResourceMethod], self_ty: &syn::Type) 
                         size: None,
                         icons: None,
                         annotations: None,
+                        meta: None,
                     },
                 })
             }
@@ -713,6 +715,7 @@ fn generate_resource_handler(resources: &[ResourceMethod], self_ty: &syn::Type) 
                         mime_type: Some(#mime_type.to_string()),
                         icons: None,
                         annotations: None,
+                        meta: None,
                     },
                 })
             } else {
@@ -865,6 +868,7 @@ fn generate_prompt_handler(prompts: &[PromptMethod], self_ty: &syn::Type) -> Tok
                     description: if #description.is_empty() { None } else { Some(#description.to_string()) },
                     icons: None,
                     arguments: #arguments_expr,
+                    meta: None,
                 }
             }
         })

--- a/crates/mcpkit-server/src/capability/prompts.rs
+++ b/crates/mcpkit-server/src/capability/prompts.rs
@@ -197,6 +197,7 @@ impl PromptBuilder {
             } else {
                 Some(self.arguments)
             },
+            meta: None,
         }
     }
 }

--- a/crates/mcpkit-server/src/capability/resources.rs
+++ b/crates/mcpkit-server/src/capability/resources.rs
@@ -230,6 +230,7 @@ impl ResourceBuilder {
             size: None,
             icons: None,
             annotations: None,
+            meta: None,
         }
     }
 }
@@ -276,6 +277,7 @@ impl ResourceTemplateBuilder {
             mime_type: self.mime_type,
             icons: None,
             annotations: None,
+            meta: None,
         }
     }
 }

--- a/crates/mcpkit-server/src/capability/tools.rs
+++ b/crates/mcpkit-server/src/capability/tools.rs
@@ -250,6 +250,7 @@ impl ToolBuilder {
             annotations,
             execution: None,
             output_schema: None,
+            meta: None,
         }
     }
 }

--- a/crates/mcpkit-testing/src/mock.rs
+++ b/crates/mcpkit-testing/src/mock.rs
@@ -117,6 +117,7 @@ impl MockTool {
             annotations: self.annotations.clone(),
             execution: None,
             output_schema: None,
+            meta: None,
         }
     }
 
@@ -187,6 +188,7 @@ impl MockResource {
             size: Some(self.content.len() as u64),
             icons: None,
             annotations: None,
+            meta: None,
         }
     }
 
@@ -198,6 +200,7 @@ impl MockResource {
             mime_type: self.mime_type.clone(),
             text: Some(self.content.clone()),
             blob: None,
+            meta: None,
         }
     }
 }
@@ -243,6 +246,7 @@ impl MockPrompt {
             description: self.description.clone(),
             icons: None,
             arguments: None,
+            meta: None,
         }
     }
 }

--- a/mcpkit/tests/capabilities_compliance.rs
+++ b/mcpkit/tests/capabilities_compliance.rs
@@ -59,6 +59,7 @@ fn test_resource_definition() -> Result<(), Box<dyn std::error::Error>> {
         size: Some(1024),
         icons: None,
         annotations: None,
+        meta: None,
     };
 
     let json = serde_json::to_value(&resource)?;
@@ -84,6 +85,7 @@ fn test_prompt_definition() -> Result<(), Box<dyn std::error::Error>> {
             description: Some("The code to review".to_string()),
             required: Some(true),
         }]),
+        meta: None,
     };
 
     let json = serde_json::to_value(&prompt)?;
@@ -164,6 +166,7 @@ fn test_resource_without_optional_fields() -> Result<(), Box<dyn std::error::Err
         size: None,
         icons: None,
         annotations: None,
+        meta: None,
     };
 
     let json = serde_json::to_value(&resource)?;
@@ -181,6 +184,7 @@ fn test_prompt_without_arguments() -> Result<(), Box<dyn std::error::Error>> {
         description: Some("A simple prompt".to_string()),
         icons: None,
         arguments: None,
+        meta: None,
     };
 
     let json = serde_json::to_value(&prompt)?;


### PR DESCRIPTION
Closes #145. First (and headline) half of #145; the object-typing half is split to #147.

## Problem
The 2025-11-25 schema defines `_meta` on the content blocks and on the standalone `Resource`/`ResourceTemplate`/`Tool`/`Prompt` objects, but mcpkit modeled none of them with a `_meta` field. So `_meta` was **silently dropped** on a deserialize -> serialize round-trip for `tools/list`, `resources/list`, `prompts/list`, and every content block — a wire-fidelity data-loss bug.

## Change
Add an optional `meta` field (`#[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]`) to the ten schema-backed types, matching the #109 (result-level) / #110 (`ToolUseContent`/`ToolResultContent`) pattern:

`TextContent`, `ImageContent`, `AudioContent`, `ResourceContent` (embedded), `ResourceLinkContent`, `ResourceContents` (nested), `Resource`, `ResourceTemplate`, `Tool`, `Prompt`.

Verified against `schema.ts` verbatim — including that `ResourceLink` inherits `_meta` from `Resource` (so `ResourceLinkContent` is in scope), and that `PromptMessage`, `PromptArgument`, `ToolAnnotations`, and `Annotations` have **no** `_meta` and are left unchanged.

Every constructor, builder, macro codegen site, mock, and bench that builds these structs initializes `meta: None`.

## Compatibility
**Wire-compatible, but Rust source-breaking.** These structs are not `#[non_exhaustive]` and do not derive `Default`, so downstream struct-literal construction (`Tool { .. }`, `Resource { .. }`, etc.) must add `meta: None`. Constructors and builders are unaffected. (Deliberately did not add `#[non_exhaustive]` — that's a separate API-hardening decision, and #109 set the precedent of just adding the field.)

## Deferred → #147
Object-typing `input`/`structuredContent` (`Value` -> object map) is a codebase-wide consistency decision (the pre-existing `CallToolResult.structured_content`/`CallToolRequest.arguments` are `Value` too), so it's split out rather than done piecemeal here.

## Tests
Per-type round-trip tests in `content`/`resource`/`tool`/`prompt`: `_meta` survives deserialize -> serialize, and constructed values omit `_meta` when absent.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --all-features --locked` all green.