### PR TITLE
docs: refresh stale struct-literal examples after fidelity work (#149)

### DIFF
--- a/docs/macros.md
+++ b/docs/macros.md
@@ -486,12 +486,9 @@ impl ServerHandler for MyServer {
 impl ToolHandler for MyServer {
     async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
         Ok(vec![
-            Tool {
-                name: "hello".to_string(),
-                description: Some("Say hello".to_string()),
-                input_schema: json!({"type": "object", "properties": {}}),
-                annotations: None,
-            }
+            Tool::new("hello")
+                .description("Say hello")
+                .input_schema(json!({"type": "object", "properties": {}})),
         ])
     }
 

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -20,6 +20,7 @@ impl PromptServer {
             messages: vec![
                 PromptMessage::user(format!("Please greet {} warmly.", name))
             ],
+            meta: None,
         }
     }
 }
@@ -49,6 +50,7 @@ async fn code_review(&self, code: String, language: String) -> GetPromptResult {
                 language, language, code
             ))
         ],
+        meta: None,
     }
 }
 ```
@@ -76,6 +78,7 @@ async fn code_review(
                 lang, code, focus_text
             ))
         ],
+        meta: None,
     }
 }
 ```
@@ -125,6 +128,7 @@ async fn debug_session(&self, error_message: String) -> GetPromptResult {
                  2. What changes did you make recently?"
             ),
         ],
+        meta: None,
     }
 }
 ```
@@ -148,6 +152,7 @@ async fn analyze_file(&self, file_path: String) -> GetPromptResult {
                 file_path, content
             ))
         ],
+        meta: None,
     }
 }
 ```
@@ -182,6 +187,7 @@ async fn generate_tests(
                 code
             ))
         ],
+        meta: None,
     }
 }
 ```
@@ -222,6 +228,7 @@ impl WritingAssistant {
                     text
                 )),
             ],
+            meta: None,
         }
     }
 
@@ -258,6 +265,7 @@ impl WritingAssistant {
                     length_instruction, format_instruction, content
                 )),
             ],
+            meta: None,
         }
     }
 
@@ -286,6 +294,7 @@ impl WritingAssistant {
                     target_language, tone_instruction, text
                 )),
             ],
+            meta: None,
         }
     }
 }

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -124,6 +124,7 @@ ToolOutput::success(CallToolResult {
         Content::text("Second result"),
     ],
     is_error: Some(false),
+    ..Default::default()
 })
 ```
 


### PR DESCRIPTION
Closes #149. The "sweep once after the fidelity work settles" cleanup.

## Change
Illustrative struct literals in the docs drifted as fields were added across the pre-1.0 fidelity work. Refreshed them, preferring self-maintaining forms:
- **docs/macros.md** — the `Tool { name, description, input_schema, annotations }` literal (the one the issue cites; missing `title`/`icons`/`execution`/`output_schema`/`meta`) → `Tool::new(..).description(..).input_schema(..)` builder, so it no longer drifts on additive fields.
- **docs/tools.md** — `CallToolResult` literal → `..Default::default()` (the type already derives `Default`) to cover `structured_content`/`meta`.
- **docs/prompts.md** — 9 `GetPromptResult` literals gained the `meta` field they were missing.

## Notes
- **Docs-only, no type code touched** — uses existing builders/`Default`. These `.md` files are illustrative (not compiled as doctests).
- **Scope was smaller than it looked:** the raw literal counts were inflated by false positives — `-> ToolOutput {` / `-> ResourceContents {` / `-> GetPromptResult {` / `-> CallToolResult {` are *function return-type signatures* that already use constructors (`ToolOutput::text`, `ResourceContents::text`, …). The real stale literals were only these three spots.
- **Left `arguments`/`structuredContent` examples untouched** so a future #147 (`Value` → object map) doesn't immediately re-churn them.