### PR TITLE
feat(tasks): route tasks/list through ListTasksResult (nextCursor + _meta) (#150)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `tasks/list` now routes through `ListTasksResult`, so it can carry `nextCursor`
+  and result-level `_meta` (#150). Both task-list paths (the runtime/adapter
+  built-in store and the user-`TaskHandler` route) previously hand-built
+  `{ "tasks": .. }`, bypassing the modeled wrapper — `get_task`/`cancel_task`
+  already returned `_meta`-capable wrappers (#136), leaving `list_tasks` the lone
+  outlier.
+  - **Breaking:** `TaskHandler::list_tasks` returns `ListTasksResult` instead of
+    `Vec<Task>`. `From<Vec<Task>> for ListTasksResult` keeps the common case
+    ergonomic (`Ok(tasks.into())`), mirroring `GetTaskResult::from(Task)`.
+  - The wire is unchanged for the common case (`nextCursor`/`_meta` omit when
+    `None`); only a handler that sets them changes the output.
+  - Request-cursor input (threading `ListTasksRequest.cursor` into `list_tasks`
+    for real cursor-driven pagination) is intentionally left as a follow-up —
+    this enables the wrapper, `_meta`, and the ability to emit `nextCursor`
+    ([#150](https://github.com/praxiomlabs/mcpkit/issues/150)).
 - TTL cleanup for terminal tasks (#121). `TaskManager::cleanup` existed but was
   never called and ignored each task's `ttl`, so terminal tasks accumulated for
   the store's lifetime — now magnified by #122's per-session adapter stores. Now:

--- a/crates/mcpkit-core/src/types/task.rs
+++ b/crates/mcpkit-core/src/types/task.rs
@@ -278,6 +278,17 @@ pub struct ListTasksResult {
     pub meta: Option<Meta>,
 }
 
+impl From<Vec<Task>> for ListTasksResult {
+    /// Wrap a task list with no `nextCursor` and no `_meta`.
+    fn from(tasks: Vec<Task>) -> Self {
+        Self {
+            tasks,
+            next_cursor: None,
+            meta: None,
+        }
+    }
+}
+
 /// Request parameters for `tasks/get`.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GetTaskRequest {

--- a/crates/mcpkit-server/src/builder.rs
+++ b/crates/mcpkit-server/src/builder.rs
@@ -527,8 +527,8 @@ mod tests {
         async fn list_tasks(
             &self,
             _ctx: &Context<'_>,
-        ) -> Result<Vec<mcpkit_core::types::Task>, McpError> {
-            Ok(vec![])
+        ) -> Result<mcpkit_core::types::ListTasksResult, McpError> {
+            Ok(vec![].into())
         }
         async fn get_task(
             &self,

--- a/crates/mcpkit-server/src/capability/tasks.rs
+++ b/crates/mcpkit-server/src/capability/tasks.rs
@@ -7,7 +7,9 @@ use crate::context::CancellationToken;
 use crate::context::Context;
 use crate::handler::TaskHandler;
 use mcpkit_core::error::McpError;
-use mcpkit_core::types::task::{CancelTaskResult, GetTaskResult, Task, TaskId, TaskStatus};
+use mcpkit_core::types::task::{
+    CancelTaskResult, GetTaskResult, ListTasksResult, Task, TaskId, TaskStatus,
+};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
@@ -307,7 +309,12 @@ pub fn route_task_store(
             .map(TaskId::new)
     };
     match method {
-        "tasks/list" => Some(Ok(serde_json::json!({ "tasks": store.list() }))),
+        "tasks/list" => {
+            // Serialize through `ListTasksResult` (the built-in store has no
+            // cursor/`_meta` to add). `nextCursor`/`_meta` omit when `None`.
+            let result = ListTasksResult::from(store.list());
+            Some(Ok(serde_json::to_value(result).unwrap_or_default()))
+        }
         "tasks/get" => {
             let Some(id) = task_id() else {
                 return Some(Err(McpError::invalid_params("tasks/get", "missing taskId")));
@@ -393,8 +400,8 @@ impl TaskService {
 }
 
 impl TaskHandler for TaskService {
-    async fn list_tasks(&self, _ctx: &Context<'_>) -> Result<Vec<Task>, McpError> {
-        Ok(self.manager.list())
+    async fn list_tasks(&self, _ctx: &Context<'_>) -> Result<ListTasksResult, McpError> {
+        Ok(self.manager.list().into())
     }
 
     async fn get_task(

--- a/crates/mcpkit-server/src/dispatch.rs
+++ b/crates/mcpkit-server/src/dispatch.rs
@@ -16,8 +16,9 @@ use crate::context::Context;
 use crate::handler::{CompletionHandler, PromptHandler, ResourceHandler, TaskHandler, ToolHandler};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    CancelTaskResult, CompleteRequest, CompleteResult, GetPromptResult, GetTaskResult, Prompt,
-    Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool, ToolOutput,
+    CancelTaskResult, CompleteRequest, CompleteResult, GetPromptResult, GetTaskResult,
+    ListTasksResult, Prompt, Resource, ResourceContents, ResourceTemplate, TaskId, Tool,
+    ToolOutput,
 };
 use serde_json::Value;
 use std::future::Future;
@@ -162,7 +163,10 @@ impl<P: PromptHandler> DynPromptHandler for P {
 /// Object-safe form of [`TaskHandler`].
 pub trait DynTaskHandler: Send + Sync {
     /// See [`TaskHandler::list_tasks`].
-    fn list_tasks<'a>(&'a self, ctx: &'a Context<'_>) -> BoxFut<'a, Result<Vec<Task>, McpError>>;
+    fn list_tasks<'a>(
+        &'a self,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<ListTasksResult, McpError>>;
     /// See [`TaskHandler::get_task`].
     fn get_task<'a>(
         &'a self,
@@ -178,7 +182,10 @@ pub trait DynTaskHandler: Send + Sync {
 }
 
 impl<K: TaskHandler> DynTaskHandler for K {
-    fn list_tasks<'a>(&'a self, ctx: &'a Context<'_>) -> BoxFut<'a, Result<Vec<Task>, McpError>> {
+    fn list_tasks<'a>(
+        &'a self,
+        ctx: &'a Context<'_>,
+    ) -> BoxFut<'a, Result<ListTasksResult, McpError>> {
         Box::pin(TaskHandler::list_tasks(self, ctx))
     }
     fn get_task<'a>(

--- a/crates/mcpkit-server/src/handler.rs
+++ b/crates/mcpkit-server/src/handler.rs
@@ -37,8 +37,9 @@
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
-    CancelTaskResult, CompleteRequest, CompleteResult, GetPromptResult, GetTaskResult, Prompt,
-    Resource, ResourceContents, ResourceTemplate, Task, TaskId, Tool, ToolOutput,
+    CancelTaskResult, CompleteRequest, CompleteResult, GetPromptResult, GetTaskResult,
+    ListTasksResult, Prompt, Resource, ResourceContents, ResourceTemplate, TaskId, Tool,
+    ToolOutput,
 };
 use serde_json::Value;
 use std::future::Future;
@@ -239,11 +240,15 @@ pub trait PromptHandler: Send + Sync {
 /// Implement this trait to support long-running operations that can be
 /// tracked, monitored, and cancelled.
 pub trait TaskHandler: Send + Sync {
-    /// List all tasks, optionally filtered by status.
+    /// List all tasks.
+    ///
+    /// The [`ListTasksResult`] wrapper may carry `nextCursor` and result-level
+    /// `_meta`; `Vec<Task>::into()` produces one with neither. (Request-cursor
+    /// input for real pagination is not yet threaded — see #150.)
     fn list_tasks(
         &self,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Vec<Task>, McpError>> + Send;
+    ) -> impl Future<Output = Result<ListTasksResult, McpError>> + Send;
 
     /// Get the current state of a task.
     ///
@@ -415,7 +420,7 @@ impl<T: TaskHandler> TaskHandler for Arc<T> {
     fn list_tasks(
         &self,
         ctx: &Context<'_>,
-    ) -> impl Future<Output = Result<Vec<Task>, McpError>> + Send {
+    ) -> impl Future<Output = Result<ListTasksResult, McpError>> + Send {
         (**self).list_tasks(ctx)
     }
 

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -1016,7 +1016,7 @@ pub async fn route_tasks(
     match method {
         methods::TASKS_LIST => {
             let result = handler.list_tasks(ctx).await;
-            Some(result.map(|tasks| serde_json::json!({ "tasks": tasks })))
+            Some(result.map(|r| serde_json::to_value(r).unwrap_or_default()))
         }
         methods::TASKS_GET => {
             let result = async {
@@ -1697,18 +1697,25 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn route_tasks_get_and_cancel_emit_result_meta() {
+    async fn route_tasks_list_get_and_cancel_emit_result_meta() {
         use crate::context::NoOpPeer;
         use mcpkit_core::capability::{ClientCapabilities, ServerCapabilities};
         use mcpkit_core::protocol::RequestId;
         use mcpkit_core::protocol_version::ProtocolVersion;
-        use mcpkit_core::types::{CancelTaskResult, GetTaskResult, Meta, Task, TaskId};
+        use mcpkit_core::types::{
+            CancelTaskResult, GetTaskResult, ListTasksResult, Meta, Task, TaskId,
+        };
 
-        // A handler that attaches result-level `_meta` on both get and cancel.
+        // A handler that attaches result-level `_meta` on list/get/cancel and a
+        // `nextCursor` on list.
         struct MetaTaskHandler;
         impl crate::handler::TaskHandler for MetaTaskHandler {
-            async fn list_tasks(&self, _ctx: &Context<'_>) -> Result<Vec<Task>, McpError> {
-                Ok(vec![])
+            async fn list_tasks(&self, _ctx: &Context<'_>) -> Result<ListTasksResult, McpError> {
+                Ok(ListTasksResult {
+                    tasks: vec![],
+                    next_cursor: Some("page-2".to_string()),
+                    meta: Some(Meta::new().with("origin", serde_json::json!("test"))),
+                })
             }
             async fn get_task(
                 &self,
@@ -1756,6 +1763,15 @@ mod tests {
             assert_eq!(resp["taskId"], "t-1", "{method}");
             assert_eq!(resp["_meta"]["origin"], "test", "{method}");
         }
+
+        // tasks/list now carries `nextCursor` + result-level `_meta` through the
+        // `ListTasksResult` wrapper (previously hand-built as `{ "tasks": .. }`).
+        let listed = route_tasks(&handler, methods::TASKS_LIST, None, &ctx)
+            .await
+            .expect("routed")
+            .expect("ok");
+        assert_eq!(listed["nextCursor"], "page-2");
+        assert_eq!(listed["_meta"]["origin"], "test");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #150.

## Problem
Both `tasks/list` paths serialized `{ "tasks": .. }` by hand, bypassing the modeled `ListTasksResult` — so `nextCursor` and result-level `_meta` were unreachable even though the type supports both:
- `capability::tasks::route_task_store` (runtime + adapters' built-in store)
- `router::route_tasks` (the user-`TaskHandler` path)

Root cause is a **consistency gap**: `get_task`/`cancel_task` already return `_meta`-capable wrappers (`GetTaskResult`/`CancelTaskResult`, from #136), but `list_tasks` was left returning a bare `Vec<Task>` — the lone outlier.

## Change
- **Breaking:** `TaskHandler::list_tasks` returns `ListTasksResult` instead of `Vec<Task>`. `From<Vec<Task>> for ListTasksResult` keeps the common case ergonomic (`Ok(tasks.into())`), mirroring `GetTaskResult::from(Task)`. Updated `DynTaskHandler`, the `Arc<T>` forward, `TaskService`, and both test handlers.
- Both routes now serialize through `ListTasksResult` (de-dup): `route_tasks` emits the handler's result; the built-in `route_task_store` emits `{ tasks, next_cursor: None, meta: None }`.
- **Wire unchanged for the common case** — `skip_serializing_if` omits `nextCursor`/`_meta` when `None` (the existing `{ "tasks": [] }` assertion still passes). Only a handler that *sets* them changes the output.

## Scope (as agreed)
Request-cursor **input** — threading `ListTasksRequest.cursor` into `list_tasks` for real cursor-driven pagination — is intentionally **deferred**. This PR enables the wrapper, `_meta`, and the ability to *emit* `nextCursor`; driving pagination end-to-end needs a cursor-semantics + store-pagination decision and is a separate follow-up.

## Tests
`MetaTaskHandler` now returns `nextCursor` + `_meta` on `list_tasks`, asserted on the wire alongside the existing `get`/`cancel` `_meta` checks.

## Verification
`cargo fmt --check`, `clippy --workspace --all-features --all-targets -D warnings`, `RUSTDOCFLAGS=-D warnings cargo doc --all-features`, and `cargo test --workspace --all-features --locked` (1324 tests, 0 failures) all green.