### PR TITLE
feat(tasks): result-level _meta on task results + status notification (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Result-level `_meta` on task results and the status notification (#136). The
+  spec types `tasks/get`/`tasks/cancel` results as `Result & Task` and the
+  status notification as `NotificationParams & Task` — each flattens the `Task`
+  fields and adds a result/notification-level `_meta`. `GetTaskResult`,
+  `CancelTaskResult`, and the new `TaskStatusNotificationParams` are now real
+  `#[serde(flatten)] task + _meta` structs (previously bare `Task` aliases that
+  dropped `_meta`); the base `Task` stays `_meta`-free (so it does not leak into
+  `CreateTaskResult.task`/`ListTasksResult.tasks[]`). With `meta: None` the wire
+  shape is byte-identical to the old aliases. `From<Task>` and `.with_meta(..)`
+  keep construction ergonomic. **Breaking:** `TaskHandler::get_task` now returns
+  `Option<GetTaskResult>` and `cancel_task` returns `Option<CancelTaskResult>`
+  (was `Option<Task>` / `bool`) — the latter also returns the post-cancellation
+  task state and cleanly distinguishes unknown (`Ok(None)`) from an internal
+  failure (`Err`), instead of the old `.is_ok()` that reported a poisoned lock as
+  "unknown task". The client's `Client::get_task`/`cancel_task` return the typed
+  results (was `Task` / `()`) so `_meta` survives on the receiving side too. The
+  `tasks/list` route still bypasses `ListTasksResult` (its `nextCursor`/`_meta`
+  are unavailable) — tracked in
+  [#150](https://github.com/praxiomlabs/mcpkit/issues/150)
+  ([#136](https://github.com/praxiomlabs/mcpkit/issues/136)).
 - `_meta` preservation on nested and listed objects (#145). The 2025-11-25 schema
   gives `_meta` to `TextContent`, `ImageContent`, `AudioContent`, the embedded
   resource block and its nested `ResourceContents`, `ResourceLink`, and the

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -22,12 +22,12 @@ use mcpkit_core::error::{
 use mcpkit_core::protocol::{Message, Notification, Request, RequestId, Response};
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_core::types::{
-    CallToolRequest, CallToolResult, CancelTaskRequest, CompleteRequest, CompleteResult,
-    CompletionArgument, CompletionRef, CreateMessageRequest, ElicitRequestParams, GetPromptRequest,
-    GetPromptResult, GetTaskRequest, ListPromptsResult, ListResourceTemplatesResult,
-    ListResourcesResult, ListTasksRequest, ListTasksResult, ListToolsResult, Prompt,
-    ReadResourceRequest, ReadResourceResult, Resource, ResourceContents, ResourceTemplate,
-    SubscribeRequest, Task, TaskStatus, Tool, UnsubscribeRequest,
+    CallToolRequest, CallToolResult, CancelTaskRequest, CancelTaskResult, CompleteRequest,
+    CompleteResult, CompletionArgument, CompletionRef, CreateMessageRequest, ElicitRequestParams,
+    GetPromptRequest, GetPromptResult, GetTaskRequest, GetTaskResult, ListPromptsResult,
+    ListResourceTemplatesResult, ListResourcesResult, ListTasksRequest, ListTasksResult,
+    ListToolsResult, Prompt, ReadResourceRequest, ReadResourceResult, Resource, ResourceContents,
+    ResourceTemplate, SubscribeRequest, Task, TaskStatus, Tool, UnsubscribeRequest,
 };
 use mcpkit_transport::Transport;
 use std::collections::HashMap;
@@ -846,10 +846,13 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
 
     /// Get a task by ID.
     ///
+    /// Returns the [`GetTaskResult`] wrapper (`Result & Task`), preserving any
+    /// result-level `_meta`; the task state is in its `task` field.
+    ///
     /// # Errors
     ///
     /// Returns an error if tasks are not supported or the task is not found.
-    pub async fn get_task(&self, id: impl Into<String>) -> Result<Task, McpError> {
+    pub async fn get_task(&self, id: impl Into<String>) -> Result<GetTaskResult, McpError> {
         self.ensure_capability("tasks", self.has_tasks())?;
 
         let request = GetTaskRequest {
@@ -859,22 +862,23 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             .await
     }
 
-    /// Cancel a running task.
+    /// Cancel a running task, returning its post-cancellation state.
+    ///
+    /// Returns the [`CancelTaskResult`] wrapper (`Result & Task`), preserving any
+    /// result-level `_meta`; the task state is in its `task` field.
     ///
     /// # Errors
     ///
     /// Returns an error if tasks are not supported, cancellation is not supported,
     /// or the task is not found.
-    pub async fn cancel_task(&self, id: impl Into<String>) -> Result<(), McpError> {
+    pub async fn cancel_task(&self, id: impl Into<String>) -> Result<CancelTaskResult, McpError> {
         self.ensure_capability("tasks", self.has_tasks())?;
 
         let request = CancelTaskRequest {
             task_id: id.into().into(),
         };
-        let _: serde_json::Value = self
-            .request("tasks/cancel", Some(serde_json::to_value(request)?))
-            .await?;
-        Ok(())
+        self.request("tasks/cancel", Some(serde_json::to_value(request)?))
+            .await
     }
 
     // ==========================================================================

--- a/crates/mcpkit-core/src/types/task.rs
+++ b/crates/mcpkit-core/src/types/task.rs
@@ -193,21 +193,65 @@ pub struct CreateTaskResult {
     pub meta: Option<Meta>,
 }
 
-// NOTE: Per the spec, `tasks/get`/`tasks/cancel` results and the task-status
-// notification are `Result & Task` / `NotificationParams & Task`, i.e. they may
-// carry a result/notification-level `_meta`. That is intentionally *not* modeled
-// here: the base `Task` has no `_meta` (adding one would leak `_meta` into nested
-// `CreateTaskResult.task` and `ListTasksResult.tasks[]`), and the task handler API
-// returns a bare `Task` with nowhere to supply result-level metadata. Modeling it
-// would need dedicated result wrapper types + a handler-contract change — see
-// issue #136. `CreateTaskResult`/`ListTasksResult` do carry their own
-// result-level `_meta`.
+// The result and status-notification wrappers below are spec `Result & Task` /
+// `NotificationParams & Task`: they flatten the `Task` fields at the top level
+// and add a result/notification-level `_meta`. The base `Task` deliberately has
+// no `_meta` of its own (that would leak into nested `CreateTaskResult.task` and
+// `ListTasksResult.tasks[]`); the `_meta` lives only on these wrappers. When
+// `meta` is `None`, `#[serde(flatten)]` produces exactly the bare `Task` wire
+// shape, so the wrappers are wire-compatible with the earlier `= Task` aliases.
 
 /// Result of `tasks/get` — the task's current state (spec `Result & Task`).
-pub type GetTaskResult = Task;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetTaskResult {
+    /// The task's current state.
+    #[serde(flatten)]
+    pub task: Task,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+}
+
+impl From<Task> for GetTaskResult {
+    fn from(task: Task) -> Self {
+        Self { task, meta: None }
+    }
+}
+
+impl GetTaskResult {
+    /// Attach result-level `_meta`.
+    #[must_use]
+    pub fn with_meta(mut self, meta: Meta) -> Self {
+        self.meta = Some(meta);
+        self
+    }
+}
 
 /// Result of `tasks/cancel` — the task's state after cancellation (`Result & Task`).
-pub type CancelTaskResult = Task;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CancelTaskResult {
+    /// The task's state after cancellation.
+    #[serde(flatten)]
+    pub task: Task,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+}
+
+impl From<Task> for CancelTaskResult {
+    fn from(task: Task) -> Self {
+        Self { task, meta: None }
+    }
+}
+
+impl CancelTaskResult {
+    /// Attach result-level `_meta`.
+    #[must_use]
+    pub fn with_meta(mut self, meta: Meta) -> Self {
+        self.meta = Some(meta);
+        self
+    }
+}
 
 /// Result of `tasks/result` — the eventual payload of the augmented request
 /// (e.g. the `CallToolResult`). An arbitrary result object.
@@ -259,8 +303,22 @@ pub struct CancelTaskRequest {
 }
 
 /// Parameters for a task status notification (spec `NotificationParams & Task`):
-/// the task's current state.
-pub type TaskStatusNotification = Task;
+/// the task's current state plus optional notification-level `_meta`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TaskStatusNotificationParams {
+    /// The task's current state.
+    #[serde(flatten)]
+    pub task: Task,
+    /// Optional protocol metadata (`_meta`).
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
+}
+
+impl From<Task> for TaskStatusNotificationParams {
+    fn from(task: Task) -> Self {
+        Self { task, meta: None }
+    }
+}
 
 /// Task-domain progress information.
 ///
@@ -287,6 +345,52 @@ pub struct TaskProgress {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn get_task_result_round_trips_result_meta() -> Result<(), Box<dyn std::error::Error>> {
+        // Wire shape is `Result & Task`: Task fields at the top level plus _meta.
+        let wire = serde_json::json!({
+            "taskId": "t-1", "status": "working",
+            "createdAt": "t", "lastUpdatedAt": "t", "ttl": null,
+            "_meta": { "k": "v" }
+        });
+        let r: GetTaskResult = serde_json::from_value(wire)?;
+        assert_eq!(r.task.task_id, TaskId::new("t-1"));
+        let back = serde_json::to_value(&r)?;
+        assert_eq!(back["taskId"], "t-1"); // Task fields stay flattened.
+        assert_eq!(back["_meta"]["k"], "v"); // result-level _meta preserved.
+        Ok(())
+    }
+
+    #[test]
+    fn cancel_task_result_round_trips_result_meta() -> Result<(), Box<dyn std::error::Error>> {
+        let r = CancelTaskResult::from(Task::new(TaskId::new("t-1")))
+            .with_meta(Meta::new().with("k", serde_json::json!("v")));
+        let back = serde_json::to_value(&r)?;
+        assert_eq!(back["taskId"], "t-1");
+        assert_eq!(back["_meta"]["k"], "v");
+        let round: CancelTaskResult = serde_json::from_value(back)?;
+        assert_eq!(
+            round.meta.and_then(|m| m.get("k").cloned()),
+            Some(serde_json::json!("v"))
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn task_result_wrappers_without_meta_match_bare_task() -> Result<(), Box<dyn std::error::Error>>
+    {
+        // With no _meta the wrapper must be wire-identical to a bare Task, so
+        // the switch from the old `type ... = Task` aliases is non-breaking.
+        let task = Task::new(TaskId::new("t-2"));
+        let bare = serde_json::to_value(&task)?;
+        assert_eq!(
+            serde_json::to_value(GetTaskResult::from(task.clone()))?,
+            bare
+        );
+        assert_eq!(serde_json::to_value(CancelTaskResult::from(task))?, bare);
+        Ok(())
+    }
 
     #[test]
     fn task_serializes_with_spec_field_names() {

--- a/crates/mcpkit-server/src/builder.rs
+++ b/crates/mcpkit-server/src/builder.rs
@@ -514,15 +514,15 @@ mod tests {
             &self,
             _id: &mcpkit_core::types::TaskId,
             _ctx: &Context<'_>,
-        ) -> Result<Option<mcpkit_core::types::Task>, McpError> {
+        ) -> Result<Option<mcpkit_core::types::GetTaskResult>, McpError> {
             Ok(None)
         }
         async fn cancel_task(
             &self,
             _id: &mcpkit_core::types::TaskId,
             _ctx: &Context<'_>,
-        ) -> Result<bool, McpError> {
-            Ok(false)
+        ) -> Result<Option<mcpkit_core::types::CancelTaskResult>, McpError> {
+            Ok(None)
         }
     }
 

--- a/crates/mcpkit-server/src/capability/tasks.rs
+++ b/crates/mcpkit-server/src/capability/tasks.rs
@@ -7,7 +7,7 @@ use crate::context::CancellationToken;
 use crate::context::Context;
 use crate::handler::TaskHandler;
 use mcpkit_core::error::McpError;
-use mcpkit_core::types::task::{Task, TaskId, TaskStatus};
+use mcpkit_core::types::task::{CancelTaskResult, GetTaskResult, Task, TaskId, TaskStatus};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -280,12 +280,28 @@ impl TaskHandler for TaskService {
         &self,
         task_id: &TaskId,
         _ctx: &Context<'_>,
-    ) -> Result<Option<Task>, McpError> {
-        Ok(self.manager.get(task_id).map(|s| s.task))
+    ) -> Result<Option<GetTaskResult>, McpError> {
+        Ok(self
+            .manager
+            .get(task_id)
+            .map(|s| GetTaskResult::from(s.task)))
     }
 
-    async fn cancel_task(&self, task_id: &TaskId, _ctx: &Context<'_>) -> Result<bool, McpError> {
-        Ok(self.manager.cancel(task_id).is_ok())
+    async fn cancel_task(
+        &self,
+        task_id: &TaskId,
+        _ctx: &Context<'_>,
+    ) -> Result<Option<CancelTaskResult>, McpError> {
+        // Unknown task -> Ok(None); a real internal failure (e.g. poisoned lock)
+        // must surface as Err, not be collapsed into "unknown".
+        if self.manager.get(task_id).is_none() {
+            return Ok(None);
+        }
+        self.manager.cancel(task_id)?;
+        Ok(self
+            .manager
+            .get(task_id)
+            .map(|s| CancelTaskResult::from(s.task)))
     }
 }
 

--- a/crates/mcpkit-server/src/dispatch.rs
+++ b/crates/mcpkit-server/src/dispatch.rs
@@ -16,8 +16,8 @@ use crate::context::Context;
 use crate::handler::{PromptHandler, ResourceHandler, TaskHandler, ToolHandler};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    GetPromptResult, Prompt, Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool,
-    ToolOutput,
+    CancelTaskResult, GetPromptResult, GetTaskResult, Prompt, Resource, ResourceContents,
+    ResourceTemplate, Task, TaskId, Tool, ToolOutput,
 };
 use serde_json::Value;
 use std::future::Future;
@@ -168,13 +168,13 @@ pub trait DynTaskHandler: Send + Sync {
         &'a self,
         id: &'a TaskId,
         ctx: &'a Context<'_>,
-    ) -> BoxFut<'a, Result<Option<Task>, McpError>>;
+    ) -> BoxFut<'a, Result<Option<GetTaskResult>, McpError>>;
     /// See [`TaskHandler::cancel_task`].
     fn cancel_task<'a>(
         &'a self,
         id: &'a TaskId,
         ctx: &'a Context<'_>,
-    ) -> BoxFut<'a, Result<bool, McpError>>;
+    ) -> BoxFut<'a, Result<Option<CancelTaskResult>, McpError>>;
 }
 
 impl<K: TaskHandler> DynTaskHandler for K {
@@ -185,14 +185,14 @@ impl<K: TaskHandler> DynTaskHandler for K {
         &'a self,
         id: &'a TaskId,
         ctx: &'a Context<'_>,
-    ) -> BoxFut<'a, Result<Option<Task>, McpError>> {
+    ) -> BoxFut<'a, Result<Option<GetTaskResult>, McpError>> {
         Box::pin(TaskHandler::get_task(self, id, ctx))
     }
     fn cancel_task<'a>(
         &'a self,
         id: &'a TaskId,
         ctx: &'a Context<'_>,
-    ) -> BoxFut<'a, Result<bool, McpError>> {
+    ) -> BoxFut<'a, Result<Option<CancelTaskResult>, McpError>> {
         Box::pin(TaskHandler::cancel_task(self, id, ctx))
     }
 }

--- a/crates/mcpkit-server/src/handler.rs
+++ b/crates/mcpkit-server/src/handler.rs
@@ -37,8 +37,8 @@
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    GetPromptResult, Prompt, Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool,
-    ToolOutput,
+    CancelTaskResult, GetPromptResult, GetTaskResult, Prompt, Resource, ResourceContents,
+    ResourceTemplate, Task, TaskId, Tool, ToolOutput,
 };
 use serde_json::Value;
 use std::future::Future;
@@ -227,18 +227,26 @@ pub trait TaskHandler: Send + Sync {
     ) -> impl Future<Output = Result<Vec<Task>, McpError>> + Send;
 
     /// Get the current state of a task.
+    ///
+    /// Return `Ok(None)` for an unknown task. The [`GetTaskResult`] wrapper may
+    /// carry result-level `_meta`; `Task::into()` produces one with no metadata.
     fn get_task(
         &self,
         id: &TaskId,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Option<Task>, McpError>> + Send;
+    ) -> impl Future<Output = Result<Option<GetTaskResult>, McpError>> + Send;
 
-    /// Cancel a running task.
+    /// Cancel a running task, returning its post-cancellation state.
+    ///
+    /// - `Ok(Some(result))` — cancellation accepted; `result` is the task's state
+    ///   afterwards (and may carry result-level `_meta`).
+    /// - `Ok(None)` — no such task.
+    /// - `Err(..)` — the task exists but cancellation failed (an internal error).
     fn cancel_task(
         &self,
         id: &TaskId,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<bool, McpError>> + Send;
+    ) -> impl Future<Output = Result<Option<CancelTaskResult>, McpError>> + Send;
 }
 
 /// Handler for completion suggestions.
@@ -393,7 +401,7 @@ impl<T: TaskHandler> TaskHandler for Arc<T> {
         &self,
         id: &TaskId,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Option<Task>, McpError>> + Send {
+    ) -> impl Future<Output = Result<Option<GetTaskResult>, McpError>> + Send {
         (**self).get_task(id, ctx)
     }
 
@@ -401,7 +409,7 @@ impl<T: TaskHandler> TaskHandler for Arc<T> {
         &self,
         id: &TaskId,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<bool, McpError>> + Send {
+    ) -> impl Future<Output = Result<Option<CancelTaskResult>, McpError>> + Send {
         (**self).cancel_task(id, ctx)
     }
 }

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -840,7 +840,7 @@ pub async fn route_tasks(
             let result = async {
                 let id = parse_task_id(params, methods::TASKS_GET)?;
                 match handler.get_task(&id, ctx).await? {
-                    Some(task) => Ok(serde_json::to_value(task).unwrap_or_default()),
+                    Some(result) => Ok(serde_json::to_value(result).unwrap_or_default()),
                     None => Err(McpError::invalid_params(
                         methods::TASKS_GET,
                         format!("unknown task: {id}"),
@@ -853,16 +853,14 @@ pub async fn route_tasks(
         methods::TASKS_CANCEL => {
             let result = async {
                 let id = parse_task_id(params, methods::TASKS_CANCEL)?;
-                if !handler.cancel_task(&id, ctx).await? {
-                    return Err(McpError::invalid_params(
+                // `Ok(None)` is an unknown task; a real cancellation failure
+                // propagates as `Err` from the handler.
+                match handler.cancel_task(&id, ctx).await? {
+                    Some(result) => Ok(serde_json::to_value(result).unwrap_or_default()),
+                    None => Err(McpError::invalid_params(
                         methods::TASKS_CANCEL,
                         format!("unknown task: {id}"),
-                    ));
-                }
-                // CancelTaskResult is `Result & Task`: return the cancelled task.
-                match handler.get_task(&id, ctx).await? {
-                    Some(task) => Ok(serde_json::to_value(task).unwrap_or_default()),
-                    None => Ok(serde_json::json!({})),
+                    )),
                 }
             }
             .await;
@@ -1479,6 +1477,68 @@ mod tests {
                 .await
                 .is_none()
         );
+    }
+
+    #[tokio::test]
+    async fn route_tasks_get_and_cancel_emit_result_meta() {
+        use crate::context::NoOpPeer;
+        use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+        use mcpkit_core::protocol::RequestId;
+        use mcpkit_core::protocol_version::ProtocolVersion;
+        use mcpkit_core::types::{CancelTaskResult, GetTaskResult, Meta, Task, TaskId};
+
+        // A handler that attaches result-level `_meta` on both get and cancel.
+        struct MetaTaskHandler;
+        impl crate::handler::TaskHandler for MetaTaskHandler {
+            async fn list_tasks(&self, _ctx: &Context<'_>) -> Result<Vec<Task>, McpError> {
+                Ok(vec![])
+            }
+            async fn get_task(
+                &self,
+                id: &TaskId,
+                _ctx: &Context<'_>,
+            ) -> Result<Option<GetTaskResult>, McpError> {
+                let meta = Meta::new().with("origin", serde_json::json!("test"));
+                Ok(Some(
+                    GetTaskResult::from(Task::new(id.clone())).with_meta(meta),
+                ))
+            }
+            async fn cancel_task(
+                &self,
+                id: &TaskId,
+                _ctx: &Context<'_>,
+            ) -> Result<Option<CancelTaskResult>, McpError> {
+                let meta = Meta::new().with("origin", serde_json::json!("test"));
+                Ok(Some(
+                    CancelTaskResult::from(Task::new(id.clone())).with_meta(meta),
+                ))
+            }
+        }
+
+        let handler = MetaTaskHandler;
+        let request_id = RequestId::Number(1);
+        let client_caps = ClientCapabilities::default();
+        let server_caps = ServerCapabilities::default();
+        let peer = NoOpPeer;
+        let ctx = Context::new(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            ProtocolVersion::LATEST,
+            &peer,
+        );
+        let params = serde_json::json!({ "taskId": "t-1" });
+
+        for method in [methods::TASKS_GET, methods::TASKS_CANCEL] {
+            let resp = route_tasks(&handler, method, Some(&params), &ctx)
+                .await
+                .expect("routed")
+                .expect("ok");
+            // Task fields flattened at the top level, plus result-level `_meta`.
+            assert_eq!(resp["taskId"], "t-1", "{method}");
+            assert_eq!(resp["_meta"]["origin"], "test", "{method}");
+        }
     }
 
     #[tokio::test]

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -880,9 +880,10 @@ where
                 let Some(id) = task_id() else {
                     return Some(Err(McpError::invalid_params("tasks/get", "missing taskId")));
                 };
-                self.task_store
-                    .get(&id)
-                    .map(|s| Ok(serde_json::to_value(s.task).unwrap_or_default()))
+                self.task_store.get(&id).map(|s| {
+                    let result = mcpkit_core::types::GetTaskResult::from(s.task);
+                    Ok(serde_json::to_value(result).unwrap_or_default())
+                })
             }
             "tasks/result" => {
                 let Some(id) = task_id() else {
@@ -914,7 +915,10 @@ where
                     Some(Ok(self
                         .task_store
                         .get(&id)
-                        .map(|s| serde_json::to_value(s.task).unwrap_or_default())
+                        .map(|s| {
+                            let result = mcpkit_core::types::CancelTaskResult::from(s.task);
+                            serde_json::to_value(result).unwrap_or_default()
+                        })
                         .unwrap_or_default()))
                 } else {
                     None


### PR DESCRIPTION
Closes #136. Second core-fidelity item (after #145). Verified all shapes against schema.ts verbatim.

## Problem
The spec types `tasks/get`/`tasks/cancel` results as `Result & Task` and the status notification as `NotificationParams & Task` — each flattens the `Task` fields **plus** a result/notification-level `_meta`. mcpkit modeled all three as bare `type ... = Task` aliases, so:
- result-level `_meta` was silently dropped on the wire, and
- the task handler returned a bare `Task`/`bool` with nowhere to attach it.

Base `Task` correctly has no `_meta` (confirmed against schema) and must keep it that way, or `_meta` would leak into nested `CreateTaskResult.task` / `ListTasksResult.tasks[]`.

## Change
- `GetTaskResult`, `CancelTaskResult`, and the new `TaskStatusNotificationParams` become real `#[serde(flatten)] task: Task` + `meta: Option<Meta>` structs. With `meta: None`, `flatten` reproduces the exact bare-`Task` wire shape, so this is **wire-identical** to the old aliases. `From<Task>` + `.with_meta(..)` keep the common case ergonomic.
- **Handler contract (breaking):** `TaskHandler::get_task -> Result<Option<GetTaskResult>, _>` and `cancel_task -> Result<Option<CancelTaskResult>, _>` (were `Option<Task>` / `bool`). Cancel now returns the **post-cancellation task state** and defines clear semantics: `Ok(Some)` = cancelled + state, `Ok(None)` = unknown task, `Err` = internal failure. The built-in `TaskService` no longer collapses a poisoned-lock error into "unknown task" via `.is_ok()` (an issue flagged in review).
- **Client (breaking):** `Client::get_task`/`cancel_task` return the typed results (were `Task` / `()`), so `_meta` survives on mcpkit's own receiving side rather than being discarded.
- Both server routing paths (`router.rs::route_tasks` and the runtime's own task routing in `server.rs`) serialize through the wrappers.

Breaking surface is small and in-tree: the trait, the `Arc`/dyn forwards, the built-in `TaskService`, the test handler, and the two client methods.

## Deferred → #150
`tasks/list` still hand-builds `{"tasks": ...}` in both routing paths, bypassing `ListTasksResult` (so its `nextCursor`/`_meta` are unavailable). That's a distinct list/pagination/result-wrapper routing gap, filed separately.

## Status notification
`TaskStatusNotificationParams` is modeled but has no producer yet (emission belongs to task-augmented execution), so it serializes with `meta: None` until there is one — no fake capability.

## Tests
- Core: `GetTaskResult`/`CancelTaskResult` round-trip `_meta`; and prove `meta: None` is byte-identical to a bare `Task` (alias-compat).
- Server: a `TaskHandler` that attaches `_meta`, routed through `route_tasks`, asserts the response carries top-level `taskId` **and** result-level `_meta` for both `tasks/get` and `tasks/cancel`.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --all-features --locked` all green.