### PR TITLE
feat(tasks): TTL cleanup for terminal tasks, configurable end-to-end (#121)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- TTL cleanup for terminal tasks (#121). `TaskManager::cleanup` existed but was
+  never called and ignored each task's `ttl`, so terminal tasks accumulated for
+  the store's lifetime — now magnified by #122's per-session adapter stores. Now:
+  - `TaskManager::cleanup_expired()` evicts terminal tasks whose age since
+    creation exceeds their own `ttl` (ms); non-terminal tasks are always kept and
+    a task with `ttl` `None` is never evicted. Called on `create` and at the top
+    of the shared `route_task_store`, so it runs for the stdio runtime and every
+    adapter with no timer (executor-agnostic).
+  - An omitted `ttl` is **materialized at creation** to the store's configured
+    default, so the returned `CreateTaskResult` reports the task's actual
+    retention (rather than reporting `null` while being evicted anyway). `None`
+    stays truly unlimited.
+  - The default is configurable: `TaskManager::with_default_ttl(Option<u64>)`
+    (`None` = unlimited), `RuntimeConfig::default_task_ttl_ms` for the stdio
+    runtime, and `McpRouter::with_task_ttl` / `McpState::with_task_ttl` for the
+    axum/actix/warp/rocket adapters (per-session stores). Default retention is
+    `DEFAULT_TASK_TTL_MS` (1 hour)
+    ([#121](https://github.com/praxiomlabs/mcpkit/issues/121)).
 - Task-augmented `tools/call` and `tasks/*` on the HTTP adapters (#122). The
   axum/actix/warp/rocket adapters dispatched `tools/call` synchronously and
   ignored a `task` field, so task execution was runtime-only. Now:

--- a/crates/mcpkit-actix/src/router.rs
+++ b/crates/mcpkit-actix/src/router.rs
@@ -88,6 +88,15 @@ where
         self
     }
 
+    /// Set the default task retention (milliseconds) for each session's task
+    /// store, applied when a task-augmented `tools/call` omits a `ttl`. Pass
+    /// `None` for unlimited retention.
+    #[must_use]
+    pub fn with_task_ttl(mut self, default_task_ttl: Option<u64>) -> Self {
+        self.state = self.state.with_task_ttl(default_task_ttl);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     ///
     /// For production, you should configure CORS manually with custom settings.

--- a/crates/mcpkit-actix/src/session.rs
+++ b/crates/mcpkit-actix/src/session.rs
@@ -500,6 +500,9 @@ pub struct SessionStore {
     sessions: DashMap<String, Session>,
     timeout: Duration,
     init_timeout: Duration,
+    /// Default task retention (ms) applied to each session's task store; `None`
+    /// means unlimited. Configure via `McpRouter::with_task_ttl`.
+    pub(crate) default_task_ttl: Option<u64>,
 }
 
 impl SessionStore {
@@ -513,6 +516,7 @@ impl SessionStore {
             sessions: DashMap::new(),
             timeout,
             init_timeout: DEFAULT_INIT_TIMEOUT,
+            default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
         }
     }
 
@@ -547,8 +551,11 @@ impl SessionStore {
     pub fn create_for_user(&self, user: Option<VerifiedUser>) -> String {
         self.cleanup_expired();
         let id = uuid::Uuid::new_v4().to_string();
-        self.sessions
-            .insert(id.clone(), Session::with_user(id.clone(), user));
+        let mut session = Session::with_user(id.clone(), user);
+        session.tasks = Arc::new(
+            mcpkit_server::capability::tasks::TaskManager::with_default_ttl(self.default_task_ttl),
+        );
+        self.sessions.insert(id.clone(), session);
         id
     }
 

--- a/crates/mcpkit-actix/src/state.rs
+++ b/crates/mcpkit-actix/src/state.rs
@@ -142,6 +142,18 @@ impl<H> McpState<H> {
         self.completion = Some(Arc::new(completion));
         self
     }
+
+    /// Set the default task retention (milliseconds) for each session's task
+    /// store, applied when a task-augmented `tools/call` omits a `ttl`. Pass
+    /// `None` for unlimited retention. Defaults to
+    /// [`DEFAULT_TASK_TTL_MS`](mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS).
+    #[must_use]
+    pub fn with_task_ttl(mut self, default_task_ttl: Option<u64>) -> Self {
+        if let Some(store) = Arc::get_mut(&mut self.sessions) {
+            store.default_task_ttl = default_task_ttl;
+        }
+        self
+    }
 }
 
 impl<H: mcpkit_server::ServerHandler> McpState<H> {

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -88,6 +88,15 @@ where
         self
     }
 
+    /// Set the default task retention (milliseconds) for each session's task
+    /// store, applied when a task-augmented `tools/call` omits a `ttl`. Pass
+    /// `None` for unlimited retention.
+    #[must_use]
+    pub fn with_task_ttl(mut self, default_task_ttl: Option<u64>) -> Self {
+        self.state = self.state.with_task_ttl(default_task_ttl);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     ///
     /// For production, you should use `with_cors_layer` with a custom configuration.

--- a/crates/mcpkit-axum/src/session.rs
+++ b/crates/mcpkit-axum/src/session.rs
@@ -519,6 +519,9 @@ pub struct SessionStore {
     sessions: DashMap<String, Session>,
     timeout: Duration,
     init_timeout: Duration,
+    /// Default task retention (ms) applied to each session's task store; `None`
+    /// means unlimited. Configure via `McpRouter::with_task_ttl`.
+    pub(crate) default_task_ttl: Option<u64>,
 }
 
 impl SessionStore {
@@ -532,6 +535,7 @@ impl SessionStore {
             sessions: DashMap::new(),
             timeout,
             init_timeout: DEFAULT_INIT_TIMEOUT,
+            default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
         }
     }
 
@@ -566,8 +570,11 @@ impl SessionStore {
     pub fn create_for_user(&self, user: Option<VerifiedUser>) -> String {
         self.cleanup_expired();
         let id = uuid::Uuid::new_v4().to_string();
-        self.sessions
-            .insert(id.clone(), Session::with_user(id.clone(), user));
+        let mut session = Session::with_user(id.clone(), user);
+        session.tasks = Arc::new(
+            mcpkit_server::capability::tasks::TaskManager::with_default_ttl(self.default_task_ttl),
+        );
+        self.sessions.insert(id.clone(), session);
         id
     }
 

--- a/crates/mcpkit-axum/src/state.rs
+++ b/crates/mcpkit-axum/src/state.rs
@@ -156,6 +156,18 @@ impl<H> McpState<H> {
         self.completion = Some(Arc::new(completion));
         self
     }
+
+    /// Set the default task retention (milliseconds) for each session's task
+    /// store, applied when a task-augmented `tools/call` omits a `ttl`. Pass
+    /// `None` for unlimited retention. Defaults to
+    /// [`DEFAULT_TASK_TTL_MS`](mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS).
+    #[must_use]
+    pub fn with_task_ttl(mut self, default_task_ttl: Option<u64>) -> Self {
+        if let Some(store) = Arc::get_mut(&mut self.sessions) {
+            store.default_task_ttl = default_task_ttl;
+        }
+        self
+    }
 }
 
 impl<H: mcpkit_server::ServerHandler> McpState<H> {

--- a/crates/mcpkit-axum/tests/tasks.rs
+++ b/crates/mcpkit-axum/tests/tasks.rs
@@ -167,6 +167,23 @@ async fn task_augmented_call_creates_gets_and_results() {
 }
 
 #[tokio::test]
+async fn with_task_ttl_configures_session_store_retention() {
+    // McpRouter/McpState::with_task_ttl sets each session store's default, and an
+    // omitted `ttl` is materialized to it on the CreateTaskResult.
+    let observed = Arc::new(AtomicBool::new(false));
+    let state = McpState::new(H {
+        observed_cancel: observed,
+    })
+    .with_task_ttl(Some(1234));
+
+    let (resp, _) = post(&state, None, call_task(1, "echo")).await;
+    assert_eq!(
+        resp["result"]["task"]["ttl"], 1234,
+        "configured task ttl not materialized: {resp}"
+    );
+}
+
+#[tokio::test]
 async fn task_augmented_call_on_forbidden_tool_is_rejected() {
     let (state, _) = state();
     let (resp, _) = post(&state, None, call_task(1, "plain")).await;

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -69,6 +69,15 @@ where
         self
     }
 
+    /// Set the default task retention (milliseconds) for each session's task
+    /// store, applied when a task-augmented `tools/call` omits a `ttl`. Pass
+    /// `None` for unlimited retention.
+    #[must_use]
+    pub fn with_task_ttl(mut self, default_task_ttl: Option<u64>) -> Self {
+        self.state = self.state.with_task_ttl(default_task_ttl);
+        self
+    }
+
     /// Enable CORS with permissive defaults.
     #[must_use]
     pub const fn with_cors(mut self) -> Self {

--- a/crates/mcpkit-rocket/src/session.rs
+++ b/crates/mcpkit-rocket/src/session.rs
@@ -18,6 +18,9 @@ pub struct SessionStore {
     sessions: Arc<DashMap<String, SessionState>>,
     sse_channels: Arc<DashMap<String, broadcast::Sender<String>>>,
     idle_timeout: Duration,
+    /// Default task retention (ms) applied to each session's task store; `None`
+    /// means unlimited. Configure via `McpRouter::with_task_ttl`.
+    pub(crate) default_task_ttl: Option<u64>,
 }
 
 struct SessionState {
@@ -49,6 +52,7 @@ impl SessionStore {
             sessions: Arc::new(DashMap::new()),
             sse_channels: Arc::new(DashMap::new()),
             idle_timeout: DEFAULT_SESSION_TIMEOUT,
+            default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
         }
     }
 
@@ -86,7 +90,11 @@ impl SessionStore {
                 protocol_version: None,
                 client_capabilities: None,
                 user,
-                tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
+                tasks: Arc::new(
+                    mcpkit_server::capability::tasks::TaskManager::with_default_ttl(
+                        self.default_task_ttl,
+                    ),
+                ),
             },
         );
         id

--- a/crates/mcpkit-rocket/src/state.rs
+++ b/crates/mcpkit-rocket/src/state.rs
@@ -100,6 +100,16 @@ impl<H> McpState<H> {
         self.completion = Some(Arc::new(completion));
         self
     }
+
+    /// Set the default task retention (milliseconds) for each session's task
+    /// store, applied when a task-augmented `tools/call` omits a `ttl`. Pass
+    /// `None` for unlimited retention. Defaults to
+    /// [`DEFAULT_TASK_TTL_MS`](mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS).
+    #[must_use]
+    pub fn with_task_ttl(mut self, default_task_ttl: Option<u64>) -> Self {
+        self.sessions.default_task_ttl = default_task_ttl;
+        self
+    }
 }
 
 impl<H: mcpkit_server::ServerHandler> McpState<H> {

--- a/crates/mcpkit-server/src/capability/tasks.rs
+++ b/crates/mcpkit-server/src/capability/tasks.rs
@@ -25,15 +25,20 @@ pub struct TaskState {
     pub cancel_token: CancellationToken,
     /// When the task was last accessed (for cleanup).
     pub last_access: Instant,
+    /// When the task was created. TTL retention is measured from here (per the
+    /// `Task.ttl` "retention duration from creation" semantics).
+    pub created: Instant,
 }
 
 impl TaskState {
     fn new(task: Task) -> Self {
+        let now = Instant::now();
         Self {
             task,
             payload: None,
             cancel_token: CancellationToken::new(),
-            last_access: Instant::now(),
+            last_access: now,
+            created: now,
         }
     }
 
@@ -103,10 +108,17 @@ impl TaskHandle {
     }
 }
 
+/// Default retention for a terminal task whose `tools/call` omitted a `ttl`
+/// (one hour, in milliseconds). Override via [`TaskManager::with_default_ttl`].
+pub const DEFAULT_TASK_TTL_MS: u64 = 60 * 60 * 1000;
+
 /// Manager coordinating the lifecycle of tracked tasks.
 #[derive(Debug)]
 pub struct TaskManager {
     tasks: RwLock<HashMap<TaskId, TaskState>>,
+    /// Retention applied to a task when the request omits `ttl`. `None` means
+    /// unlimited (such tasks are never TTL-evicted).
+    default_ttl_ms: Option<u64>,
 }
 
 impl Default for TaskManager {
@@ -116,18 +128,33 @@ impl Default for TaskManager {
 }
 
 impl TaskManager {
-    /// Create a new task manager.
+    /// Create a new task manager retaining terminal tasks for
+    /// [`DEFAULT_TASK_TTL_MS`] when the request omits a `ttl`.
     #[must_use]
     pub fn new() -> Self {
+        Self::with_default_ttl(Some(DEFAULT_TASK_TTL_MS))
+    }
+
+    /// Create a task manager with a custom default retention (milliseconds) for
+    /// tasks whose request omits `ttl`. Pass `None` for unlimited retention (such
+    /// tasks are never TTL-evicted).
+    #[must_use]
+    pub fn with_default_ttl(default_ttl_ms: Option<u64>) -> Self {
         Self {
             tasks: RwLock::new(HashMap::new()),
+            default_ttl_ms,
         }
     }
 
     /// Create a new `working` task and return a handle to it.
+    ///
+    /// A `None` `ttl` is materialized to the manager's default so the returned
+    /// task reports its actual retention. Expired terminal tasks are swept first.
     pub fn create(self: &Arc<Self>, ttl: Option<u64>) -> TaskHandle {
+        self.cleanup_expired();
+
         let mut task = Task::create();
-        task.ttl = ttl;
+        task.ttl = ttl.or(self.default_ttl_ms);
         let task_id = task.task_id.clone();
 
         if let Ok(mut tasks) = self.tasks.write() {
@@ -237,6 +264,26 @@ impl TaskManager {
             });
         }
     }
+
+    /// Evict terminal tasks whose age since creation exceeds their own `ttl`
+    /// (milliseconds). Non-terminal tasks are always kept; a task with `ttl`
+    /// `None` (unlimited) is never evicted. Called on `create` and on task-store
+    /// access, so no timer is required.
+    pub fn cleanup_expired(&self) {
+        if let Ok(mut tasks) = self.tasks.write() {
+            tasks.retain(|_, state| {
+                if !state.task.status.is_terminal() {
+                    return true;
+                }
+                match state.task.ttl {
+                    Some(ttl_ms) => {
+                        state.created.elapsed() < std::time::Duration::from_millis(ttl_ms)
+                    }
+                    None => true,
+                }
+            });
+        }
+    }
 }
 
 /// Serve task queries from a [`TaskManager`] store.
@@ -250,6 +297,9 @@ pub fn route_task_store(
     method: &str,
     params: Option<&Value>,
 ) -> Option<Result<Value, McpError>> {
+    // Sweep expired terminal tasks on access, so a session that stops creating
+    // but keeps polling/listing still bounds its store.
+    store.cleanup_expired();
     let task_id = || {
         params
             .and_then(|p| p.get("taskId"))
@@ -453,5 +503,83 @@ mod tests {
         assert_eq!(service.manager().list().len(), 1);
         assert!(service.manager().get(&task_id).is_some());
         Ok(())
+    }
+
+    // --- #121: TTL cleanup ------------------------------------------------
+
+    #[test]
+    fn omitted_ttl_is_materialized_to_default() {
+        let manager = Arc::new(TaskManager::with_default_ttl(Some(5000)));
+        // Omitted ttl -> materialized to the default so the task reports it.
+        assert_eq!(manager.create(None).task().unwrap().ttl, Some(5000));
+        // An explicit ttl is preserved.
+        assert_eq!(manager.create(Some(1234)).task().unwrap().ttl, Some(1234));
+    }
+
+    #[test]
+    fn cleanup_expired_evicts_old_terminal_task() {
+        let manager = Arc::new(TaskManager::with_default_ttl(Some(1)));
+        let handle = manager.create(None); // ttl materialized to 1ms
+        let id = handle.id().clone();
+        handle.complete(serde_json::json!({})).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        manager.cleanup_expired();
+        assert!(
+            manager.get(&id).is_none(),
+            "expired terminal task not evicted"
+        );
+    }
+
+    #[test]
+    fn cleanup_expired_keeps_fresh_terminal_task() {
+        let manager = Arc::new(TaskManager::new());
+        let handle = manager.create(Some(60_000));
+        let id = handle.id().clone();
+        handle.complete(serde_json::json!({})).unwrap();
+        manager.cleanup_expired();
+        assert!(
+            manager.get(&id).is_some(),
+            "fresh terminal task wrongly evicted"
+        );
+    }
+
+    #[test]
+    fn cleanup_expired_keeps_non_terminal_task() {
+        let manager = Arc::new(TaskManager::with_default_ttl(Some(1)));
+        let handle = manager.create(None); // stays Working
+        let id = handle.id().clone();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        manager.cleanup_expired();
+        assert!(
+            manager.get(&id).is_some(),
+            "non-terminal task must never be evicted"
+        );
+    }
+
+    #[test]
+    fn unlimited_ttl_is_never_evicted() {
+        let manager = Arc::new(TaskManager::with_default_ttl(None));
+        let handle = manager.create(None); // ttl stays None (unlimited)
+        let id = handle.id().clone();
+        assert_eq!(handle.task().unwrap().ttl, None);
+        handle.complete(serde_json::json!({})).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        manager.cleanup_expired();
+        assert!(
+            manager.get(&id).is_some(),
+            "unlimited-ttl task wrongly evicted"
+        );
+    }
+
+    #[test]
+    fn route_task_store_access_triggers_cleanup() {
+        let manager = Arc::new(TaskManager::with_default_ttl(Some(1)));
+        let handle = manager.create(None);
+        let id = handle.id().clone();
+        handle.complete(serde_json::json!({})).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        // A tasks/* access (not just create) sweeps the store.
+        let _ = route_task_store(&manager, "tasks/list", None);
+        assert!(manager.get(&id).is_none(), "access did not trigger cleanup");
     }
 }

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -457,6 +457,9 @@ pub struct RuntimeConfig {
     /// How long a server-initiated request (e.g. elicitation, sampling) waits
     /// for the client's response before failing.
     pub outbound_request_timeout: Duration,
+    /// Retention (milliseconds) applied to a task whose `tools/call` omits a
+    /// `ttl`. `None` means unlimited (such tasks are never TTL-evicted).
+    pub default_task_ttl_ms: Option<u64>,
 }
 
 impl Default for RuntimeConfig {
@@ -465,6 +468,7 @@ impl Default for RuntimeConfig {
             auto_initialized: true,
             max_concurrent_requests: 100,
             outbound_request_timeout: Duration::from_secs(60),
+            default_task_ttl_ms: Some(crate::capability::tasks::DEFAULT_TASK_TTL_MS),
         }
     }
 }
@@ -1090,14 +1094,7 @@ where
 {
     /// Create a new server runtime.
     pub fn new(server: Server<H, T, R, P, K>, transport: Tr) -> Self {
-        let caps = server.capabilities().clone();
-        Self {
-            server,
-            transport: Arc::new(transport),
-            state: Arc::new(ServerState::new(caps)),
-            task_store: Arc::new(crate::capability::tasks::TaskManager::new()),
-            config: RuntimeConfig::default(),
-        }
+        Self::with_config(server, transport, RuntimeConfig::default())
     }
 
     /// Create a new server runtime with custom configuration.
@@ -1107,11 +1104,14 @@ where
         config: RuntimeConfig,
     ) -> Self {
         let caps = server.capabilities().clone();
+        let task_store = Arc::new(crate::capability::tasks::TaskManager::with_default_ttl(
+            config.default_task_ttl_ms,
+        ));
         Self {
             server,
             transport: Arc::new(transport),
             state: Arc::new(ServerState::new(caps)),
-            task_store: Arc::new(crate::capability::tasks::TaskManager::new()),
+            task_store,
             config,
         }
     }

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -117,6 +117,18 @@ where
         self
     }
 
+    /// Set the default task retention (milliseconds) for each session's task
+    /// store, applied when a task-augmented `tools/call` omits a `ttl`. Pass
+    /// `None` for unlimited retention.
+    #[must_use]
+    pub fn with_task_ttl(mut self, default_task_ttl: Option<u64>) -> Self {
+        // The builder owns the only reference to the state at this point.
+        if let Some(state) = Arc::get_mut(&mut self.state) {
+            state.sessions.default_task_ttl = default_task_ttl;
+        }
+        self
+    }
+
     fn set_origin_validator(&mut self, validator: OriginValidator) {
         // The builder owns the only reference to the state at this point, so
         // `get_mut` succeeds.

--- a/crates/mcpkit-warp/src/session.rs
+++ b/crates/mcpkit-warp/src/session.rs
@@ -18,6 +18,9 @@ pub struct SessionStore {
     sessions: Arc<DashMap<String, SessionState>>,
     sse_channels: Arc<DashMap<String, broadcast::Sender<String>>>,
     idle_timeout: Duration,
+    /// Default task retention (ms) applied to each session's task store; `None`
+    /// means unlimited. Configure via `McpRouter::with_task_ttl`.
+    pub(crate) default_task_ttl: Option<u64>,
 }
 
 struct SessionState {
@@ -47,6 +50,7 @@ impl SessionStore {
             sessions: Arc::new(DashMap::new()),
             sse_channels: Arc::new(DashMap::new()),
             idle_timeout: DEFAULT_SESSION_TIMEOUT,
+            default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
         }
     }
 
@@ -83,7 +87,11 @@ impl SessionStore {
                 protocol_version: None,
                 client_capabilities: None,
                 user,
-                tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
+                tasks: Arc::new(
+                    mcpkit_server::capability::tasks::TaskManager::with_default_ttl(
+                        self.default_task_ttl,
+                    ),
+                ),
             },
         );
         id

--- a/crates/mcpkit-warp/src/state.rs
+++ b/crates/mcpkit-warp/src/state.rs
@@ -100,6 +100,16 @@ impl<H> McpState<H> {
         self.completion = Some(Arc::new(completion));
         self
     }
+
+    /// Set the default task retention (milliseconds) for each session's task
+    /// store, applied when a task-augmented `tools/call` omits a `ttl`. Pass
+    /// `None` for unlimited retention. Defaults to
+    /// [`DEFAULT_TASK_TTL_MS`](mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS).
+    #[must_use]
+    pub fn with_task_ttl(mut self, default_task_ttl: Option<u64>) -> Self {
+        self.sessions.default_task_ttl = default_task_ttl;
+        self
+    }
 }
 
 impl<H: mcpkit_server::ServerHandler> McpState<H> {


### PR DESCRIPTION
Closes #121. Builds on #122 (per-session adapter task stores).

## Problem
`TaskManager::cleanup` existed but was **never called** and ignored each task's `ttl` (it swept a global `max_age` against `last_access`). So terminal tasks accumulated for the store's lifetime — now magnified by #122, where every per-session adapter store has the same leak.

## Change
- **`cleanup_expired()`**: evicts a terminal task when its age *since creation* (new `TaskState.created`) exceeds its own `ttl` (ms). Non-terminal tasks are always kept; a task with `ttl = None` is never evicted (truly unlimited). Called on `create` **and** at the top of the shared `route_task_store`, so it runs for the stdio runtime and all four adapters with **no timer** (executor-agnostic, per the issue's constraint).
- **Materialize the default at creation** (per review): an omitted `ttl` becomes `Some(default_ms)` at `create`, so the returned `CreateTaskResult` reports the task's *actual* retention instead of reporting `null` while being evicted anyway. `None` stays genuinely unlimited.
- **Configurable end-to-end**: `TaskManager::with_default_ttl(Option<u64>)` (`None` = unlimited); `RuntimeConfig::default_task_ttl_ms` for the stdio runtime; and `McpRouter::with_task_ttl` / `McpState::with_task_ttl` on axum/actix/warp/rocket (threaded into each session's task store). Default `DEFAULT_TASK_TTL_MS` = 1 hour.
- Left the old dead `cleanup(max_age)` untouched — added `cleanup_expired()` as a distinct method rather than silently repurposing it (per review's API note).

## Design decisions (as agreed with reviewers)
- **TTL from creation** (matches `Task.ttl` docs). Documented edge case: a `ttl` shorter than the tool's runtime makes the result evictable at completion.
- **`None` = unlimited stays honest** by materializing the default at creation rather than hiding it in cleanup.
- **Sweep on create + access**, not create-only, so a session that stops creating but keeps polling still bounds its store.

## Tests
- Core (`capability/tasks.rs`): terminal past its explicit ttl evicted; fresh terminal survives; non-terminal never evicted; omitted ttl materialized to the default; `with_default_ttl(None)` never evicted; `route_task_store` access (not just create) triggers cleanup.
- axum E2E: `with_task_ttl` materializes the configured retention on `CreateTaskResult` through the adapter (proves the config threads to the per-session store).

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --all-features --locked` (1324 tests, 0 failures) all green.