### PR TITLE
feat(adapters): task-augmented tools/call + tasks/* on the HTTP adapters (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Task-augmented `tools/call` and `tasks/*` on the HTTP adapters (#122). The
+  axum/actix/warp/rocket adapters dispatched `tools/call` synchronously and
+  ignored a `task` field, so task execution was runtime-only. Now:
+  - The stdio task machinery is factored into executor-agnostic shared helpers
+    (`router::{tool_task_support, call_tool_json, run_augmented_tool,
+    begin_augmented_task}`, `capability::tasks::route_task_store`) reused by both
+    the runtime and the adapters.
+  - Each adapter intercepts a task-augmented `tools/call`: it gates on the tool's
+    declared `taskSupport`, creates the task, replies with `CreateTaskResult`
+    immediately, and runs the tool in the background via the adapter's own
+    `tokio::spawn`; later `tasks/get`/`tasks/result`/`tasks/cancel` are served
+    from the store.
+  - **Per-session isolation:** each MCP session owns its task store (mirroring the
+    stdio runtime's per-connection store), so one session cannot read or cancel
+    another's tasks.
+  - **Limitations (documented):** an adapter background task runs with a
+    `NoOpPeer`, so it cannot make server-to-client requests (elicitation/sampling)
+    and its notifications/logging/progress are dropped; cancellation via
+    `tasks/cancel` still trips the tool's `ctx.cancelled()`. Background tasks are
+    fire-and-forget (no graceful shutdown drain)
+    ([#122](https://github.com/praxiomlabs/mcpkit/issues/122)).
 - Inbound client-notification dispatch to `ServerHandler` hooks (#141). The stdio
   `ServerRuntime` previously logged `notifications/initialized` and never invoked
   `ServerHandler::on_initialized` — the hook was orphaned — and had no way to react

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,9 +1063,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -10,11 +10,14 @@ use mcpkit_core::auth::VerifiedUser;
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
+use mcpkit_server::capability::tasks::{TaskManager, route_task_store};
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_completion, route_logging,
-    route_prompts, route_resources, route_tools,
+    AugmentedTaskOutcome, PromptHandler, ResourceHandler, ServerHandler, ToolHandler,
+    begin_augmented_task, route_completion, route_logging, route_prompts, route_resources,
+    route_tools,
 };
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
@@ -128,13 +131,21 @@ where
                 .as_ref()
                 .and_then(|s| s.protocol_version)
                 .unwrap_or(ProtocolVersion::LATEST);
+            // This session's task store (per-session isolation for `tasks/*`).
+            let task_store = session.as_ref().map(|s| s.tasks.clone());
             let client_caps = session
                 .and_then(|s| s.client_capabilities)
                 .unwrap_or_default();
 
             // Create a basic response using the handler's capabilities
-            let response =
-                create_response_for_request(&state, &request, protocol_version, &client_caps).await;
+            let response = create_response_for_request(
+                &state,
+                &request,
+                protocol_version,
+                &client_caps,
+                task_store.as_ref(),
+            )
+            .await;
 
             let body = serde_json::to_string(&Message::Response(response))
                 .map_err(ExtensionError::Serialization)?;
@@ -192,6 +203,7 @@ async fn create_response_for_request<H>(
     request: &mcpkit_core::protocol::Request,
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
+    task_store: Option<&Arc<TaskManager>>,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -226,6 +238,37 @@ where
             Response::success(request.id.clone(), init_result)
         }
         _ => {
+            // Task-augmented tools/call and tasks/* are served from this
+            // session's own task store (per-session isolation).
+            if let Some(store) = task_store {
+                if method == "tools/call" {
+                    match begin_augmented_task(
+                        state.handler.clone(),
+                        store,
+                        params,
+                        client_caps.clone(),
+                        server_caps.clone(),
+                        protocol_version,
+                    )
+                    .await
+                    {
+                        AugmentedTaskOutcome::Started(create_result, fut) => {
+                            tokio::spawn(fut);
+                            return Response::success(request.id.clone(), create_result);
+                        }
+                        AugmentedTaskOutcome::Rejected(e) => {
+                            return Response::error(request.id.clone(), e.into());
+                        }
+                        AugmentedTaskOutcome::NotApplicable => {}
+                    }
+                } else if let Some(result) = route_task_store(store, method, params) {
+                    return match result {
+                        Ok(value) => Response::success(request.id.clone(), value),
+                        Err(e) => Response::error(request.id.clone(), e.into()),
+                    };
+                }
+            }
+
             // Try routing to tools
             if let Some(result) = route_tools(
                 state.handler.as_ref(),

--- a/crates/mcpkit-actix/src/session.rs
+++ b/crates/mcpkit-actix/src/session.rs
@@ -39,6 +39,10 @@ pub struct Session {
     /// The verified user this session is bound to, if any. Once bound, the
     /// session may only be used by the same user (see [`SessionBindingError`]).
     pub user: Option<VerifiedUser>,
+    /// This session's task store for task-augmented `tools/call`. Scoped per
+    /// session so one session cannot read or cancel another's tasks (matching
+    /// the stdio runtime's per-connection store).
+    pub tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
 }
 
 impl Session {
@@ -60,6 +64,7 @@ impl Session {
             client_capabilities: None,
             protocol_version: None,
             user,
+            tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
         }
     }
 

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -27,10 +27,12 @@ use mcpkit_core::auth::VerifiedUser;
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
+use mcpkit_server::capability::tasks::{TaskManager, route_task_store};
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_completion, route_logging,
-    route_prompts, route_resources, route_tools,
+    AugmentedTaskOutcome, PromptHandler, ResourceHandler, ServerHandler, ToolHandler,
+    begin_augmented_task, route_completion, route_logging, route_prompts, route_resources,
+    route_tools,
 };
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -150,14 +152,22 @@ where
                 .as_ref()
                 .and_then(|s| s.protocol_version)
                 .unwrap_or(ProtocolVersion::LATEST);
+            // This session's task store (per-session isolation for `tasks/*`).
+            let task_store = session.as_ref().map(|s| s.tasks.clone());
             let client_caps = session
                 .and_then(|s| s.client_capabilities)
                 .unwrap_or_default();
 
             // Create a basic response using the handler's capabilities
             // In a full implementation, this would route to the handler's methods
-            let response =
-                create_response_for_request(&state, &request, protocol_version, &client_caps).await;
+            let response = create_response_for_request(
+                &state,
+                &request,
+                protocol_version,
+                &client_caps,
+                task_store.as_ref(),
+            )
+            .await;
 
             match serde_json::to_string(&Message::Response(response)) {
                 Ok(body) => (
@@ -221,6 +231,7 @@ async fn create_response_for_request<H>(
     request: &mcpkit_core::protocol::Request,
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
+    task_store: Option<&Arc<TaskManager>>,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -255,6 +266,38 @@ where
             Response::success(request.id.clone(), init_result)
         }
         _ => {
+            // Task-augmented tools/call and tasks/* are served from this
+            // session's own task store (per-session isolation).
+            if let Some(store) = task_store {
+                if method == "tools/call" {
+                    match begin_augmented_task(
+                        state.handler.clone(),
+                        store,
+                        params,
+                        client_caps.clone(),
+                        server_caps.clone(),
+                        protocol_version,
+                    )
+                    .await
+                    {
+                        AugmentedTaskOutcome::Started(create_result, fut) => {
+                            tokio::spawn(fut);
+                            return Response::success(request.id.clone(), create_result);
+                        }
+                        AugmentedTaskOutcome::Rejected(e) => {
+                            return Response::error(request.id.clone(), e.into());
+                        }
+                        // Not task-augmented — fall through to the normal path.
+                        AugmentedTaskOutcome::NotApplicable => {}
+                    }
+                } else if let Some(result) = route_task_store(store, method, params) {
+                    return match result {
+                        Ok(value) => Response::success(request.id.clone(), value),
+                        Err(e) => Response::error(request.id.clone(), e.into()),
+                    };
+                }
+            }
+
             // Try routing to tools
             if let Some(result) = route_tools(
                 state.handler.as_ref(),

--- a/crates/mcpkit-axum/src/session.rs
+++ b/crates/mcpkit-axum/src/session.rs
@@ -29,6 +29,10 @@ pub struct Session {
     /// The verified user this session is bound to, if any. Once bound, the
     /// session may only be used by the same user (see [`SessionBindingError`]).
     pub user: Option<VerifiedUser>,
+    /// This session's task store for task-augmented `tools/call`. Scoped per
+    /// session so one session cannot read or cancel another's tasks (matching
+    /// the stdio runtime's per-connection store).
+    pub tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
 }
 
 impl Session {
@@ -50,6 +54,7 @@ impl Session {
             client_capabilities: None,
             protocol_version: None,
             user,
+            tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
         }
     }
 

--- a/crates/mcpkit-axum/tests/tasks.rs
+++ b/crates/mcpkit-axum/tests/tasks.rs
@@ -1,0 +1,239 @@
+//! E2E for #122: task-augmented `tools/call` and `tasks/*` served through the
+//! axum adapter, including per-session isolation and cancellation propagation.
+
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue};
+use axum::response::IntoResponse;
+use mcpkit_axum::McpState;
+use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    GetPromptResult, Prompt, Resource, ResourceContents, TaskSupport, Tool, ToolOutput,
+};
+use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
+
+struct H {
+    observed_cancel: Arc<AtomicBool>,
+}
+
+impl ServerHandler for H {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("tasks-test", "0.0.0")
+    }
+}
+impl ToolHandler for H {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![
+            Tool::new("echo").task_support(TaskSupport::Optional),
+            Tool::new("waiter").task_support(TaskSupport::Optional),
+            // No execution.taskSupport -> Forbidden by default.
+            Tool::new("plain"),
+        ])
+    }
+    async fn call_tool(
+        &self,
+        name: &str,
+        _args: serde_json::Value,
+        ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        match name {
+            "echo" => Ok(ToolOutput::text("echoed")),
+            "waiter" => {
+                // Park until cancelled, then record that cancellation propagated.
+                ctx.cancelled().await;
+                self.observed_cancel.store(true, Ordering::SeqCst);
+                Ok(ToolOutput::text("cancelled"))
+            }
+            other => Err(McpError::method_not_found(other)),
+        }
+    }
+}
+impl ResourceHandler for H {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for H {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        _name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Err(McpError::method_not_found("get_prompt"))
+    }
+}
+
+fn state() -> (McpState<H>, Arc<AtomicBool>) {
+    let observed = Arc::new(AtomicBool::new(false));
+    let state = McpState::new(H {
+        observed_cancel: observed.clone(),
+    });
+    (state, observed)
+}
+
+/// POST one JSON-RPC message; returns (parsed response JSON, session id header).
+async fn post(
+    state: &McpState<H>,
+    session: Option<&str>,
+    body: serde_json::Value,
+) -> (serde_json::Value, Option<String>) {
+    let mut headers = HeaderMap::new();
+    if let Some(s) = session {
+        headers.insert(
+            "mcp-session-id",
+            HeaderValue::from_str(s).expect("session header"),
+        );
+    }
+    let response =
+        mcpkit_axum::handle_mcp_post(State(state.clone()), headers, None, body.to_string())
+            .await
+            .into_response();
+    let sid = response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (json, sid)
+}
+
+fn call_task(id: u64, name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": id, "method": "tools/call",
+        "params": { "name": name, "arguments": {}, "task": {} }
+    })
+}
+
+fn task_method(id: u64, method: &str, task_id: &str) -> serde_json::Value {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": id, "method": method,
+        "params": { "taskId": task_id }
+    })
+}
+
+#[tokio::test]
+async fn task_augmented_call_creates_gets_and_results() {
+    let (state, _) = state();
+
+    // Augmented tools/call returns CreateTaskResult (status "working") immediately.
+    let (resp, sid) = post(&state, None, call_task(1, "echo")).await;
+    let sid = sid.expect("session id");
+    assert!(resp["error"].is_null(), "augmented call errored: {resp}");
+    assert_eq!(resp["result"]["task"]["status"], "working");
+    let task_id = resp["result"]["task"]["taskId"]
+        .as_str()
+        .expect("taskId")
+        .to_string();
+
+    // The tool runs in the background (tokio::spawn); tasks/result yields once done.
+    let mut payload = serde_json::Value::Null;
+    for _ in 0..100 {
+        let (r, _) = post(&state, Some(&sid), task_method(2, "tasks/result", &task_id)).await;
+        if r["error"].is_null() && !r["result"].is_null() {
+            payload = r["result"].clone();
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert_eq!(
+        payload["content"][0]["text"], "echoed",
+        "payload: {payload}"
+    );
+
+    // tasks/get reports the terminal status.
+    let (g, _) = post(&state, Some(&sid), task_method(3, "tasks/get", &task_id)).await;
+    assert_eq!(g["result"]["status"], "completed", "get: {g}");
+}
+
+#[tokio::test]
+async fn task_augmented_call_on_forbidden_tool_is_rejected() {
+    let (state, _) = state();
+    let (resp, _) = post(&state, None, call_task(1, "plain")).await;
+    // A tool without taskSupport must be rejected, not run as a task.
+    assert!(!resp["error"].is_null(), "expected rejection, got: {resp}");
+    assert!(resp["result"]["task"].is_null());
+}
+
+#[tokio::test]
+async fn tasks_cancel_trips_ctx_cancelled() {
+    let (state, observed) = state();
+
+    // Start a task whose tool parks on ctx.cancelled().
+    let (resp, sid) = post(&state, None, call_task(1, "waiter")).await;
+    let sid = sid.expect("session id");
+    let task_id = resp["result"]["task"]["taskId"]
+        .as_str()
+        .expect("taskId")
+        .to_string();
+    assert!(
+        !observed.load(Ordering::SeqCst),
+        "tool cancelled before request"
+    );
+
+    // tasks/cancel must trip the token wired into the background context.
+    let (c, _) = post(&state, Some(&sid), task_method(2, "tasks/cancel", &task_id)).await;
+    assert!(c["error"].is_null(), "cancel errored: {c}");
+
+    // The tool observes cancellation and records it.
+    let mut seen = false;
+    for _ in 0..100 {
+        if observed.load(Ordering::SeqCst) {
+            seen = true;
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(
+        seen,
+        "tasks/cancel did not trip ctx.cancelled() in the tool"
+    );
+}
+
+#[tokio::test]
+async fn tasks_are_isolated_per_session() {
+    let (state, _) = state();
+
+    // Session A creates a task.
+    let (resp, sid_a) = post(&state, None, call_task(1, "echo")).await;
+    let sid_a = sid_a.expect("session A id");
+    let task_id = resp["result"]["task"]["taskId"]
+        .as_str()
+        .expect("taskId")
+        .to_string();
+
+    // Session B is a distinct session (no session header -> new session).
+    let (_probe, sid_b) = post(&state, None, call_task(2, "echo")).await;
+    let sid_b = sid_b.expect("session B id");
+    assert_ne!(sid_a, sid_b, "expected two distinct sessions");
+
+    // Session B must not be able to read session A's task.
+    let (g, _) = post(&state, Some(&sid_b), task_method(3, "tasks/get", &task_id)).await;
+    assert!(
+        !g["error"].is_null(),
+        "session B could read session A's task: {g}"
+    );
+    // And session A still can.
+    let (ga, _) = post(&state, Some(&sid_a), task_method(4, "tasks/get", &task_id)).await;
+    assert!(ga["error"].is_null(), "session A lost its own task: {ga}");
+}

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -6,10 +6,12 @@ use mcpkit_core::auth::VerifiedUser;
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
+use mcpkit_server::capability::tasks::{TaskManager, route_task_store};
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_completion, route_logging,
-    route_prompts, route_resources, route_tools,
+    AugmentedTaskOutcome, PromptHandler, ResourceHandler, ServerHandler, ToolHandler,
+    begin_augmented_task, route_completion, route_logging, route_prompts, route_resources,
+    route_tools,
 };
 use rocket::http::{ContentType, Header, Status};
 use rocket::request::{FromRequest, Outcome, Request};
@@ -286,9 +288,17 @@ where
                     || (ProtocolVersion::LATEST, ClientCapabilities::default()),
                     |(v, c)| (v, c.unwrap_or_default()),
                 );
+            // This session's task store (per-session isolation for `tasks/*`).
+            let task_store = state.sessions.tasks(&session_id);
 
-            let response =
-                create_response_for_request(state, &request, protocol_version, &client_caps).await;
+            let response = create_response_for_request(
+                state,
+                &request,
+                protocol_version,
+                &client_caps,
+                task_store.as_ref(),
+            )
+            .await;
 
             match serde_json::to_string(&Message::Response(response)) {
                 Ok(body) => McpResponse::success(body, session_id),
@@ -343,6 +353,7 @@ async fn create_response_for_request<H>(
     request: &mcpkit_core::protocol::Request,
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
+    task_store: Option<&Arc<TaskManager>>,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -377,6 +388,37 @@ where
             Response::success(request.id.clone(), init_result)
         }
         _ => {
+            // Task-augmented tools/call and tasks/* are served from this
+            // session's own task store (per-session isolation).
+            if let Some(store) = task_store {
+                if method == "tools/call" {
+                    match begin_augmented_task(
+                        state.handler.clone(),
+                        store,
+                        params,
+                        client_caps.clone(),
+                        server_caps.clone(),
+                        protocol_version,
+                    )
+                    .await
+                    {
+                        AugmentedTaskOutcome::Started(create_result, fut) => {
+                            tokio::spawn(fut);
+                            return Response::success(request.id.clone(), create_result);
+                        }
+                        AugmentedTaskOutcome::Rejected(e) => {
+                            return Response::error(request.id.clone(), e.into());
+                        }
+                        AugmentedTaskOutcome::NotApplicable => {}
+                    }
+                } else if let Some(result) = route_task_store(store, method, params) {
+                    return match result {
+                        Ok(value) => Response::success(request.id.clone(), value),
+                        Err(e) => Response::error(request.id.clone(), e.into()),
+                    };
+                }
+            }
+
             // Try routing to tools
             if let Some(result) = route_tools(
                 state.handler.as_ref(),

--- a/crates/mcpkit-rocket/src/session.rs
+++ b/crates/mcpkit-rocket/src/session.rs
@@ -30,6 +30,9 @@ struct SessionState {
     client_capabilities: Option<ClientCapabilities>,
     /// The verified user this session is bound to, if any.
     user: Option<VerifiedUser>,
+    /// This session's task store for task-augmented `tools/call` (per-session
+    /// isolation for `tasks/*`).
+    tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
 }
 
 impl Default for SessionStore {
@@ -83,6 +86,7 @@ impl SessionStore {
                 protocol_version: None,
                 client_capabilities: None,
                 user,
+                tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
             },
         );
         id
@@ -137,6 +141,12 @@ impl SessionStore {
                 s.client_capabilities.clone(),
             )
         })
+    }
+
+    /// This session's task store, if the session exists.
+    #[must_use]
+    pub fn tasks(&self, id: &str) -> Option<Arc<mcpkit_server::capability::tasks::TaskManager>> {
+        self.sessions.get(id).map(|s| s.tasks.clone())
     }
 
     /// Check if a session exists.

--- a/crates/mcpkit-server/src/capability/tasks.rs
+++ b/crates/mcpkit-server/src/capability/tasks.rs
@@ -104,6 +104,7 @@ impl TaskHandle {
 }
 
 /// Manager coordinating the lifecycle of tracked tasks.
+#[derive(Debug)]
 pub struct TaskManager {
     tasks: RwLock<HashMap<TaskId, TaskState>>,
 }

--- a/crates/mcpkit-server/src/capability/tasks.rs
+++ b/crates/mcpkit-server/src/capability/tasks.rs
@@ -238,6 +238,76 @@ impl TaskManager {
     }
 }
 
+/// Serve task queries from a [`TaskManager`] store.
+///
+/// Returns `None` for non-task methods, and for `tasks/get`/`tasks/result`/
+/// `tasks/cancel` whose id the store does not own (so a caller can fall through
+/// to a custom task handler). Shared by the stdio runtime and the HTTP adapters
+/// so both serve `tasks/*` identically against their own store.
+pub fn route_task_store(
+    store: &TaskManager,
+    method: &str,
+    params: Option<&Value>,
+) -> Option<Result<Value, McpError>> {
+    let task_id = || {
+        params
+            .and_then(|p| p.get("taskId"))
+            .and_then(|v| v.as_str())
+            .map(TaskId::new)
+    };
+    match method {
+        "tasks/list" => Some(Ok(serde_json::json!({ "tasks": store.list() }))),
+        "tasks/get" => {
+            let Some(id) = task_id() else {
+                return Some(Err(McpError::invalid_params("tasks/get", "missing taskId")));
+            };
+            store.get(&id).map(|s| {
+                let result = GetTaskResult::from(s.task);
+                Ok(serde_json::to_value(result).unwrap_or_default())
+            })
+        }
+        "tasks/result" => {
+            let Some(id) = task_id() else {
+                return Some(Err(McpError::invalid_params(
+                    "tasks/result",
+                    "missing taskId",
+                )));
+            };
+            if let Some(payload) = store.payload(&id) {
+                Some(Ok(payload))
+            } else if store.get(&id).is_some() {
+                Some(Err(McpError::invalid_params(
+                    "tasks/result",
+                    "task is not completed",
+                )))
+            } else {
+                None
+            }
+        }
+        "tasks/cancel" => {
+            let Some(id) = task_id() else {
+                return Some(Err(McpError::invalid_params(
+                    "tasks/cancel",
+                    "missing taskId",
+                )));
+            };
+            if store.get(&id).is_some() {
+                let _ = store.cancel(&id);
+                Some(Ok(store
+                    .get(&id)
+                    .map(|s| {
+                        let result = CancelTaskResult::from(s.task);
+                        serde_json::to_value(result).unwrap_or_default()
+                    })
+                    .unwrap_or_default()))
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
 /// Task service implementing the [`TaskHandler`] trait over a [`TaskManager`].
 pub struct TaskService {
     manager: Arc<TaskManager>,

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -81,7 +81,10 @@ pub use health::{
     ComponentHealth, HealthChecker, HealthReport, HealthStatus, LivenessResponse, ReadinessResponse,
 };
 pub use metrics::{MethodStats, MetricsSnapshot, ServerMetrics};
-pub use router::{route_completion, route_logging, route_prompts, route_resources, route_tools};
+pub use router::{
+    call_tool_json, route_completion, route_logging, route_prompts, route_resources, route_tools,
+    run_augmented_tool, tool_task_support,
+};
 pub use server::{
     RequestRouter, RuntimeConfig, ServerNotifier, ServerRuntime, ServerState, TransportPeer,
 };

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -82,8 +82,8 @@ pub use health::{
 };
 pub use metrics::{MethodStats, MetricsSnapshot, ServerMetrics};
 pub use router::{
-    call_tool_json, route_completion, route_logging, route_prompts, route_resources, route_tools,
-    run_augmented_tool, tool_task_support,
+    AugmentedTaskOutcome, begin_augmented_task, call_tool_json, route_completion, route_logging,
+    route_prompts, route_resources, route_tools, run_augmented_tool, tool_task_support,
 };
 pub use server::{
     RequestRouter, RuntimeConfig, ServerNotifier, ServerRuntime, ServerState, TransportPeer,

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -612,6 +612,90 @@ pub async fn route_tools(
     }
 }
 
+/// The task-augmentation support a tool declares (`Tool.execution.taskSupport`).
+///
+/// Defaults to `Forbidden` when the tool is unknown or declares nothing. Used to
+/// gate a task-augmented `tools/call` before creating the task. Shared by the
+/// stdio runtime and the HTTP adapters.
+pub async fn tool_task_support(
+    handler: &dyn DynToolHandler,
+    name: &str,
+    ctx: &Context<'_>,
+) -> mcpkit_core::types::TaskSupport {
+    use mcpkit_core::types::TaskSupport;
+    let tools = handler.list_tools(ctx).await.unwrap_or_default();
+    tools
+        .iter()
+        .find(|t| t.name == name)
+        .and_then(|t| t.execution.as_ref())
+        .and_then(|e| e.task_support)
+        .unwrap_or(TaskSupport::Forbidden)
+}
+
+/// Run a tool and return its `CallToolResult` as JSON (the `tasks/result`
+/// payload shape). Shared by the stdio runtime and the HTTP adapters.
+pub async fn call_tool_json(
+    handler: &dyn DynToolHandler,
+    name: &str,
+    args: serde_json::Value,
+    ctx: &Context<'_>,
+) -> Result<serde_json::Value, McpError> {
+    let output = handler.call_tool(name, args, ctx).await?;
+    let result: CallToolResult = output.into();
+    Ok(serde_json::to_value(result).unwrap_or_default())
+}
+
+/// Run a task-augmented tool to completion, writing the result (or failure) back
+/// through the task-store `handle`.
+///
+/// Built for HTTP adapters, which spawn this onto their own executor after
+/// replying with the initial `CreateTaskResult`. The background context uses a
+/// [`NoOpPeer`](crate::context::NoOpPeer): a task-augmented tool on an adapter
+/// cannot make server-to-client requests (elicitation/sampling) and its
+/// notifications/logging/progress are dropped. Cancellation still works — the
+/// handle's cancellation token is wired into the context, so a cooperative tool
+/// awaiting `ctx.cancelled()` observes `tasks/cancel`.
+pub async fn run_augmented_tool(
+    handler: std::sync::Arc<dyn DynToolHandler>,
+    handle: crate::capability::tasks::TaskHandle,
+    name: String,
+    args: serde_json::Value,
+    client_caps: mcpkit_core::capability::ClientCapabilities,
+    server_caps: mcpkit_core::capability::ServerCapabilities,
+    protocol_version: mcpkit_core::protocol_version::ProtocolVersion,
+) {
+    use crate::context::{Context, NoOpPeer};
+    let peer = NoOpPeer;
+    let request_id = mcpkit_core::protocol::RequestId::String(handle.id().as_str().to_string());
+    let ctx = match handle.cancel_token() {
+        Some(token) => Context::with_cancellation(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            protocol_version,
+            &peer,
+            token,
+        ),
+        None => Context::new(
+            &request_id,
+            None,
+            &client_caps,
+            &server_caps,
+            protocol_version,
+            &peer,
+        ),
+    };
+    match call_tool_json(handler.as_ref(), &name, args, &ctx).await {
+        Ok(payload) => {
+            let _ = handle.complete(payload);
+        }
+        Err(e) => {
+            let _ = handle.fail(e.to_string());
+        }
+    }
+}
+
 /// Route resource-related requests to a handler implementing
 /// [`ResourceHandler`](crate::handler::ResourceHandler).
 ///

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -696,6 +696,100 @@ pub async fn run_augmented_tool(
     }
 }
 
+/// Outcome of [`begin_augmented_task`] — the adapter's decision for a
+/// (potentially) task-augmented `tools/call`.
+pub enum AugmentedTaskOutcome {
+    /// Not a task-augmented call (no non-null `task` field, or malformed) — the
+    /// caller should fall through to the normal synchronous `tools/call` path.
+    NotApplicable,
+    /// Rejected before any task was created (e.g. the tool forbids task
+    /// augmentation) — reply with this error.
+    Rejected(McpError),
+    /// A task was created. Reply immediately with the JSON `CreateTaskResult`
+    /// (`.0`), then run the background future (`.1`) on the caller's executor
+    /// (e.g. `tokio::spawn`); it writes the result back into the store.
+    Started(serde_json::Value, futures::future::BoxFuture<'static, ()>),
+}
+
+/// Begin a task-augmented `tools/call` against a per-session task `store`.
+///
+/// Mirrors the stdio runtime's `try_begin_task`: detect the `task` field, gate on
+/// the tool's declared `taskSupport`, create the task, and return the initial
+/// `CreateTaskResult` plus a background future the caller spawns. Only call this
+/// for the `tools/call` method. See [`run_augmented_tool`] for the background
+/// context's limitations (no server-to-client from the tool).
+pub async fn begin_augmented_task(
+    handler: std::sync::Arc<dyn DynToolHandler>,
+    store: &std::sync::Arc<crate::capability::tasks::TaskManager>,
+    params: Option<&serde_json::Value>,
+    client_caps: mcpkit_core::capability::ClientCapabilities,
+    server_caps: mcpkit_core::capability::ServerCapabilities,
+    protocol_version: mcpkit_core::protocol_version::ProtocolVersion,
+) -> AugmentedTaskOutcome {
+    use mcpkit_core::types::TaskSupport;
+
+    let Some(task_meta) = params.and_then(|p| p.get("task")) else {
+        return AugmentedTaskOutcome::NotApplicable;
+    };
+    if task_meta.is_null() {
+        return AugmentedTaskOutcome::NotApplicable;
+    }
+    let Some(name) = params
+        .and_then(|p| p.get("name"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+    else {
+        // Malformed; let the normal path report it.
+        return AugmentedTaskOutcome::NotApplicable;
+    };
+    let args = params
+        .and_then(|p| p.get("arguments"))
+        .cloned()
+        .unwrap_or_else(|| serde_json::json!({}));
+    let ttl = task_meta.get("ttl").and_then(serde_json::Value::as_u64);
+
+    // Gate on the tool's declared task support (a `forbidden` tool must not be
+    // task-augmented). The gating context needs no real peer.
+    let support = {
+        use crate::context::{Context, NoOpPeer};
+        let peer = NoOpPeer;
+        let gate_id = mcpkit_core::protocol::RequestId::String("tasks/gate".to_string());
+        let ctx = Context::new(
+            &gate_id,
+            None,
+            &client_caps,
+            &server_caps,
+            protocol_version,
+            &peer,
+        );
+        tool_task_support(handler.as_ref(), &name, &ctx).await
+    };
+    if support == TaskSupport::Forbidden {
+        return AugmentedTaskOutcome::Rejected(McpError::invalid_params(
+            "tools/call",
+            format!("tool '{name}' does not support task-augmented execution"),
+        ));
+    }
+
+    let handle = store.create(ttl);
+    let task = handle
+        .task()
+        .unwrap_or_else(|| mcpkit_core::types::Task::new(handle.id().clone()));
+    let create_result =
+        serde_json::to_value(mcpkit_core::types::CreateTaskResult { task, meta: None })
+            .unwrap_or_default();
+    let fut = run_augmented_tool(
+        handler,
+        handle,
+        name,
+        args,
+        client_caps,
+        server_caps,
+        protocol_version,
+    );
+    AugmentedTaskOutcome::Started(create_result, Box::pin(fut))
+}
+
 /// Route resource-related requests to a handler implementing
 /// [`ResourceHandler`](crate::handler::ResourceHandler).
 ///

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -905,64 +905,7 @@ where
         method: &str,
         params: Option<&serde_json::Value>,
     ) -> Option<Result<serde_json::Value, McpError>> {
-        let task_id = || {
-            params
-                .and_then(|p| p.get("taskId"))
-                .and_then(|v| v.as_str())
-                .map(mcpkit_core::types::TaskId::new)
-        };
-        match method {
-            "tasks/list" => Some(Ok(serde_json::json!({ "tasks": self.task_store.list() }))),
-            "tasks/get" => {
-                let Some(id) = task_id() else {
-                    return Some(Err(McpError::invalid_params("tasks/get", "missing taskId")));
-                };
-                self.task_store.get(&id).map(|s| {
-                    let result = mcpkit_core::types::GetTaskResult::from(s.task);
-                    Ok(serde_json::to_value(result).unwrap_or_default())
-                })
-            }
-            "tasks/result" => {
-                let Some(id) = task_id() else {
-                    return Some(Err(McpError::invalid_params(
-                        "tasks/result",
-                        "missing taskId",
-                    )));
-                };
-                if let Some(payload) = self.task_store.payload(&id) {
-                    Some(Ok(payload))
-                } else if self.task_store.get(&id).is_some() {
-                    Some(Err(McpError::invalid_params(
-                        "tasks/result",
-                        "task is not completed",
-                    )))
-                } else {
-                    None
-                }
-            }
-            "tasks/cancel" => {
-                let Some(id) = task_id() else {
-                    return Some(Err(McpError::invalid_params(
-                        "tasks/cancel",
-                        "missing taskId",
-                    )));
-                };
-                if self.task_store.get(&id).is_some() {
-                    let _ = self.task_store.cancel(&id);
-                    Some(Ok(self
-                        .task_store
-                        .get(&id)
-                        .map(|s| {
-                            let result = mcpkit_core::types::CancelTaskResult::from(s.task);
-                            serde_json::to_value(result).unwrap_or_default()
-                        })
-                        .unwrap_or_default()))
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
+        crate::capability::tasks::route_task_store(&self.task_store, method, params)
     }
 
     /// Handle the initialize request.
@@ -1340,17 +1283,10 @@ where
         name: &str,
         ctx: &Context<'_>,
     ) -> mcpkit_core::types::TaskSupport {
-        use mcpkit_core::types::TaskSupport;
-        let Some(handler) = self.tools.as_tool_handler() else {
-            return TaskSupport::Forbidden;
-        };
-        let tools = handler.list_tools(ctx).await.unwrap_or_default();
-        tools
-            .iter()
-            .find(|t| t.name == name)
-            .and_then(|t| t.execution.as_ref())
-            .and_then(|e| e.task_support)
-            .unwrap_or(TaskSupport::Forbidden)
+        match self.tools.as_tool_handler() {
+            Some(handler) => crate::router::tool_task_support(handler, name, ctx).await,
+            None => mcpkit_core::types::TaskSupport::Forbidden,
+        }
     }
 
     async fn call_tool_json(
@@ -1359,12 +1295,10 @@ where
         args: serde_json::Value,
         ctx: &Context<'_>,
     ) -> Result<serde_json::Value, McpError> {
-        let Some(handler) = self.tools.as_tool_handler() else {
-            return Err(McpError::method_not_found(name));
-        };
-        let output = handler.call_tool(name, args, ctx).await?;
-        let result: mcpkit_core::types::CallToolResult = output.into();
-        Ok(serde_json::to_value(result).unwrap_or_default())
+        match self.tools.as_tool_handler() {
+            Some(handler) => crate::router::call_tool_json(handler, name, args, ctx).await,
+            None => Err(McpError::method_not_found(name)),
+        }
     }
 }
 

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -7,10 +7,12 @@ use mcpkit_core::auth::VerifiedUser;
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
+use mcpkit_server::capability::tasks::{TaskManager, route_task_store};
 use mcpkit_server::context::{Context, NoOpPeer};
 use mcpkit_server::{
-    PromptHandler, ResourceHandler, ServerHandler, ToolHandler, route_completion, route_logging,
-    route_prompts, route_resources, route_tools,
+    AugmentedTaskOutcome, PromptHandler, ResourceHandler, ServerHandler, ToolHandler,
+    begin_augmented_task, route_completion, route_logging, route_prompts, route_resources,
+    route_tools,
 };
 use std::convert::Infallible;
 use std::sync::Arc;
@@ -149,9 +151,17 @@ where
                     || (ProtocolVersion::LATEST, ClientCapabilities::default()),
                     |(v, c)| (v, c.unwrap_or_default()),
                 );
+            // This session's task store (per-session isolation for `tasks/*`).
+            let task_store = state.sessions.tasks(&session_id);
 
-            let response =
-                create_response_for_request(&state, &request, protocol_version, &client_caps).await;
+            let response = create_response_for_request(
+                &state,
+                &request,
+                protocol_version,
+                &client_caps,
+                task_store.as_ref(),
+            )
+            .await;
 
             match serde_json::to_value(Message::Response(response)) {
                 Ok(body) => Ok(warp::reply::with_status(
@@ -226,6 +236,7 @@ async fn create_response_for_request<H>(
     request: &mcpkit_core::protocol::Request,
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
+    task_store: Option<&Arc<TaskManager>>,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -260,6 +271,37 @@ where
             Response::success(request.id.clone(), init_result)
         }
         _ => {
+            // Task-augmented tools/call and tasks/* are served from this
+            // session's own task store (per-session isolation).
+            if let Some(store) = task_store {
+                if method == "tools/call" {
+                    match begin_augmented_task(
+                        state.handler.clone(),
+                        store,
+                        params,
+                        client_caps.clone(),
+                        server_caps.clone(),
+                        protocol_version,
+                    )
+                    .await
+                    {
+                        AugmentedTaskOutcome::Started(create_result, fut) => {
+                            tokio::spawn(fut);
+                            return Response::success(request.id.clone(), create_result);
+                        }
+                        AugmentedTaskOutcome::Rejected(e) => {
+                            return Response::error(request.id.clone(), e.into());
+                        }
+                        AugmentedTaskOutcome::NotApplicable => {}
+                    }
+                } else if let Some(result) = route_task_store(store, method, params) {
+                    return match result {
+                        Ok(value) => Response::success(request.id.clone(), value),
+                        Err(e) => Response::error(request.id.clone(), e.into()),
+                    };
+                }
+            }
+
             // Try routing to tools
             if let Some(result) = route_tools(
                 state.handler.as_ref(),

--- a/crates/mcpkit-warp/src/session.rs
+++ b/crates/mcpkit-warp/src/session.rs
@@ -28,6 +28,9 @@ struct SessionState {
     client_capabilities: Option<ClientCapabilities>,
     /// The verified user this session is bound to, if any.
     user: Option<VerifiedUser>,
+    /// This session's task store for task-augmented `tools/call` (per-session
+    /// isolation for `tasks/*`).
+    tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
 }
 
 impl Default for SessionStore {
@@ -80,6 +83,7 @@ impl SessionStore {
                 protocol_version: None,
                 client_capabilities: None,
                 user,
+                tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
             },
         );
         id
@@ -134,6 +138,12 @@ impl SessionStore {
                 s.client_capabilities.clone(),
             )
         })
+    }
+
+    /// This session's task store, if the session exists.
+    #[must_use]
+    pub fn tasks(&self, id: &str) -> Option<Arc<mcpkit_server::capability::tasks::TaskManager>> {
+        self.sessions.get(id).map(|s| s.tasks.clone())
     }
 
     /// Check if a session exists.


### PR DESCRIPTION
Closes #122. Largest item in the queue. Two commits: an executor-agnostic refactor (no behavior change), then the adapter wiring.

## Problem
Task-augmented `tools/call` and `tasks/*` were served only by the stdio `ServerRuntime`. The axum/actix/warp/rocket adapters dispatch `tools/call` synchronously via `route_tools` and **silently ignore** a `task` field; they had no task store and no `tasks/*` handling. The runtime's flow is coupled to its persistent receive loop + `Arc<Transport>` (two-phase send, background `FuturesUnordered`, `TransportPeer`).

## Commit 1 — refactor (no behavior change, proven by existing runtime task tests)
Factor the machinery both sides reuse, keeping mcpkit-server executor-agnostic:
- `capability::tasks::route_task_store(store, method, params)` — the `tasks/list|get|result|cancel` store-serving logic (lifted verbatim out of `ServerRuntime::route_runtime_tasks`, which now delegates).
- `router::{tool_task_support, call_tool_json}` — free functions over `&dyn DynToolHandler` (lifted out of the `Server` `RequestRouter` impl, which now delegates). Object-safe, so both the typestate server (via `ToolSlot`) and the adapters (`Arc<H>`) call them.
- `router::run_augmented_tool` — background executor that runs a tool into a task-store handle with a `NoOpPeer` context.

## Commit 2 — adapter wiring
- `router::begin_augmented_task` + `AugmentedTaskOutcome`: gate on the tool's `taskSupport`, create the task, return the `CreateTaskResult` JSON **plus a background future** the caller spawns. The adapter owns the executor (`tokio::spawn`), so mcpkit-server stays executor-agnostic (**#123 is not a prerequisite**).
- Each adapter's `create_response_for_request` intercepts a task-augmented `tools/call`: reply `CreateTaskResult` immediately, `tokio::spawn` the tool; serve `tasks/*` via `route_task_store`.
- **Per-session isolation** (per review): each MCP session owns an `Arc<TaskManager>` (on `Session` for axum/actix, `SessionState` + a `tasks()` accessor for warp/rocket). On stdio the store is per-connection = per-session, so a global `McpState` store would have let session B read/cancel session A's task on a leaked id — this avoids that.

## Design decisions (all as agreed with reviewers)
- **Spawn:** adapter-local `tokio::spawn`; core stays executor-agnostic.
- **Server→client from background tasks:** out of scope — the adapter context uses `NoOpPeer` (already true for *all* adapter calls, so not a regression). A background task cannot elicit/sample, and its notifications/logging/progress are dropped. Documented.
- **Cancellation:** the store's cancel token is wired into the background context, so `tasks/cancel` trips the tool's `ctx.cancelled()` (tested).
- **Store scope:** per-session, in-memory, per-instance (no horizontal scaling — same as the runtime). Fire-and-forget on shutdown (no drain). Documented.

## Tests
axum E2E (`tests/tasks.rs`): create → `tasks/get`/`tasks/result`; forbidden-tool rejection; `tasks/cancel` trips `ctx.cancelled()`; and **two-session isolation** (session B cannot read session A's task, session A still can).

**Coverage note (please weigh in):** full E2E is on axum only. actix/warp/rocket use the **identical** wiring calling the same shared helpers (build-verified across the workspace), matching how the #113 completion adapter rollout was tested (axum E2E + shared coverage). I can add per-adapter E2E harnesses (actix-web test / warp filter / rocket local client) as a follow-up if you'd prefer belt-and-suspenders on the per-adapter session wiring.

## Follow-ups
- **#121 (TTL cleanup)** is now more important (long-lived multi-session HTTP servers accumulate terminal tasks) and must sweep **each session's** store, not one global store. Recommend it next.
- Pre-existing (not touched here): `TaskManager::complete` doesn't guard a `Cancelled` terminal state — same on stdio; out of scope for #122.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --all-features --locked` (1317 tests, 0 failures) all green.