### PR TITLE
feat(completion): make completion/complete functional and spec-complete (#113)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Functional, spec-complete argument completion (#113). `completion/complete`
+  was advertised (`with_completions()`), had a `CompletionHandler` trait, a
+  `CompletionService`, and client methods — but **nothing dispatched it**: the
+  runtime `route()` and all four HTTP adapters never routed completion, so a
+  client request got method-not-found (the same "advertised-but-non-functional"
+  gap as #107/#108). This wires it end-to-end:
+  - A shared `route_completion` helper, gated on a registered handler, is invoked
+    from `Server::route` and all four adapters (mirroring the logging pattern), so
+    completion works everywhere the server routes requests.
+  - Register a handler with `Server::with_completion(..)` (runtime) or
+    `McpState::with_completion(..)` (adapters). Completion is a leaf capability, so
+    it is an optional field rather than a typestate slot — which is also the only
+    shape the adapters (flat combined handler) can carry.
+  - `CompleteRequest` gains the spec's `context` (`{ arguments?: {String:String} }`)
+    for previously-resolved template/prompt variables.
+  - The route layer enforces the spec's 100-value cap (`MAX_COMPLETION_VALUES`):
+    oversized handler output is truncated and `hasMore` forced to `true`.
+  - `total`/`hasMore` now omit from the wire when `None` (they are optional).
+  - `Client::complete(CompleteRequest)` sends an arbitrary completion request
+    (including `context`); the existing `complete_prompt_argument`/
+    `complete_resource_argument` helpers delegate to it.
+  - **Breaking:** `CompletionHandler` is reshaped from `complete_resource` /
+    `complete_prompt_arg` (each returning `Vec<String>`) to a single
+    `complete(&CompleteRequest) -> Completion`, the only shape that can carry
+    `ref` + `argument` + `context` and return a real `total`/`hasMore`
+    ([#113](https://github.com/praxiomlabs/mcpkit/issues/113)).
 - Result-level `_meta` on task results and the status notification (#136). The
   spec types `tasks/get`/`tasks/cancel` results as `Result & Task` and the
   status notification as `NotificationParams & Task` — each flattens the `Task`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - A shared `route_completion` helper, gated on a registered handler, is invoked
     from `Server::route` and all four adapters (mirroring the logging pattern), so
     completion works everywhere the server routes requests.
-  - Register a handler with `Server::with_completion(..)` (runtime) or
-    `McpState::with_completion(..)` (adapters). Completion is a leaf capability, so
-    it is an optional field rather than a typestate slot — which is also the only
-    shape the adapters (flat combined handler) can carry.
+  - Register a handler with `Server::with_completion(..)` (runtime),
+    `McpRouter::with_completion(..)` (high-level adapters), or
+    `McpState::with_completion(..)` (low-level adapter state). Completion is a leaf
+    capability, so it is an optional field rather than a typestate slot — which is
+    also the only shape the adapters (flat combined handler) can carry. Registering
+    on an adapter also makes `initialize` advertise `completions` (via effective
+    capabilities) even when the base handler does not.
   - `CompleteRequest` gains the spec's `context` (`{ arguments?: {String:String} }`)
     for previously-resolved template/prompt variables.
   - The route layer enforces the spec's 100-value cap (`MAX_COMPLETION_VALUES`):
@@ -32,8 +35,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     `complete_resource_argument` helpers delegate to it.
   - **Breaking:** `CompletionHandler` is reshaped from `complete_resource` /
     `complete_prompt_arg` (each returning `Vec<String>`) to a single
-    `complete(&CompleteRequest) -> Completion`, the only shape that can carry
-    `ref` + `argument` + `context` and return a real `total`/`hasMore`
+    `complete(&CompleteRequest) -> CompleteResult`, the only shape that can carry
+    `ref` + `argument` + `context` and return a real `total`/`hasMore` plus
+    result-level `_meta` (`Completion::into()` for the common case, or
+    `CompleteResult::with_meta`)
     ([#113](https://github.com/praxiomlabs/mcpkit/issues/113)).
 - Result-level `_meta` on task results and the status notification (#136). The
   spec types `tasks/get`/`tasks/cancel` results as `Result & Task` and the

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -12,8 +12,8 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_logging, route_prompts,
-    route_resources, route_tools,
+    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_completion, route_logging,
+    route_prompts, route_resources, route_tools,
 };
 use std::time::Duration;
 use tracing::{debug, info, warn};
@@ -283,6 +283,16 @@ where
                 &ctx,
             )
             .await
+            {
+                return match result {
+                    Ok(value) => Response::success(request.id.clone(), value),
+                    Err(e) => Response::error(request.id.clone(), e.into()),
+                };
+            }
+
+            // Try routing completion/complete (when a completion handler is set)
+            if let Some(result) =
+                route_completion(state.completion.as_deref(), method, params, &ctx).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -204,7 +204,7 @@ where
 
     // Create a context for the request
     let req_id = request.id.clone();
-    let server_caps = state.handler.capabilities();
+    let server_caps = state.effective_capabilities();
     let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
@@ -221,7 +221,7 @@ where
             let init_result = serde_json::json!({
                 "protocolVersion": protocol_version.as_str(),
                 "serverInfo": state.server_info,
-                "capabilities": state.handler.capabilities(),
+                "capabilities": server_caps,
             });
             Response::success(request.id.clone(), init_result)
         }
@@ -275,14 +275,8 @@ where
             }
 
             // Try routing logging/setLevel (gated on the advertised capability)
-            if let Some(result) = route_logging(
-                state.handler.as_ref(),
-                &state.handler.capabilities(),
-                method,
-                params,
-                &ctx,
-            )
-            .await
+            if let Some(result) =
+                route_logging(state.handler.as_ref(), &server_caps, method, params, &ctx).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-actix/src/router.rs
+++ b/crates/mcpkit-actix/src/router.rs
@@ -78,6 +78,16 @@ where
         self
     }
 
+    /// Register a completion handler and advertise the `completions` capability.
+    #[must_use]
+    pub fn with_completion<C: mcpkit_server::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        self.state = self.state.with_completion(completion);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     ///
     /// For production, you should configure CORS manually with custom settings.

--- a/crates/mcpkit-actix/src/state.rs
+++ b/crates/mcpkit-actix/src/state.rs
@@ -2,7 +2,7 @@
 
 use crate::session::{SessionManager, SessionStore};
 use mcpkit_core::auth::ProtectedResourceMetadata;
-use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_server::ServerHandler;
 use mcpkit_transport::http::OriginValidator;
 use std::sync::Arc;
@@ -141,5 +141,20 @@ impl<H> McpState<H> {
     ) -> Self {
         self.completion = Some(Arc::new(completion));
         self
+    }
+}
+
+impl<H: mcpkit_server::ServerHandler> McpState<H> {
+    /// The handler's advertised capabilities, plus `completions` when a
+    /// completion handler is registered on this adapter (the handler itself
+    /// cannot know it was registered here, so the adapter advertises it).
+    #[must_use]
+    pub fn effective_capabilities(&self) -> ServerCapabilities {
+        let caps = self.handler.capabilities();
+        if self.completion.is_some() && !caps.has_completions() {
+            caps.with_completions()
+        } else {
+            caps
+        }
     }
 }

--- a/crates/mcpkit-actix/src/state.rs
+++ b/crates/mcpkit-actix/src/state.rs
@@ -26,7 +26,6 @@ impl<T: ServerHandler> HasServerInfo for T {
 ///
 /// Note: Clone is implemented manually to avoid requiring `H: Clone`.
 /// The handler is wrapped in `Arc`, so cloning only clones the Arc pointer.
-#[derive(Debug)]
 pub struct McpState<H> {
     /// The user's MCP handler.
     pub handler: Arc<H>,
@@ -41,6 +40,20 @@ pub struct McpState<H> {
     pub origin_validator: Arc<OriginValidator>,
     /// Page size for `*/list` results; `None` disables pagination.
     pub list_page_size: Option<usize>,
+    /// Optional completion handler for `completion/complete`.
+    pub completion: Option<Arc<dyn mcpkit_server::dispatch::DynCompletionHandler>>,
+}
+
+// Manual Debug to avoid requiring `H: Debug` and because the completion handler
+// is a trait object.
+impl<H> std::fmt::Debug for McpState<H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("McpState")
+            .field("handler", &format_args!("Arc<H>"))
+            .field("server_info", &self.server_info)
+            .field("list_page_size", &self.list_page_size)
+            .finish_non_exhaustive()
+    }
 }
 
 impl<H> McpState<H>
@@ -57,6 +70,7 @@ where
             server_info,
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
+            completion: None,
         }
     }
 
@@ -70,6 +84,7 @@ where
             sse_sessions: Arc::new(sse_sessions),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
+            completion: None,
         }
     }
 }
@@ -83,6 +98,7 @@ impl<H> Clone for McpState<H> {
             server_info: self.server_info.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
             list_page_size: self.list_page_size,
+            completion: self.completion.clone(),
         }
     }
 }
@@ -113,6 +129,17 @@ impl<H> McpState<H> {
     #[must_use]
     pub const fn with_list_page_size(mut self, page_size: usize) -> Self {
         self.list_page_size = Some(page_size);
+        self
+    }
+
+    /// Register a completion handler so this adapter answers
+    /// `completion/complete`.
+    #[must_use]
+    pub fn with_completion<C: mcpkit_server::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        self.completion = Some(Arc::new(completion));
         self
     }
 }

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -233,7 +233,7 @@ where
 
     // Create a context for the request
     let req_id = request.id.clone();
-    let server_caps = state.handler.capabilities();
+    let server_caps = state.effective_capabilities();
     let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
@@ -250,7 +250,7 @@ where
             let init_result = serde_json::json!({
                 "protocolVersion": protocol_version.as_str(),
                 "serverInfo": state.server_info,
-                "capabilities": state.handler.capabilities(),
+                "capabilities": server_caps,
             });
             Response::success(request.id.clone(), init_result)
         }
@@ -304,14 +304,8 @@ where
             }
 
             // Try routing logging/setLevel (gated on the advertised capability)
-            if let Some(result) = route_logging(
-                state.handler.as_ref(),
-                &state.handler.capabilities(),
-                method,
-                params,
-                &ctx,
-            )
-            .await
+            if let Some(result) =
+                route_logging(state.handler.as_ref(), &server_caps, method, params, &ctx).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -29,8 +29,8 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_logging, route_prompts,
-    route_resources, route_tools,
+    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_completion, route_logging,
+    route_prompts, route_resources, route_tools,
 };
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -312,6 +312,16 @@ where
                 &ctx,
             )
             .await
+            {
+                return match result {
+                    Ok(value) => Response::success(request.id.clone(), value),
+                    Err(e) => Response::error(request.id.clone(), e.into()),
+                };
+            }
+
+            // Try routing completion/complete (when a completion handler is set)
+            if let Some(result) =
+                route_completion(state.completion.as_deref(), method, params, &ctx).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -75,6 +75,19 @@ where
         self
     }
 
+    /// Register a completion handler and advertise the `completions` capability.
+    ///
+    /// Wires `completion/complete` for this adapter; `initialize` will advertise
+    /// `completions` even if the base handler does not.
+    #[must_use]
+    pub fn with_completion<C: mcpkit_server::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        self.state = self.state.with_completion(completion);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     ///
     /// For production, you should use `with_cors_layer` with a custom configuration.

--- a/crates/mcpkit-axum/src/state.rs
+++ b/crates/mcpkit-axum/src/state.rs
@@ -2,7 +2,7 @@
 
 use crate::session::{SessionManager, SessionStore};
 use mcpkit_core::auth::ProtectedResourceMetadata;
-use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_transport::http::OriginValidator;
 use std::fmt;
 use std::sync::Arc;
@@ -155,5 +155,20 @@ impl<H> McpState<H> {
     ) -> Self {
         self.completion = Some(Arc::new(completion));
         self
+    }
+}
+
+impl<H: mcpkit_server::ServerHandler> McpState<H> {
+    /// The handler's advertised capabilities, plus `completions` when a
+    /// completion handler is registered on this adapter (the handler itself
+    /// cannot know it was registered here, so the adapter advertises it).
+    #[must_use]
+    pub fn effective_capabilities(&self) -> ServerCapabilities {
+        let caps = self.handler.capabilities();
+        if self.completion.is_some() && !caps.has_completions() {
+            caps.with_completions()
+        } else {
+            caps
+        }
     }
 }

--- a/crates/mcpkit-axum/src/state.rs
+++ b/crates/mcpkit-axum/src/state.rs
@@ -28,6 +28,8 @@ pub struct McpState<H> {
     pub origin_validator: Arc<OriginValidator>,
     /// Page size for `*/list` results; `None` disables pagination.
     pub list_page_size: Option<usize>,
+    /// Optional completion handler for `completion/complete`.
+    pub completion: Option<Arc<dyn mcpkit_server::dispatch::DynCompletionHandler>>,
 }
 
 // Manual Clone implementation to avoid requiring H: Clone
@@ -40,6 +42,7 @@ impl<H> Clone for McpState<H> {
             sse_sessions: Arc::clone(&self.sse_sessions),
             origin_validator: Arc::clone(&self.origin_validator),
             list_page_size: self.list_page_size,
+            completion: self.completion.clone(),
         }
     }
 }
@@ -54,6 +57,10 @@ impl<H> fmt::Debug for McpState<H> {
             .field("sse_sessions", &format_args!("Arc<SessionManager>"))
             .field("origin_validator", &self.origin_validator)
             .field("list_page_size", &self.list_page_size)
+            .field(
+                "completion",
+                &format_args!("Option<Arc<dyn DynCompletionHandler>>"),
+            )
             .finish()
     }
 }
@@ -72,6 +79,7 @@ impl<H> McpState<H> {
             sse_sessions: Arc::new(SessionManager::new()),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
+            completion: None,
         }
     }
 
@@ -88,6 +96,7 @@ impl<H> McpState<H> {
             sse_sessions: Arc::new(sse_sessions),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
+            completion: None,
         }
     }
 }
@@ -134,6 +143,17 @@ impl<H> McpState<H> {
     #[must_use]
     pub const fn with_list_page_size(mut self, page_size: usize) -> Self {
         self.list_page_size = Some(page_size);
+        self
+    }
+
+    /// Register a completion handler so this adapter answers
+    /// `completion/complete`.
+    #[must_use]
+    pub fn with_completion<C: mcpkit_server::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        self.completion = Some(Arc::new(completion));
         self
     }
 }

--- a/crates/mcpkit-axum/tests/completion.rs
+++ b/crates/mcpkit-axum/tests/completion.rs
@@ -10,8 +10,8 @@ use mcpkit_axum::McpState;
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    CompleteRequest, Completion, GetPromptResult, Prompt, Resource, ResourceContents, Tool,
-    ToolOutput,
+    CompleteRequest, CompleteResult, Completion, GetPromptResult, Prompt, Resource,
+    ResourceContents, Tool, ToolOutput,
 };
 use mcpkit_server::{
     CompletionHandler, Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler,
@@ -23,8 +23,10 @@ impl ServerHandler for H {
     fn server_info(&self) -> ServerInfo {
         ServerInfo::new("t", "1.0.0")
     }
+    // Deliberately does NOT advertise completions: registering a completion
+    // handler on the adapter must be what advertises it (regression: #113 review).
     fn capabilities(&self) -> ServerCapabilities {
-        ServerCapabilities::new().with_completions()
+        ServerCapabilities::new()
     }
 }
 impl ToolHandler for H {
@@ -77,14 +79,14 @@ impl CompletionHandler for Comp {
         &self,
         request: &CompleteRequest,
         _ctx: &Context<'_>,
-    ) -> Result<Completion, McpError> {
+    ) -> Result<CompleteResult, McpError> {
         let owner = request
             .context
             .as_ref()
             .and_then(|c| c.arguments.as_ref())
             .and_then(|a| a.get("owner").cloned())
             .unwrap_or_default();
-        Ok(Completion::new(vec![format!("{owner}-suggestion")]))
+        Ok(Completion::new(vec![format!("{owner}-suggestion")]).into())
     }
 }
 
@@ -117,6 +119,33 @@ async fn completion_complete_works_through_axum_adapter() {
         json["result"]["completion"]["values"][0], "acme-suggestion",
         "response: {json}"
     );
+}
+
+#[tokio::test]
+async fn with_completion_advertises_capability_in_initialize() {
+    // The base handler does not advertise completions; `.with_completion(..)`
+    // must cause `initialize` to advertise it (else clients never call it).
+    async fn init_caps(state: McpState<H>) -> serde_json::Value {
+        let body = serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": { "protocolVersion": "2025-11-25", "capabilities": {} }
+        })
+        .to_string();
+        let response = mcpkit_axum::handle_mcp_post(State(state), HeaderMap::new(), None, body)
+            .await
+            .into_response();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+        json["result"]["capabilities"].clone()
+    }
+
+    let with = init_caps(McpState::new(H).with_completion(Comp)).await;
+    assert!(with.get("completions").is_some(), "caps: {with}");
+
+    let without = init_caps(McpState::new(H)).await;
+    assert!(without.get("completions").is_none(), "caps: {without}");
 }
 
 #[tokio::test]

--- a/crates/mcpkit-axum/tests/completion.rs
+++ b/crates/mcpkit-axum/tests/completion.rs
@@ -1,0 +1,147 @@
+//! Regression test for #113: `completion/complete` must be answered through the
+//! HTTP adapter (with a registered completion handler), not return
+//! method-not-found. The adapters dispatch via the shared `route_completion`
+//! helper, so this guards the adapter "routing split" from forgetting completion.
+
+use axum::extract::State;
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use mcpkit_axum::McpState;
+use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    CompleteRequest, Completion, GetPromptResult, Prompt, Resource, ResourceContents, Tool,
+    ToolOutput,
+};
+use mcpkit_server::{
+    CompletionHandler, Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler,
+};
+
+struct H;
+
+impl ServerHandler for H {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("t", "1.0.0")
+    }
+    fn capabilities(&self) -> ServerCapabilities {
+        ServerCapabilities::new().with_completions()
+    }
+}
+impl ToolHandler for H {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![])
+    }
+    async fn call_tool(
+        &self,
+        _name: &str,
+        _args: serde_json::Value,
+        _ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        Ok(ToolOutput::text("x"))
+    }
+}
+impl ResourceHandler for H {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for H {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        _name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Ok(GetPromptResult {
+            description: None,
+            messages: vec![],
+            meta: None,
+        })
+    }
+}
+
+/// Completion handler that echoes the previously-resolved `owner` context value.
+struct Comp;
+impl CompletionHandler for Comp {
+    async fn complete(
+        &self,
+        request: &CompleteRequest,
+        _ctx: &Context<'_>,
+    ) -> Result<Completion, McpError> {
+        let owner = request
+            .context
+            .as_ref()
+            .and_then(|c| c.arguments.as_ref())
+            .and_then(|a| a.get("owner").cloned())
+            .unwrap_or_default();
+        Ok(Completion::new(vec![format!("{owner}-suggestion")]))
+    }
+}
+
+#[tokio::test]
+async fn completion_complete_works_through_axum_adapter() {
+    let state = McpState::new(H).with_completion(Comp);
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "completion/complete",
+        "params": {
+            "ref": { "type": "ref/prompt", "name": "p" },
+            "argument": { "name": "a", "value": "x" },
+            "context": { "arguments": { "owner": "acme" } }
+        }
+    })
+    .to_string();
+
+    let response = mcpkit_axum::handle_mcp_post(State(state), HeaderMap::new(), None, body)
+        .await
+        .into_response();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+
+    // Answered (not method-not-found), and the completion context propagated.
+    assert!(json.get("error").is_none(), "response: {json}");
+    assert_eq!(
+        json["result"]["completion"]["values"][0], "acme-suggestion",
+        "response: {json}"
+    );
+}
+
+#[tokio::test]
+async fn completion_complete_without_handler_is_method_not_found() {
+    // Without `.with_completion(..)`, the adapter must report method-not-found
+    // rather than silently succeeding.
+    let state = McpState::new(H);
+    let body = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "completion/complete",
+        "params": {
+            "ref": { "type": "ref/prompt", "name": "p" },
+            "argument": { "name": "a", "value": "x" }
+        }
+    })
+    .to_string();
+
+    let response = mcpkit_axum::handle_mcp_post(State(state), HeaderMap::new(), None, body)
+        .await
+        .into_response();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+
+    assert_eq!(json["error"]["code"], -32601, "response: {json}");
+}

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -910,7 +910,23 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
                 name: argument_name.into(),
                 value: current_value.into(),
             },
+            context: None,
         };
+        self.complete(request).await
+    }
+
+    /// Send a completion request, including any previously-resolved
+    /// [`context`](CompleteRequest::context).
+    ///
+    /// The `complete_prompt_argument`/`complete_resource_argument` helpers cover
+    /// the common no-context case; use this for URI-template or multi-argument
+    /// completion where earlier values must be supplied.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if completions are not supported or the request fails.
+    pub async fn complete(&self, request: CompleteRequest) -> Result<CompleteResult, McpError> {
+        self.ensure_capability("completions", self.has_completions())?;
         self.request("completion/complete", Some(serde_json::to_value(request)?))
             .await
     }
@@ -940,9 +956,9 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
                 name: argument_name.into(),
                 value: current_value.into(),
             },
+            context: None,
         };
-        self.request("completion/complete", Some(serde_json::to_value(request)?))
-            .await
+        self.complete(request).await
     }
 
     // ==========================================================================

--- a/crates/mcpkit-core/src/types/completion.rs
+++ b/crates/mcpkit-core/src/types/completion.rs
@@ -63,6 +63,14 @@ pub struct CompletionArgument {
     pub value: String,
 }
 
+/// Additional context for resolving a completion (spec `context`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CompletionContext {
+    /// Previously-resolved variables in a URI template or prompt.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub arguments: Option<std::collections::BTreeMap<String, String>>,
+}
+
 /// Request for argument completion.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CompleteRequest {
@@ -71,21 +79,55 @@ pub struct CompleteRequest {
     pub ref_: CompletionRef,
     /// Argument to complete.
     pub argument: CompletionArgument,
+    /// Additional, previously-resolved context (e.g. earlier template variables).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context: Option<CompletionContext>,
 }
+
+/// The maximum number of completion values allowed on the wire per the spec.
+pub const MAX_COMPLETION_VALUES: usize = 100;
 
 /// Completion result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Completion {
-    /// Suggested values.
+    /// Suggested values. The spec caps this at [`MAX_COMPLETION_VALUES`].
     pub values: Vec<String>,
-    /// Total number of available completions (if known).
+    /// Total number of available completions (if known). May exceed the number
+    /// of `values` actually returned.
     ///
     /// Per the MCP spec this is a plain count; whether more are available beyond
     /// what was returned is conveyed separately by [`has_more`](Self::has_more).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total: Option<usize>,
-    /// Whether there are more completions available.
-    #[serde(rename = "hasMore")]
+    /// Whether there are more completions available beyond `values`.
+    #[serde(rename = "hasMore", default, skip_serializing_if = "Option::is_none")]
     pub has_more: Option<bool>,
+}
+
+impl Completion {
+    /// Create a completion from a list of values, reporting `total` as the
+    /// number of values and no further pages.
+    #[must_use]
+    pub fn new(values: Vec<String>) -> Self {
+        let total = values.len();
+        Self {
+            values,
+            total: Some(total),
+            has_more: Some(false),
+        }
+    }
+
+    /// Enforce the spec's [`MAX_COMPLETION_VALUES`] cap: truncate `values` to the
+    /// limit and, if truncation occurred, force `has_more` to `true` so the wire
+    /// stays valid regardless of what a handler returned.
+    #[must_use]
+    pub fn capped(mut self) -> Self {
+        if self.values.len() > MAX_COMPLETION_VALUES {
+            self.values.truncate(MAX_COMPLETION_VALUES);
+            self.has_more = Some(true);
+        }
+        self
+    }
 }
 
 /// Result of a completion request.
@@ -101,6 +143,51 @@ pub struct CompleteResult {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn capped_truncates_to_100_and_forces_has_more() {
+        let over = Completion {
+            values: (0..150).map(|i| i.to_string()).collect(),
+            total: Some(150),
+            has_more: Some(false),
+        }
+        .capped();
+        assert_eq!(over.values.len(), MAX_COMPLETION_VALUES);
+        assert_eq!(over.has_more, Some(true));
+        assert_eq!(over.total, Some(150)); // handler-reported total is preserved
+
+        // At or under the cap is left untouched.
+        let under = Completion::new(vec!["a".to_string()]).capped();
+        assert_eq!(under.values.len(), 1);
+        assert_eq!(under.has_more, Some(false));
+    }
+
+    #[test]
+    fn context_round_trips_and_omits_when_empty() -> Result<(), Box<dyn std::error::Error>> {
+        let req: CompleteRequest = serde_json::from_value(serde_json::json!({
+            "ref": {"type": "ref/prompt", "name": "p"},
+            "argument": {"name": "a", "value": "v"},
+            "context": {"arguments": {"owner": "acme"}}
+        }))?;
+        let args = req
+            .context
+            .as_ref()
+            .and_then(|c| c.arguments.as_ref())
+            .ok_or("expected context.arguments")?;
+        assert_eq!(args.get("owner").map(String::as_str), Some("acme"));
+
+        // A request without context must not emit the key.
+        let bare = CompleteRequest {
+            ref_: CompletionRef::prompt("p"),
+            argument: CompletionArgument {
+                name: "a".to_string(),
+                value: "v".to_string(),
+            },
+            context: None,
+        };
+        assert!(serde_json::to_value(&bare)?.get("context").is_none());
+        Ok(())
+    }
 
     #[test]
     fn completion_total_is_a_plain_number() {
@@ -138,6 +225,7 @@ mod tests {
                 name: "arg1".to_string(),
                 value: "val".to_string(),
             },
+            context: None,
         };
 
         let json = serde_json::to_string(&request)?;

--- a/crates/mcpkit-core/src/types/completion.rs
+++ b/crates/mcpkit-core/src/types/completion.rs
@@ -140,6 +140,24 @@ pub struct CompleteResult {
     pub meta: Option<Meta>,
 }
 
+impl From<Completion> for CompleteResult {
+    fn from(completion: Completion) -> Self {
+        Self {
+            completion,
+            meta: None,
+        }
+    }
+}
+
+impl CompleteResult {
+    /// Attach result-level `_meta`.
+    #[must_use]
+    pub fn with_meta(mut self, meta: Meta) -> Self {
+        self.meta = Some(meta);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -355,7 +355,7 @@ where
 
     // Create a context for the request
     let req_id = request.id.clone();
-    let server_caps = state.handler.capabilities();
+    let server_caps = state.effective_capabilities();
     let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
@@ -372,7 +372,7 @@ where
             let init_result = serde_json::json!({
                 "protocolVersion": protocol_version.as_str(),
                 "serverInfo": state.server_info,
-                "capabilities": state.handler.capabilities(),
+                "capabilities": server_caps,
             });
             Response::success(request.id.clone(), init_result)
         }
@@ -426,14 +426,8 @@ where
             }
 
             // Try routing logging/setLevel (gated on the advertised capability)
-            if let Some(result) = route_logging(
-                state.handler.as_ref(),
-                &state.handler.capabilities(),
-                method,
-                params,
-                &ctx,
-            )
-            .await
+            if let Some(result) =
+                route_logging(state.handler.as_ref(), &server_caps, method, params, &ctx).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -8,8 +8,8 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_logging, route_prompts,
-    route_resources, route_tools,
+    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_completion, route_logging,
+    route_prompts, route_resources, route_tools,
 };
 use rocket::http::{ContentType, Header, Status};
 use rocket::request::{FromRequest, Outcome, Request};
@@ -434,6 +434,16 @@ where
                 &ctx,
             )
             .await
+            {
+                return match result {
+                    Ok(value) => Response::success(request.id.clone(), value),
+                    Err(e) => Response::error(request.id.clone(), e.into()),
+                };
+            }
+
+            // Try routing completion/complete (when a completion handler is set)
+            if let Some(result) =
+                route_completion(state.completion.as_deref(), method, params, &ctx).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -59,6 +59,16 @@ where
         self
     }
 
+    /// Register a completion handler and advertise the `completions` capability.
+    #[must_use]
+    pub fn with_completion<C: mcpkit_server::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        self.state = self.state.with_completion(completion);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     #[must_use]
     pub const fn with_cors(mut self) -> Self {

--- a/crates/mcpkit-rocket/src/state.rs
+++ b/crates/mcpkit-rocket/src/state.rs
@@ -102,6 +102,21 @@ impl<H> McpState<H> {
     }
 }
 
+impl<H: mcpkit_server::ServerHandler> McpState<H> {
+    /// The handler's advertised capabilities, plus `completions` when a
+    /// completion handler is registered on this adapter (the handler itself
+    /// cannot know it was registered here, so the adapter advertises it).
+    #[must_use]
+    pub fn effective_capabilities(&self) -> ServerCapabilities {
+        let caps = self.handler.capabilities();
+        if self.completion.is_some() && !caps.has_completions() {
+            caps.with_completions()
+        } else {
+            caps
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mcpkit-rocket/src/state.rs
+++ b/crates/mcpkit-rocket/src/state.rs
@@ -33,6 +33,8 @@ pub struct McpState<H> {
     pub origin_validator: Arc<OriginValidator>,
     /// Page size for `*/list` results; `None` disables pagination.
     pub list_page_size: Option<usize>,
+    /// Optional completion handler for `completion/complete`.
+    pub completion: Option<Arc<dyn mcpkit_server::dispatch::DynCompletionHandler>>,
 }
 
 impl<H> McpState<H>
@@ -49,6 +51,7 @@ where
             sse_sessions: SessionStore::new(),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
+            completion: None,
         }
     }
 
@@ -71,6 +74,7 @@ impl<H> Clone for McpState<H> {
             sse_sessions: self.sse_sessions.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
             list_page_size: self.list_page_size,
+            completion: self.completion.clone(),
         }
     }
 }
@@ -83,6 +87,17 @@ impl<H> McpState<H> {
     #[must_use]
     pub const fn with_list_page_size(mut self, page_size: usize) -> Self {
         self.list_page_size = Some(page_size);
+        self
+    }
+
+    /// Register a completion handler so this adapter answers
+    /// `completion/complete`.
+    #[must_use]
+    pub fn with_completion<C: mcpkit_server::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        self.completion = Some(Arc::new(completion));
         self
     }
 }

--- a/crates/mcpkit-server/src/builder.rs
+++ b/crates/mcpkit-server/src/builder.rs
@@ -324,6 +324,7 @@ where
             tasks: self.tasks,
             capabilities: self.capabilities,
             list_page_size: None,
+            completion: None,
         }
     }
 }
@@ -346,6 +347,10 @@ pub struct Server<H, T, R, P, K> {
     /// Page size for `*/list` results; `None` disables pagination (list
     /// responses return everything, no `nextCursor`).
     pub(crate) list_page_size: Option<usize>,
+    /// Optional completion handler (`completion/complete`). Not a typestate slot
+    /// — completion is a leaf capability registered post-build so it can also be
+    /// carried by the framework adapters, which take a flat combined handler.
+    pub(crate) completion: Option<std::sync::Arc<dyn crate::dispatch::DynCompletionHandler>>,
 }
 
 impl<H, T, R, P, K> Server<H, T, R, P, K>
@@ -368,6 +373,21 @@ where
     #[must_use]
     pub const fn list_page_size(mut self, page_size: usize) -> Self {
         self.list_page_size = Some(page_size);
+        self
+    }
+
+    /// Register a completion handler and advertise the `completions` capability.
+    ///
+    /// This wires `completion/complete` on both the runtime and the framework
+    /// adapters. Completion is a leaf capability, so unlike tools/resources/
+    /// prompts/tasks it is not tracked in the type parameters.
+    #[must_use]
+    pub fn with_completion<C: crate::handler::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        self.completion = Some(std::sync::Arc::new(completion));
+        self.capabilities = self.capabilities.with_completions();
         self
     }
 

--- a/crates/mcpkit-server/src/capability/completions.rs
+++ b/crates/mcpkit-server/src/capability/completions.rs
@@ -6,7 +6,7 @@
 use crate::context::Context;
 use crate::handler::CompletionHandler;
 use mcpkit_core::error::McpError;
-use mcpkit_core::types::completion::{CompleteRequest, Completion, CompletionRef};
+use mcpkit_core::types::completion::{CompleteRequest, CompleteResult, Completion, CompletionRef};
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -130,7 +130,7 @@ impl CompletionHandler for CompletionService {
         &self,
         request: &CompleteRequest,
         ctx: &Context<'_>,
-    ) -> Result<Completion, McpError> {
+    ) -> Result<CompleteResult, McpError> {
         // Dispatch to the registered closure for this (ref, argument). Closures
         // return the matching values; `total`/`has_more` are derived here (a
         // handler that needs a real superset total or paging should implement
@@ -142,10 +142,10 @@ impl CompletionHandler for CompletionService {
         );
 
         let Some(registered) = self.completions.get(&key) else {
-            return Ok(Completion::new(Vec::new()));
+            return Ok(Completion::new(Vec::new()).into());
         };
         let values = (registered.handler)(&request.argument.value, ctx).await?;
-        Ok(Completion::new(values))
+        Ok(Completion::new(values).into())
     }
 }
 
@@ -315,8 +315,8 @@ mod tests {
             .value("py")
             .build();
 
-        let completion = service.complete(&request, &ctx).await?;
-        assert_eq!(completion.values, vec!["python"]);
+        let result = service.complete(&request, &ctx).await?;
+        assert_eq!(result.completion.values, vec!["python"]);
 
         Ok(())
     }

--- a/crates/mcpkit-server/src/capability/completions.rs
+++ b/crates/mcpkit-server/src/capability/completions.rs
@@ -6,9 +6,7 @@
 use crate::context::Context;
 use crate::handler::CompletionHandler;
 use mcpkit_core::error::McpError;
-use mcpkit_core::types::completion::{
-    CompleteRequest, CompleteResult, Completion, CompletionArgument, CompletionRef,
-};
+use mcpkit_core::types::completion::{CompleteRequest, Completion, CompletionRef};
 use std::collections::HashMap;
 use std::future::Future;
 use std::pin::Pin;
@@ -115,44 +113,6 @@ impl CompletionService {
         );
     }
 
-    /// Complete an argument value.
-    pub async fn complete(
-        &self,
-        request: &CompleteRequest,
-        ctx: &Context<'_>,
-    ) -> Result<CompleteResult, McpError> {
-        let ref_type = request.ref_.ref_type().to_string();
-        let ref_value = request.ref_.value().to_string();
-        let arg_name = request.argument.name.clone();
-        let input = &request.argument.value;
-
-        let key = (ref_type, ref_value, arg_name);
-
-        if let Some(registered) = self.completions.get(&key) {
-            let values = (registered.handler)(input, ctx).await?;
-            let total = values.len();
-
-            Ok(CompleteResult {
-                completion: Completion {
-                    values,
-                    total: Some(total),
-                    has_more: Some(false),
-                },
-                meta: None,
-            })
-        } else {
-            // Return empty completions if no handler registered
-            Ok(CompleteResult {
-                completion: Completion {
-                    values: Vec::new(),
-                    total: Some(0),
-                    has_more: Some(false),
-                },
-                meta: None,
-            })
-        }
-    }
-
     /// Check if a completion provider exists.
     #[must_use]
     pub fn has_completion(&self, ref_type: &str, ref_value: &str, arg_name: &str) -> bool {
@@ -166,40 +126,26 @@ impl CompletionService {
 }
 
 impl CompletionHandler for CompletionService {
-    async fn complete_resource(
+    async fn complete(
         &self,
-        partial_uri: &str,
+        request: &CompleteRequest,
         ctx: &Context<'_>,
-    ) -> Result<Vec<String>, McpError> {
-        let request = CompleteRequest {
-            ref_: CompletionRef::resource(partial_uri),
-            argument: CompletionArgument {
-                name: "uri".to_string(),
-                value: partial_uri.to_string(),
-            },
+    ) -> Result<Completion, McpError> {
+        // Dispatch to the registered closure for this (ref, argument). Closures
+        // return the matching values; `total`/`has_more` are derived here (a
+        // handler that needs a real superset total or paging should implement
+        // `CompletionHandler` directly rather than via the closure registry).
+        let key = (
+            request.ref_.ref_type().to_string(),
+            request.ref_.value().to_string(),
+            request.argument.name.clone(),
+        );
+
+        let Some(registered) = self.completions.get(&key) else {
+            return Ok(Completion::new(Vec::new()));
         };
-
-        let result = Self::complete(self, &request, ctx).await?;
-        Ok(result.completion.values)
-    }
-
-    async fn complete_prompt_arg(
-        &self,
-        prompt_name: &str,
-        arg_name: &str,
-        partial_value: &str,
-        ctx: &Context<'_>,
-    ) -> Result<Vec<String>, McpError> {
-        let request = CompleteRequest {
-            ref_: CompletionRef::prompt(prompt_name),
-            argument: CompletionArgument {
-                name: arg_name.to_string(),
-                value: partial_value.to_string(),
-            },
-        };
-
-        let result = Self::complete(self, &request, ctx).await?;
-        Ok(result.completion.values)
+        let values = (registered.handler)(&request.argument.value, ctx).await?;
+        Ok(Completion::new(values))
     }
 }
 
@@ -244,6 +190,7 @@ impl CompleteRequestBuilder {
                 name: self.arg_name,
                 value: self.arg_value,
             },
+            context: None,
         }
     }
 }
@@ -368,8 +315,8 @@ mod tests {
             .value("py")
             .build();
 
-        let result = service.complete(&request, &ctx).await?;
-        assert_eq!(result.completion.values, vec!["python"]);
+        let completion = service.complete(&request, &ctx).await?;
+        assert_eq!(completion.values, vec!["python"]);
 
         Ok(())
     }

--- a/crates/mcpkit-server/src/dispatch.rs
+++ b/crates/mcpkit-server/src/dispatch.rs
@@ -13,11 +13,11 @@
 
 use crate::builder::{NotRegistered, Registered};
 use crate::context::Context;
-use crate::handler::{PromptHandler, ResourceHandler, TaskHandler, ToolHandler};
+use crate::handler::{CompletionHandler, PromptHandler, ResourceHandler, TaskHandler, ToolHandler};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    CancelTaskResult, GetPromptResult, GetTaskResult, Prompt, Resource, ResourceContents,
-    ResourceTemplate, Task, TaskId, Tool, ToolOutput,
+    CancelTaskResult, CompleteRequest, Completion, GetPromptResult, GetTaskResult, Prompt,
+    Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool, ToolOutput,
 };
 use serde_json::Value;
 use std::future::Future;
@@ -194,6 +194,26 @@ impl<K: TaskHandler> DynTaskHandler for K {
         ctx: &'a Context<'_>,
     ) -> BoxFut<'a, Result<Option<CancelTaskResult>, McpError>> {
         Box::pin(TaskHandler::cancel_task(self, id, ctx))
+    }
+}
+
+/// Object-safe form of [`CompletionHandler`].
+pub trait DynCompletionHandler: Send + Sync {
+    /// See [`CompletionHandler::complete`].
+    fn complete<'a>(
+        &'a self,
+        request: &'a CompleteRequest,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Completion, McpError>>;
+}
+
+impl<C: CompletionHandler> DynCompletionHandler for C {
+    fn complete<'a>(
+        &'a self,
+        request: &'a CompleteRequest,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<Completion, McpError>> {
+        Box::pin(CompletionHandler::complete(self, request, ctx))
     }
 }
 

--- a/crates/mcpkit-server/src/dispatch.rs
+++ b/crates/mcpkit-server/src/dispatch.rs
@@ -16,7 +16,7 @@ use crate::context::Context;
 use crate::handler::{CompletionHandler, PromptHandler, ResourceHandler, TaskHandler, ToolHandler};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    CancelTaskResult, CompleteRequest, Completion, GetPromptResult, GetTaskResult, Prompt,
+    CancelTaskResult, CompleteRequest, CompleteResult, GetPromptResult, GetTaskResult, Prompt,
     Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool, ToolOutput,
 };
 use serde_json::Value;
@@ -204,7 +204,7 @@ pub trait DynCompletionHandler: Send + Sync {
         &'a self,
         request: &'a CompleteRequest,
         ctx: &'a Context<'_>,
-    ) -> BoxFut<'a, Result<Completion, McpError>>;
+    ) -> BoxFut<'a, Result<CompleteResult, McpError>>;
 }
 
 impl<C: CompletionHandler> DynCompletionHandler for C {
@@ -212,7 +212,7 @@ impl<C: CompletionHandler> DynCompletionHandler for C {
         &'a self,
         request: &'a CompleteRequest,
         ctx: &'a Context<'_>,
-    ) -> BoxFut<'a, Result<Completion, McpError>> {
+    ) -> BoxFut<'a, Result<CompleteResult, McpError>> {
         Box::pin(CompletionHandler::complete(self, request, ctx))
     }
 }

--- a/crates/mcpkit-server/src/handler.rs
+++ b/crates/mcpkit-server/src/handler.rs
@@ -37,7 +37,7 @@
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    CancelTaskResult, CompleteRequest, Completion, GetPromptResult, GetTaskResult, Prompt,
+    CancelTaskResult, CompleteRequest, CompleteResult, GetPromptResult, GetTaskResult, Prompt,
     Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool, ToolOutput,
 };
 use serde_json::Value;
@@ -256,16 +256,18 @@ pub trait TaskHandler: Send + Sync {
 /// passed so a handler can dispatch on the [`ref`](CompleteRequest::ref_),
 /// read the [`argument`](CompleteRequest::argument) being typed, and use any
 /// previously-resolved [`context`](CompleteRequest::context). Return a
-/// [`Completion`] with the suggested `values` and, if known, a real `total`
-/// and `has_more` (the route layer caps `values` at
-/// [`MAX_COMPLETION_VALUES`](mcpkit_core::types::MAX_COMPLETION_VALUES)).
+/// [`CompleteResult`] — build one from a
+/// [`Completion`](mcpkit_core::types::Completion) via `.into()` for the common
+/// case, or attach result-level `_meta` with [`CompleteResult::with_meta`]. The
+/// route layer caps `values` at
+/// [`MAX_COMPLETION_VALUES`](mcpkit_core::types::MAX_COMPLETION_VALUES).
 pub trait CompletionHandler: Send + Sync {
     /// Produce completion suggestions for the request.
     fn complete(
         &self,
         request: &CompleteRequest,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Completion, McpError>> + Send;
+    ) -> impl Future<Output = Result<CompleteResult, McpError>> + Send;
 }
 
 /// The MCP logging severity, re-exported from core.
@@ -416,7 +418,7 @@ impl<T: CompletionHandler> CompletionHandler for Arc<T> {
         &self,
         request: &CompleteRequest,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Completion, McpError>> + Send {
+    ) -> impl Future<Output = Result<CompleteResult, McpError>> + Send {
         (**self).complete(request, ctx)
     }
 }

--- a/crates/mcpkit-server/src/handler.rs
+++ b/crates/mcpkit-server/src/handler.rs
@@ -37,8 +37,8 @@
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    CancelTaskResult, GetPromptResult, GetTaskResult, Prompt, Resource, ResourceContents,
-    ResourceTemplate, Task, TaskId, Tool, ToolOutput,
+    CancelTaskResult, CompleteRequest, Completion, GetPromptResult, GetTaskResult, Prompt,
+    Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool, ToolOutput,
 };
 use serde_json::Value;
 use std::future::Future;
@@ -249,26 +249,23 @@ pub trait TaskHandler: Send + Sync {
     ) -> impl Future<Output = Result<Option<CancelTaskResult>, McpError>> + Send;
 }
 
-/// Handler for completion suggestions.
+/// Handler for completion suggestions (`completion/complete`).
 ///
-/// Implement this trait to provide autocomplete suggestions for
-/// resource URIs, prompt arguments, etc.
+/// Implement this trait to provide autocomplete suggestions for prompt
+/// arguments and resource-template variables. The full [`CompleteRequest`] is
+/// passed so a handler can dispatch on the [`ref`](CompleteRequest::ref_),
+/// read the [`argument`](CompleteRequest::argument) being typed, and use any
+/// previously-resolved [`context`](CompleteRequest::context). Return a
+/// [`Completion`] with the suggested `values` and, if known, a real `total`
+/// and `has_more` (the route layer caps `values` at
+/// [`MAX_COMPLETION_VALUES`](mcpkit_core::types::MAX_COMPLETION_VALUES)).
 pub trait CompletionHandler: Send + Sync {
-    /// Complete a partial resource URI.
-    fn complete_resource(
+    /// Produce completion suggestions for the request.
+    fn complete(
         &self,
-        partial_uri: &str,
+        request: &CompleteRequest,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Vec<String>, McpError>> + Send;
-
-    /// Complete a partial prompt argument.
-    fn complete_prompt_arg(
-        &self,
-        prompt_name: &str,
-        arg_name: &str,
-        partial_value: &str,
-        ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Vec<String>, McpError>> + Send;
+    ) -> impl Future<Output = Result<Completion, McpError>> + Send;
 }
 
 /// The MCP logging severity, re-exported from core.
@@ -415,22 +412,12 @@ impl<T: TaskHandler> TaskHandler for Arc<T> {
 }
 
 impl<T: CompletionHandler> CompletionHandler for Arc<T> {
-    fn complete_resource(
+    fn complete(
         &self,
-        partial_uri: &str,
+        request: &CompleteRequest,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Vec<String>, McpError>> + Send {
-        (**self).complete_resource(partial_uri, ctx)
-    }
-
-    fn complete_prompt_arg(
-        &self,
-        prompt_name: &str,
-        arg_name: &str,
-        partial_value: &str,
-        ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Vec<String>, McpError>> + Send {
-        (**self).complete_prompt_arg(prompt_name, arg_name, partial_value, ctx)
+    ) -> impl Future<Output = Result<Completion, McpError>> + Send {
+        (**self).complete(request, ctx)
     }
 }
 

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -81,7 +81,7 @@ pub use health::{
     ComponentHealth, HealthChecker, HealthReport, HealthStatus, LivenessResponse, ReadinessResponse,
 };
 pub use metrics::{MethodStats, MetricsSnapshot, ServerMetrics};
-pub use router::{route_logging, route_prompts, route_resources, route_tools};
+pub use router::{route_completion, route_logging, route_prompts, route_resources, route_tools};
 pub use server::{
     RequestRouter, RuntimeConfig, ServerNotifier, ServerRuntime, ServerState, TransportPeer,
 };

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -925,10 +925,12 @@ pub async fn route_completion(
         let req: CompleteRequest = serde_json::from_value(params.clone()).map_err(|e| {
             McpError::invalid_params(method, format!("invalid completion request: {e}"))
         })?;
-        let completion = handler.complete(&req, ctx).await?.capped();
+        // Cap the values to the spec limit while preserving any result-level
+        // `_meta` the handler attached.
+        let CompleteResult { completion, meta } = handler.complete(&req, ctx).await?;
         let result = CompleteResult {
-            completion,
-            meta: None,
+            completion: completion.capped(),
+            meta,
         };
         Ok(serde_json::to_value(result).unwrap_or_default())
     }
@@ -1585,27 +1587,30 @@ mod tests {
         use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
         use mcpkit_core::protocol::RequestId;
         use mcpkit_core::protocol_version::ProtocolVersion;
-        use mcpkit_core::types::{CompleteRequest, Completion};
+        use mcpkit_core::types::{CompleteRequest, CompleteResult, Completion, Meta};
 
-        // Reads `context.arguments.owner` and returns more than the 100-value cap.
+        // Reads `context.arguments.owner`, returns more than the 100-value cap,
+        // and attaches result-level `_meta`.
         struct CtxCompletion;
         impl crate::handler::CompletionHandler for CtxCompletion {
             async fn complete(
                 &self,
                 request: &CompleteRequest,
                 _ctx: &Context<'_>,
-            ) -> Result<Completion, McpError> {
+            ) -> Result<CompleteResult, McpError> {
                 let owner = request
                     .context
                     .as_ref()
                     .and_then(|c| c.arguments.as_ref())
                     .and_then(|a| a.get("owner").cloned())
                     .unwrap_or_default();
-                Ok(Completion {
+                let completion = Completion {
                     values: (0..150).map(|i| format!("{owner}-{i}")).collect(),
                     total: Some(150),
                     has_more: Some(false),
-                })
+                };
+                Ok(CompleteResult::from(completion)
+                    .with_meta(Meta::new().with("origin", serde_json::json!("test"))))
             }
         }
 
@@ -1657,6 +1662,7 @@ mod tests {
         assert_eq!(values[0], "acme-0"); // context.arguments propagated
         assert_eq!(resp["completion"]["hasMore"], true); // forced true by the cap
         assert_eq!(resp["completion"]["total"], 150); // handler total preserved
+        assert_eq!(resp["_meta"]["origin"], "test"); // handler result-level _meta
     }
 
     #[tokio::test]

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -509,9 +509,13 @@ fn parse_list_params(params: Option<&Value>) -> ListParams {
 // =============================================================================
 
 use crate::context::Context;
-use crate::dispatch::{DynPromptHandler, DynResourceHandler, DynTaskHandler, DynToolHandler};
+use crate::dispatch::{
+    DynCompletionHandler, DynPromptHandler, DynResourceHandler, DynTaskHandler, DynToolHandler,
+};
 use mcpkit_core::pagination::paginate;
-use mcpkit_core::types::{CallToolResult, SubscribeRequest, TaskId, UnsubscribeRequest};
+use mcpkit_core::types::{
+    CallToolResult, CompleteRequest, CompleteResult, SubscribeRequest, TaskId, UnsubscribeRequest,
+};
 
 /// Build a paginated list result: the items under `key` plus an optional
 /// `nextCursor`.
@@ -894,6 +898,39 @@ pub async fn route_logging<H: crate::handler::ServerHandler>(
             .map_err(|_| McpError::invalid_params(method, "invalid or missing level"))?;
         handler.set_log_level(req.level, ctx).await?;
         Ok(serde_json::json!({}))
+    }
+    .await;
+    Some(result)
+}
+
+/// Route `completion/complete` to a registered completion handler.
+///
+/// Returns `None` when the method is not `completion/complete` or no completion
+/// handler is registered (so the caller falls through to its normal not-found
+/// handling). Shared by the runtime and the framework adapters so completion is
+/// dispatched consistently wherever the server routes requests. The response's
+/// `values` are capped at [`MAX_COMPLETION_VALUES`](mcpkit_core::types::MAX_COMPLETION_VALUES).
+pub async fn route_completion(
+    handler: Option<&dyn DynCompletionHandler>,
+    method: &str,
+    params: Option<&serde_json::Value>,
+    ctx: &Context<'_>,
+) -> Option<Result<serde_json::Value, McpError>> {
+    if method != methods::COMPLETION_COMPLETE {
+        return None;
+    }
+    let handler = handler?;
+    let result = async {
+        let params = params.ok_or_else(|| McpError::invalid_params(method, "missing params"))?;
+        let req: CompleteRequest = serde_json::from_value(params.clone()).map_err(|e| {
+            McpError::invalid_params(method, format!("invalid completion request: {e}"))
+        })?;
+        let completion = handler.complete(&req, ctx).await?.capped();
+        let result = CompleteResult {
+            completion,
+            meta: None,
+        };
+        Ok(serde_json::to_value(result).unwrap_or_default())
     }
     .await;
     Some(result)
@@ -1539,6 +1576,87 @@ mod tests {
             assert_eq!(resp["taskId"], "t-1", "{method}");
             assert_eq!(resp["_meta"]["origin"], "test", "{method}");
         }
+    }
+
+    #[tokio::test]
+    async fn route_completion_dispatches_with_context_and_caps_values() {
+        use crate::context::NoOpPeer;
+        use crate::dispatch::DynCompletionHandler;
+        use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
+        use mcpkit_core::protocol::RequestId;
+        use mcpkit_core::protocol_version::ProtocolVersion;
+        use mcpkit_core::types::{CompleteRequest, Completion};
+
+        // Reads `context.arguments.owner` and returns more than the 100-value cap.
+        struct CtxCompletion;
+        impl crate::handler::CompletionHandler for CtxCompletion {
+            async fn complete(
+                &self,
+                request: &CompleteRequest,
+                _ctx: &Context<'_>,
+            ) -> Result<Completion, McpError> {
+                let owner = request
+                    .context
+                    .as_ref()
+                    .and_then(|c| c.arguments.as_ref())
+                    .and_then(|a| a.get("owner").cloned())
+                    .unwrap_or_default();
+                Ok(Completion {
+                    values: (0..150).map(|i| format!("{owner}-{i}")).collect(),
+                    total: Some(150),
+                    has_more: Some(false),
+                })
+            }
+        }
+
+        let handler = CtxCompletion;
+        let dyn_handler: &dyn DynCompletionHandler = &handler;
+        let request_id = RequestId::Number(1);
+        let client_caps = ClientCapabilities::default();
+        let server_caps = ServerCapabilities::default();
+        let peer = NoOpPeer;
+        let ctx = Context::new(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            ProtocolVersion::LATEST,
+            &peer,
+        );
+        let params = serde_json::json!({
+            "ref": {"type": "ref/prompt", "name": "p"},
+            "argument": {"name": "a", "value": "x"},
+            "context": {"arguments": {"owner": "acme"}}
+        });
+
+        // No handler registered -> not dispatched (caller yields method-not-found).
+        assert!(
+            route_completion(None, methods::COMPLETION_COMPLETE, Some(&params), &ctx)
+                .await
+                .is_none()
+        );
+        // A non-completion method is not handled here.
+        assert!(
+            route_completion(Some(dyn_handler), methods::TOOLS_LIST, None, &ctx)
+                .await
+                .is_none()
+        );
+
+        // Dispatched: context propagates and the 100-value cap is enforced.
+        let resp = route_completion(
+            Some(dyn_handler),
+            methods::COMPLETION_COMPLETE,
+            Some(&params),
+            &ctx,
+        )
+        .await
+        .expect("routed")
+        .expect("ok");
+        let values = resp["completion"]["values"].as_array().expect("values");
+        assert_eq!(values.len(), 100); // capped from 150
+        assert_eq!(values[0], "acme-0"); // context.arguments propagated
+        assert_eq!(resp["completion"]["hasMore"], true); // forced true by the cap
+        assert_eq!(resp["completion"]["total"], 150); // handler total preserved
     }
 
     #[tokio::test]

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -1243,6 +1243,13 @@ where
         {
             return result;
         }
+        // `completion/complete` is handled when a completion handler is
+        // registered (shared with the HTTP adapters).
+        if let Some(result) =
+            crate::router::route_completion(self.completion.as_deref(), method, params, ctx).await
+        {
+            return result;
+        }
         Err(McpError::method_not_found(method))
     }
 

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -238,7 +238,7 @@ where
 
     // Create a context for the request
     let req_id = request.id.clone();
-    let server_caps = state.handler.capabilities();
+    let server_caps = state.effective_capabilities();
     let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
@@ -255,7 +255,7 @@ where
             let init_result = serde_json::json!({
                 "protocolVersion": protocol_version.as_str(),
                 "serverInfo": state.server_info,
-                "capabilities": state.handler.capabilities(),
+                "capabilities": server_caps,
             });
             Response::success(request.id.clone(), init_result)
         }
@@ -309,14 +309,8 @@ where
             }
 
             // Try routing logging/setLevel (gated on the advertised capability)
-            if let Some(result) = route_logging(
-                state.handler.as_ref(),
-                &state.handler.capabilities(),
-                method,
-                params,
-                &ctx,
-            )
-            .await
+            if let Some(result) =
+                route_logging(state.handler.as_ref(), &server_caps, method, params, &ctx).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -9,8 +9,8 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_logging, route_prompts,
-    route_resources, route_tools,
+    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_completion, route_logging,
+    route_prompts, route_resources, route_tools,
 };
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -317,6 +317,16 @@ where
                 &ctx,
             )
             .await
+            {
+                return match result {
+                    Ok(value) => Response::success(request.id.clone(), value),
+                    Err(e) => Response::error(request.id.clone(), e.into()),
+                };
+            }
+
+            // Try routing completion/complete (when a completion handler is set)
+            if let Some(result) =
+                route_completion(state.completion.as_deref(), method, params, &ctx).await
             {
                 return match result {
                     Ok(value) => Response::success(request.id.clone(), value),

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -104,6 +104,19 @@ where
         self
     }
 
+    /// Register a completion handler and advertise the `completions` capability.
+    #[must_use]
+    pub fn with_completion<C: mcpkit_server::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        // The builder owns the only reference to the state at this point.
+        if let Some(state) = Arc::get_mut(&mut self.state) {
+            state.completion = Some(Arc::new(completion));
+        }
+        self
+    }
+
     fn set_origin_validator(&mut self, validator: OriginValidator) {
         // The builder owns the only reference to the state at this point, so
         // `get_mut` succeeds.

--- a/crates/mcpkit-warp/src/state.rs
+++ b/crates/mcpkit-warp/src/state.rs
@@ -102,6 +102,21 @@ impl<H> McpState<H> {
     }
 }
 
+impl<H: mcpkit_server::ServerHandler> McpState<H> {
+    /// The handler's advertised capabilities, plus `completions` when a
+    /// completion handler is registered on this adapter (the handler itself
+    /// cannot know it was registered here, so the adapter advertises it).
+    #[must_use]
+    pub fn effective_capabilities(&self) -> ServerCapabilities {
+        let caps = self.handler.capabilities();
+        if self.completion.is_some() && !caps.has_completions() {
+            caps.with_completions()
+        } else {
+            caps
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mcpkit-warp/src/state.rs
+++ b/crates/mcpkit-warp/src/state.rs
@@ -33,6 +33,8 @@ pub struct McpState<H> {
     pub origin_validator: Arc<OriginValidator>,
     /// Page size for `*/list` results; `None` disables pagination.
     pub list_page_size: Option<usize>,
+    /// Optional completion handler for `completion/complete`.
+    pub completion: Option<Arc<dyn mcpkit_server::dispatch::DynCompletionHandler>>,
 }
 
 impl<H> McpState<H>
@@ -49,6 +51,7 @@ where
             sse_sessions: SessionStore::new(),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
+            completion: None,
         }
     }
 
@@ -71,6 +74,7 @@ impl<H> Clone for McpState<H> {
             sse_sessions: self.sse_sessions.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
             list_page_size: self.list_page_size,
+            completion: self.completion.clone(),
         }
     }
 }
@@ -83,6 +87,17 @@ impl<H> McpState<H> {
     #[must_use]
     pub const fn with_list_page_size(mut self, page_size: usize) -> Self {
         self.list_page_size = Some(page_size);
+        self
+    }
+
+    /// Register a completion handler so this adapter answers
+    /// `completion/complete`.
+    #[must_use]
+    pub fn with_completion<C: mcpkit_server::CompletionHandler + 'static>(
+        mut self,
+        completion: C,
+    ) -> Self {
+        self.completion = Some(Arc::new(completion));
         self
     }
 }


### PR DESCRIPTION
Closes #113. Last core-fidelity item. Scope grew beyond the issue title (see the finding below); confirmed with review as option B.

## The finding
The issue framed #113 as "`context` is unmodeled and `total`/`hasMore` are no-ops". Tracing the actual dispatch showed the deeper problem: **`completion/complete` is never dispatched at all.** The runtime `route()` and all four adapters route only tools/resources/prompts/logging; there is no `route_completion`, no builder slot, and `parse_request` (the only thing that builds a completion `ParsedRequest`) is test-only. So `CompletionCapability`/`CompletionHandler`/`CompletionService` existed but a client calling `completion/complete` got **method-not-found** — the #107/#108 "advertised-but-non-functional" pattern, with *zero* wired paths. A types-only fix would have polished unreachable code.

## Change (option B: make completion work + spec-complete, one PR)
- **Dispatch:** a shared `route_completion` helper, gated on a registered handler, invoked from `Server::route` and all four adapters (axum/actix/warp/rocket) — completion now works everywhere the server routes requests.
- **Registration:** `Server::with_completion(..)` (runtime) and `McpState::with_completion(..)` (adapters). Held as an optional field, **not** a typestate slot — that's the only shape the adapters (which take a flat `ServerHandler + ToolHandler + ResourceHandler + PromptHandler`) can carry, so the runtime and adapters stay consistent.
- **`context`:** `CompleteRequest` gains the spec's `context { arguments?: {String:String} }`.
- **100-value cap:** enforced at the route layer (`MAX_COMPLETION_VALUES`) — oversized handler output is truncated and `hasMore` forced `true`, so the wire is always valid. `total`/`hasMore` now omit when `None`.
- **Client:** `Client::complete(CompleteRequest)` sends an arbitrary request incl. `context`; the existing `complete_prompt_argument`/`complete_resource_argument` delegate to it (they already returned `CompleteResult`, so `total`/`hasMore`/`_meta` are preserved).
- **Breaking:** `CompletionHandler` collapses from `complete_resource`/`complete_prompt_arg` (each `-> Vec<String>`) to a single `complete(&CompleteRequest) -> Completion` — the only shape that carries `ref` + `argument` + `context` and returns a real `total`/`hasMore`. It was orphaned (never dispatched), so blast radius is tiny. `CompletionService` keeps its ergonomic closure registry and implements the new trait.

## Review requirements (all addressed)
Added `context`; redesigned around the full request shape; enforce the 100-cap at the route layer; one shared `route_completion` into `Server::route` + all four adapters; client can pass context; and E2E tests. The adapter combined-handler bound (no `TaskHandler`/`CompletionHandler` on it) is exactly why registration is an optional field, not a bound.

## Tests
- Core: `capped()` truncation + `has_more` forcing; `context` round-trip and omission.
- Router: `route_completion` dispatches with context propagation, enforces the 100-cap, and returns `None` (→ method-not-found) with no handler / wrong method.
- Axum E2E (`tests/completion.rs`, mirroring the #108 logging regression test): `completion/complete` is answered through the HTTP adapter with context, **and** is method-not-found without a registered handler.

## Deferred (unchanged by this PR)
`CompletionService`'s closure registry still returns `Vec<String>` (context-/total-aware behavior is for direct `CompletionHandler` impls) — documented, not a regression.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --all-features --locked` (1310 tests, 0 failures) all green.