### PR TITLE
docs(tasks): guide CPU-bound/blocking tool handlers to offload (#123)

### DIFF
--- a/crates/mcpkit-server/src/handler.rs
+++ b/crates/mcpkit-server/src/handler.rs
@@ -130,6 +130,16 @@ pub trait ToolHandler: Send + Sync {
     /// (or [`ValidatingToolHandler`](crate::validation::ValidatingToolHandler) for
     /// adapter users) to enforce those schemas.
     ///
+    /// # CPU-bound or blocking work
+    ///
+    /// The stdio runtime drives requests cooperatively on one task, so a
+    /// `call_tool` that does heavy CPU work (or blocks) *before* awaiting stalls
+    /// all other in-flight requests until it yields. Offload the hot section to
+    /// your runtime's blocking/thread mechanism — `tokio::task::spawn_blocking`,
+    /// `std::thread`, `rayon`, etc. — and `.await` its result. The same applies to
+    /// task-augmented tools: background task futures are polled by the same
+    /// cooperative loop.
+    ///
     /// # Arguments
     ///
     /// * `name` - The name of the tool to call


### PR DESCRIPTION
Resolves #123 with a documented workaround instead of building the optional executor knob.

## Why not build the `futures::Spawn` executor
Two independent reviews plus the code converged on the same conclusion:
- **The ownership cost is real, the value narrow.** Background task futures borrow `&self` and call `self.server.call_tool_json` where `server: S` is owned (not `Arc`). Spawning onto an external executor forces `ServerRuntime.server → Arc<S>` + `S: Send + Sync + 'static` + new public runtime config + a run-loop branch — a core refactor for a severity-low, opt-in feature.
- **A generic `futures::task::Spawn` knob doesn't even reliably fix the problem** — it only helps if the user wires a genuinely *threaded* pool; on the same async runtime, CPU-bound futures still starve workers.
- **The stall isn't task-specific.** Normal requests run through `in_flight.push(self.handle_request_isolated(request))`, polled cooperatively by the same loop — so a CPU-bound `call_tool` stalls a plain `tools/call` too.

## Change
A note on `ToolHandler::call_tool` (the general, visible spot): offload CPU-bound/blocking work to `tokio::task::spawn_blocking` / `std::thread` / `rayon` and `.await` the result, with a task-specific note that background task futures share the same cooperative loop.

Doc-only. `RUSTDOCFLAGS=-D warnings cargo doc` clean.

## Not a forever-rejection
Closing as "documented workaround / deferred until demand." If a real user needs library-managed offload, revisit with a purpose-built blocking-executor API rather than a generic `Spawn` knob.