### PR TITLE
feat(server): dispatch inbound client notifications to ServerHandler hooks (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Inbound client-notification dispatch to `ServerHandler` hooks (#141). The stdio
+  `ServerRuntime` previously logged `notifications/initialized` and never invoked
+  `ServerHandler::on_initialized` — the hook was orphaned — and had no way to react
+  to `notifications/roots/list_changed`. Now:
+  - `RequestRouter` gains `route_notification` (default no-op), the
+    notification-side analogue of `route()`, so the runtime can dispatch inbound
+    notifications to the typed server through the same abstraction it uses for
+    requests.
+  - `notifications/initialized` invokes `on_initialized`; `notifications/roots/list_changed`
+    invokes the new `ServerHandler::on_roots_list_changed(&self, ctx)` hook
+    (default no-op, forwarded through `Arc<T>` and `ValidatingToolHandler`), gated
+    on the client having advertised the `roots` capability.
+  - A hook receives a notification-scoped `Context` (`Context::for_notification`)
+    that is fully outbound-capable — e.g. `on_roots_list_changed` may call
+    `ctx.list_roots()` to re-fetch. Notifications carry no request id, so the
+    context's `request_id` is a documented sentinel, not a real JSON-RPC id.
+  - Notification hooks now run **concurrently** with the receive loop (like
+    requests), so a hook that issues its own server-to-client request no longer
+    deadlocks the loop waiting for its own reply.
+  - `notifications/cancelled` remains a runtime concern (the cancellation
+    registry), not a handler hook.
+  - Adapter notification-hook dispatch (HTTP) is tracked separately in
+    [#153](https://github.com/praxiomlabs/mcpkit/issues/153), as it is entangled
+    with the adapters' server-initiated-request path
+    ([#141](https://github.com/praxiomlabs/mcpkit/issues/141)).
 - Functional, spec-complete argument completion (#113). `completion/complete`
   was advertised (`with_completions()`), had a `CompletionHandler` trait, a
   `CompletionService`, and client methods — but **nothing dispatched it**: the

--- a/crates/mcpkit-server/src/context.rs
+++ b/crates/mcpkit-server/src/context.rs
@@ -220,6 +220,12 @@ pub struct Context<'a> {
     cancel: CancellationToken,
 }
 
+/// Sentinel [`RequestId`] for notification-scoped contexts (see
+/// [`Context::for_notification`]). Notifications have no request id; this is not
+/// a real JSON-RPC id.
+static NOTIFICATION_REQUEST_ID: std::sync::LazyLock<RequestId> =
+    std::sync::LazyLock::new(|| RequestId::String("__notification__".to_string()));
+
 impl<'a> Context<'a> {
     /// Create a new context with all required references.
     #[must_use]
@@ -261,6 +267,32 @@ impl<'a> Context<'a> {
             protocol_version,
             peer,
             cancel,
+        }
+    }
+
+    /// Create a context for handling an inbound client notification.
+    ///
+    /// Notifications carry no JSON-RPC request id, so
+    /// [`request_id`](Self::request_id) is a documented sentinel
+    /// (`__notification__`) that must **not** be treated as a real id. The
+    /// context is still outbound-capable: a hook may call
+    /// [`list_roots`](Self::list_roots) or send notifications, and those
+    /// server-to-client requests allocate their own ids via the peer.
+    #[must_use]
+    pub fn for_notification(
+        client_caps: &'a ClientCapabilities,
+        server_caps: &'a ServerCapabilities,
+        protocol_version: ProtocolVersion,
+        peer: &'a dyn Peer,
+    ) -> Self {
+        Self {
+            request_id: &NOTIFICATION_REQUEST_ID,
+            progress_token: None,
+            client_caps,
+            server_caps,
+            protocol_version,
+            peer,
+            cancel: CancellationToken::new(),
         }
     }
 

--- a/crates/mcpkit-server/src/handler.rs
+++ b/crates/mcpkit-server/src/handler.rs
@@ -82,6 +82,15 @@ pub trait ServerHandler: Send + Sync {
         async {}
     }
 
+    /// Called when the client sends `notifications/roots/list_changed`.
+    ///
+    /// Only invoked when the client advertised the `roots` capability. A good
+    /// place to invalidate cached roots and re-request them via
+    /// [`Context::list_roots`]. The default is a no-op.
+    fn on_roots_list_changed(&self, _ctx: &Context<'_>) -> impl Future<Output = ()> + Send {
+        async {}
+    }
+
     /// Called when the connection is about to be closed.
     fn on_shutdown(&self) -> impl Future<Output = ()> + Send {
         async {}
@@ -301,6 +310,10 @@ impl<T: ServerHandler> ServerHandler for Arc<T> {
 
     fn on_initialized(&self, ctx: &Context<'_>) -> impl Future<Output = ()> + Send {
         (**self).on_initialized(ctx)
+    }
+
+    fn on_roots_list_changed(&self, ctx: &Context<'_>) -> impl Future<Output = ()> + Send {
+        (**self).on_roots_list_changed(ctx)
     }
 
     fn on_shutdown(&self) -> impl Future<Output = ()> + Send {

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -510,26 +510,51 @@ enum TaskBegin {
 /// Make progress on in-flight requests and background task executions, returning
 /// any new background work an in-flight request just produced. Background tasks
 /// are polled here but do not count against the request concurrency limit.
-async fn drive_sets<F1, F2>(
+async fn drive_sets<F1, F2, F3>(
     in_flight: &mut futures::stream::FuturesUnordered<F1>,
     background: &mut futures::stream::FuturesUnordered<F2>,
+    notifications: &mut futures::stream::FuturesUnordered<F3>,
 ) -> Option<BackgroundExec>
 where
     F1: std::future::Future<Output = Option<BackgroundExec>>,
     F2: std::future::Future<Output = ()>,
+    F3: std::future::Future<Output = Result<(), McpError>>,
 {
     use futures::future::{Either, select};
     use futures::stream::StreamExt;
-    if in_flight.is_empty() {
-        background.next().await;
-        return None;
-    }
-    if background.is_empty() {
-        return in_flight.next().await.flatten();
-    }
-    match select(in_flight.next(), background.next()).await {
-        Either::Left((res, _)) => res.flatten(),
-        Either::Right((_finished, _)) => None,
+    use std::future::pending;
+    use std::pin::pin;
+
+    // Each set is polled only when non-empty; an empty set parks forever
+    // (`pending`) so it never wins the race or busy-loops. Only `in_flight` can
+    // surface a `BackgroundExec` (a request that spun off task-augmented work).
+    let requests = pin!(async {
+        if in_flight.is_empty() {
+            pending::<Option<BackgroundExec>>().await
+        } else {
+            in_flight.next().await.flatten()
+        }
+    });
+    let tasks = pin!(async {
+        if background.is_empty() {
+            pending::<()>().await;
+        } else {
+            background.next().await;
+        }
+    });
+    let notifs = pin!(async {
+        if notifications.is_empty() {
+            pending::<()>().await;
+        } else if let Some(Err(e)) = notifications.next().await {
+            tracing::error!(error = %e, "Error handling notification");
+        }
+    });
+    let unit = pin!(async {
+        let _ = select(tasks, notifs).await;
+    });
+    match select(requests, unit).await {
+        Either::Left((res, _)) => res,
+        Either::Right(((), _)) => None,
     }
 }
 
@@ -565,7 +590,8 @@ where
     /// reached, no new messages are accepted until an in-flight request
     /// completes (backpressure). Each request runs with panic isolation, so a
     /// panicking handler returns a JSON-RPC internal error instead of tearing
-    /// down the connection. Notifications are handled inline.
+    /// down the connection. Notification hooks run concurrently too, so a hook
+    /// that issues its own server-to-client request does not deadlock the loop.
     pub async fn run(&self) -> Result<(), McpError> {
         use futures::future::{Either, select};
         use futures::stream::{FuturesUnordered, StreamExt};
@@ -584,6 +610,10 @@ where
         // Task-augmented tool executions run here, off the request concurrency
         // limit, so long-running tasks never starve normal request handling.
         let mut background = FuturesUnordered::new();
+        // Notification hooks run here so a hook that makes its own server-to-client
+        // request (e.g. `on_roots_list_changed` calling `ctx.list_roots()`) does
+        // not block the loop from receiving that request's reply.
+        let mut notifications = FuturesUnordered::new();
         // Requests received while at the concurrency limit. They run as soon as a
         // slot frees. Crucially the loop keeps receiving in the meantime, so a
         // handler parked on its own server-initiated request (which needs an
@@ -602,14 +632,19 @@ where
             // Always receive (so responses to our own outbound requests are
             // routed even when every slot is parked) while making progress on
             // in-flight requests and background tasks.
-            let step = if in_flight.is_empty() && background.is_empty() {
+            let step = if in_flight.is_empty() && background.is_empty() && notifications.is_empty()
+            {
                 match self.transport.recv().await {
                     Ok(opt) => Step::Message(opt),
                     Err(e) => break Err(e.into()),
                 }
             } else {
                 let recv = std::pin::pin!(self.transport.recv());
-                let progress = std::pin::pin!(drive_sets(&mut in_flight, &mut background));
+                let progress = std::pin::pin!(drive_sets(
+                    &mut in_flight,
+                    &mut background,
+                    &mut notifications
+                ));
                 match select(recv, progress).await {
                     Either::Left((Ok(opt), _)) => Step::Message(opt),
                     Either::Left((Err(e), _)) => break Err(e.into()),
@@ -631,9 +666,10 @@ where
                     }
                 }
                 Step::Message(Some(Message::Notification(notification))) => {
-                    if let Err(e) = self.handle_notification(notification).await {
-                        tracing::error!(error = %e, "Error handling notification");
-                    }
+                    // Handle concurrently so a hook doing a server-to-client
+                    // request does not deadlock the receive loop. Errors are
+                    // logged when the future completes in `drive_sets`.
+                    notifications.push(self.handle_notification(notification));
                 }
                 Step::Message(Some(Message::Response(response))) => {
                     // A reply to a server-initiated request (elicitation, etc.).
@@ -653,6 +689,7 @@ where
         self.state.fail_pending_requests();
         while in_flight.next().await.is_some() {}
         while background.next().await.is_some() {}
+        while notifications.next().await.is_some() {}
 
         if let Err(ref err) = outcome {
             tracing::error!(error = %err, "Transport error");
@@ -1050,34 +1087,50 @@ where
 
         tracing::debug!(method = %method, "Handling notification");
 
-        match method {
-            "notifications/initialized" => {
-                tracing::info!("Client sent initialized notification");
-                Ok(())
+        // `notifications/cancelled` is a runtime concern — it trips the
+        // cancellation registry for an in-flight request, not a handler hook.
+        if method == "notifications/cancelled" {
+            if let Some(request_id) = notification
+                .params
+                .as_ref()
+                .and_then(|p| {
+                    serde_json::from_value::<mcpkit_core::types::CancelledNotificationParams>(
+                        p.clone(),
+                    )
+                    .ok()
+                })
+                .and_then(|c| c.request_id)
+            {
+                // Match the canonical id form `route_request` registers with,
+                // so numeric and string request ids both resolve.
+                self.state.cancel_request(&request_id.to_string());
             }
-            "notifications/cancelled" => {
-                if let Some(request_id) = notification
-                    .params
-                    .as_ref()
-                    .and_then(|p| {
-                        serde_json::from_value::<mcpkit_core::types::CancelledNotificationParams>(
-                            p.clone(),
-                        )
-                        .ok()
-                    })
-                    .and_then(|c| c.request_id)
-                {
-                    // Match the canonical id form `route_request` registers with,
-                    // so numeric and string request ids both resolve.
-                    self.state.cancel_request(&request_id.to_string());
-                }
-                Ok(())
-            }
-            _ => {
-                tracing::debug!(method = %method, "Ignoring unknown notification");
-                Ok(())
-            }
+            return Ok(());
         }
+
+        // Everything else is dispatched to the server's notification hooks with a
+        // notification-scoped, outbound-capable context (so a hook may call e.g.
+        // `ctx.list_roots()`). Unhandled methods are a no-op in `route_notification`.
+        let client_caps = self.state.client_caps();
+        let protocol_version = self
+            .state
+            .protocol_version()
+            .unwrap_or(ProtocolVersion::LATEST);
+        let peer = TransportPeer::with_outbound(
+            self.transport.clone(),
+            self.state.clone(),
+            self.config.outbound_request_timeout,
+        );
+        let ctx = Context::for_notification(
+            &client_caps,
+            &self.state.server_caps,
+            protocol_version,
+            &peer,
+        );
+        self.server
+            .route_notification(method, notification.params.as_ref(), &ctx)
+            .await;
+        Ok(())
     }
 }
 
@@ -1137,6 +1190,18 @@ pub trait RequestRouter: Send + Sync {
         params: Option<&serde_json::Value>,
         ctx: &Context<'_>,
     ) -> Result<serde_json::Value, McpError>;
+
+    /// Dispatch an inbound client notification (e.g. `notifications/initialized`
+    /// or `notifications/roots/list_changed`) to the server's lifecycle hooks.
+    /// Analogous to [`route`](Self::route) but for notifications — there is no
+    /// reply. Defaults to a no-op.
+    async fn route_notification(
+        &self,
+        _method: &str,
+        _params: Option<&serde_json::Value>,
+        _ctx: &Context<'_>,
+    ) {
+    }
 
     /// The task-augmentation support a tool declares (`Tool.execution.taskSupport`),
     /// used to gate task-augmented `tools/call`. Defaults to `Forbidden`.
@@ -1203,6 +1268,23 @@ where
 {
     fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
         self.handler().server_info()
+    }
+
+    async fn route_notification(
+        &self,
+        method: &str,
+        _params: Option<&serde_json::Value>,
+        ctx: &Context<'_>,
+    ) {
+        match method {
+            "notifications/initialized" => self.handler().on_initialized(ctx).await,
+            // Only meaningful from a client that advertised the `roots`
+            // capability; ignore it otherwise.
+            "notifications/roots/list_changed" if ctx.client_caps.has_roots() => {
+                self.handler().on_roots_list_changed(ctx).await;
+            }
+            _ => {}
+        }
     }
 
     async fn route(
@@ -1525,6 +1607,153 @@ mod tests {
             Message::Response(r) => r,
             other => panic!("expected response, got {other:?}"),
         }
+    }
+
+    fn notif_msg(method: &str) -> Message {
+        Message::Notification(Notification::with_params(
+            method.to_string(),
+            serde_json::json!({}),
+        ))
+    }
+
+    /// Records lifecycle-hook invocations; `on_roots_list_changed` exercises the
+    /// notification-scoped context by calling `ctx.list_roots()`.
+    struct RootsHookHandler {
+        initialized: Arc<std::sync::atomic::AtomicBool>,
+        roots_changed: Arc<std::sync::atomic::AtomicUsize>,
+        seen_roots: Arc<std::sync::Mutex<Vec<mcpkit_core::types::Root>>>,
+        done: Arc<Notify>,
+    }
+
+    impl crate::handler::ServerHandler for RootsHookHandler {
+        fn server_info(&self) -> ServerInfo {
+            ServerInfo::new("roots-test", "0.0.0")
+        }
+        async fn on_initialized(&self, _ctx: &Context<'_>) {
+            self.initialized
+                .store(true, std::sync::atomic::Ordering::SeqCst);
+            self.done.notify_one();
+        }
+        async fn on_roots_list_changed(&self, ctx: &Context<'_>) {
+            self.roots_changed
+                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            if let Ok(roots) = ctx.list_roots().await {
+                *self.seen_roots.lock().expect("lock") = roots;
+            }
+            self.done.notify_one();
+        }
+    }
+
+    #[tokio::test]
+    async fn notification_hooks_fire_and_on_roots_list_changed_can_list_roots() {
+        use crate::builder::ServerBuilder;
+        use mcpkit_core::capability::ClientCapabilities;
+        use mcpkit_core::types::{ListRootsResult, Root};
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        let initialized = Arc::new(AtomicBool::new(false));
+        let roots_changed = Arc::new(AtomicUsize::new(0));
+        let seen = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let done = Arc::new(Notify::new());
+        let handler = RootsHookHandler {
+            initialized: initialized.clone(),
+            roots_changed: roots_changed.clone(),
+            seen_roots: seen.clone(),
+            done: done.clone(),
+        };
+
+        let (client, server_tr) = MemoryTransport::pair();
+        let runtime = ServerRuntime::new(ServerBuilder::new(handler).build(), server_tr);
+        runtime.state().set_initialized();
+        runtime
+            .state()
+            .set_client_caps(ClientCapabilities::default().with_roots());
+        let handle = tokio::spawn(async move { runtime.run().await });
+
+        // `on_initialized` fires on notifications/initialized.
+        client
+            .send(notif_msg("notifications/initialized"))
+            .await
+            .expect("send");
+        timeout(Duration::from_secs(2), done.notified())
+            .await
+            .expect("on_initialized never ran");
+        assert!(initialized.load(Ordering::SeqCst));
+
+        // `on_roots_list_changed` fires and calls `ctx.list_roots()`, which issues
+        // a server->client roots/list request the loop must service concurrently.
+        client
+            .send(notif_msg("notifications/roots/list_changed"))
+            .await
+            .expect("send");
+        let roots_req = match timeout(Duration::from_secs(2), client.recv())
+            .await
+            .expect("no roots/list request")
+            .expect("recv ok")
+            .expect("some message")
+        {
+            Message::Request(r) => r,
+            other => panic!("expected roots/list, got {other:?}"),
+        };
+        assert_eq!(roots_req.method.as_ref(), "roots/list");
+        let result = ListRootsResult {
+            roots: vec![Root::new("file:///work")],
+            meta: None,
+        };
+        client
+            .send(Message::Response(Response::success(
+                roots_req.id.clone(),
+                serde_json::to_value(result).expect("serialize"),
+            )))
+            .await
+            .expect("send");
+
+        timeout(Duration::from_secs(2), done.notified())
+            .await
+            .expect("on_roots_list_changed never finished");
+        assert_eq!(roots_changed.load(Ordering::SeqCst), 1);
+        assert_eq!(seen.lock().expect("lock")[0].uri, "file:///work");
+
+        drop(client);
+        let _ = timeout(Duration::from_secs(2), handle).await;
+    }
+
+    #[tokio::test]
+    async fn roots_list_changed_is_ignored_without_roots_capability() {
+        use crate::builder::ServerBuilder;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+
+        let roots_changed = Arc::new(AtomicUsize::new(0));
+        let handler = RootsHookHandler {
+            initialized: Arc::new(AtomicBool::new(false)),
+            roots_changed: roots_changed.clone(),
+            seen_roots: Arc::new(std::sync::Mutex::new(Vec::new())),
+            done: Arc::new(Notify::new()),
+        };
+
+        let (client, server_tr) = MemoryTransport::pair();
+        // No `set_client_caps` with roots -> the client did not advertise roots.
+        let runtime = ServerRuntime::new(ServerBuilder::new(handler).build(), server_tr);
+        runtime.state().set_initialized();
+        let handle = tokio::spawn(async move { runtime.run().await });
+
+        client
+            .send(notif_msg("notifications/roots/list_changed"))
+            .await
+            .expect("send");
+        // A ping round-trips; the reply must be the ping response, never a
+        // roots/list request (which would mean the gated hook wrongly ran).
+        client.send(req("ping", 1)).await.expect("send");
+        let resp = next_response(&client).await;
+        assert_eq!(resp.id, RequestId::Number(1));
+        assert_eq!(
+            roots_changed.load(Ordering::SeqCst),
+            0,
+            "on_roots_list_changed must not fire without the roots capability"
+        );
+
+        drop(client);
+        let _ = timeout(Duration::from_secs(2), handle).await;
     }
 
     #[tokio::test]

--- a/crates/mcpkit-server/src/validation.rs
+++ b/crates/mcpkit-server/src/validation.rs
@@ -226,6 +226,10 @@ impl<H: ServerHandler> ServerHandler for ValidatingToolHandler<H> {
         self.inner.on_initialized(ctx)
     }
 
+    fn on_roots_list_changed(&self, ctx: &Context<'_>) -> impl Future<Output = ()> + Send {
+        self.inner.on_roots_list_changed(ctx)
+    }
+
     fn on_shutdown(&self) -> impl Future<Output = ()> + Send {
         self.inner.on_shutdown()
     }


### PR DESCRIPTION
Closes #141. First Phase-2 (server functional completeness) item. Runtime-only scope; adapter dispatch tracked in #153.

## Problem
The stdio `ServerRuntime`'s `handle_notification` only logged `notifications/initialized` and handled `notifications/cancelled`. So **`ServerHandler::on_initialized` was orphaned** (defined + forwarded, never invoked) and there was no way to react to `notifications/roots/list_changed`. `handle_notification` lives in the generic `impl<S: RequestRouter>` block and only sees the server through `RequestRouter`, which had no notification path.

## Change
- **`RequestRouter::route_notification`** (default no-op) — the notification-side analogue of `route()`, so the runtime dispatches inbound notifications to the typed server the same way it dispatches requests. The default keeps the ~8 mock `RequestRouter` impls compiling untouched.
- **`Server<..>` dispatches**: `notifications/initialized` → `on_initialized`; `notifications/roots/list_changed` → the new **`ServerHandler::on_roots_list_changed(&self, ctx)`** hook (default no-op, forwarded through `Arc<T>` and `ValidatingToolHandler`), **gated on `ctx.client_caps.has_roots()`**.
- **`Context::for_notification`** — a notification-scoped, outbound-capable context. `on_roots_list_changed` can call `ctx.list_roots()` to re-fetch. Notifications have no request id, so `request_id` is a documented sentinel (`"__notification__"`), not a real JSON-RPC id (chose this over making `Context.request_id` an `Option`, which would churn every call site).
- **Concurrent notification handling**: hooks now run in a third `FuturesUnordered` set alongside requests/tasks, so a hook that issues its own server→client request doesn't deadlock the receive loop (the loop must stay free to read the reply — the same reason requests already use `in_flight`).
- `notifications/cancelled` stays a runtime concern (cancellation registry), not a handler hook.

## Scope (per review)
Runtime (stdio) only. The HTTP adapters return `202 Accepted` for notifications and wiring `on_roots_list_changed` there needs the SSE server→client path — filed as **#153** so the parity gap is tracked, rather than half-wired here.

## Tests
- `on_initialized` fires on `notifications/initialized`.
- `on_roots_list_changed` fires **and successfully calls `ctx.list_roots()`** through the runtime over `MemoryTransport` (mock client replies with `ListRootsResult`) — validates the notification-scoped context **and** the concurrent outbound path (the actual hard part, not just a counter).
- `roots/list_changed` is **ignored** when the client did not advertise roots (proves the gate; asserts no hook fire and no stray `roots/list` request).

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --all-features --locked` (1313 tests, 0 failures) all green.