### PR TITLE
chore: follow-ups from the #147 object-typing review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `Object` is re-exported from the `mcpkit_core` prelude (and therefore
+  `mcpkit::prelude::*`), since `ToolHandler::call_tool` implementors now need it
+  in every signature (follow-up to #147). Also from the #147 review: regression
+  tests pinning the non-object `arguments` rejection (`tools/call` and
+  `prompts/get` parsing, `Client::call_tool`), and the hand-rolled JSON-RPC
+  examples (http-server, websocket-server, multi-service, with-middleware) now
+  reject a non-object `arguments` with invalid params instead of silently
+  defaulting it to `{}`.
 - `tasks/list` now routes through `ListTasksResult`, so it can carry `nextCursor`
   and result-level `_meta` (#150). Both task-list paths (the runtime/adapter
   built-in store and the user-`TaskHandler` route) previously hand-built

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -1542,6 +1542,32 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn call_tool_rejects_non_object_arguments_before_sending() {
+        let init = InitializeResult {
+            capabilities: ServerCapabilities::new().with_tools(),
+            ..test_init_result()
+        };
+        let client = Client::new(
+            SilentTransport,
+            init,
+            ClientInfo::new("test-client", "1.0.0"),
+            ClientCapabilities::default(),
+            Duration::from_secs(3600),
+        );
+
+        // Rejected locally, so this returns immediately even though the
+        // transport never answers.
+        let err = client
+            .call_tool("add", serde_json::json!(5))
+            .await
+            .expect_err("non-object arguments must be rejected");
+        assert!(
+            err.to_string().contains("arguments must be a JSON object"),
+            "expected invalid-params on arguments, got: {err}"
+        );
+    }
+
     /// A transport that serves `tools/list` in fixed-size pages, echoing an
     /// opaque numeric `nextCursor`. With `stuck_cursor` it always returns the
     /// same cursor, to exercise the non-advancing-cursor guard.

--- a/crates/mcpkit-core/src/lib.rs
+++ b/crates/mcpkit-core/src/lib.rs
@@ -127,6 +127,8 @@ pub mod prelude {
         ListTasksRequest,
         ListTasksResult,
         ModelPreferences,
+        // The JSON object map used by object-typed spec fields
+        Object,
         Prompt,
         PromptArgument,
         PromptMessage,

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -1245,6 +1245,32 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_tools_call_rejects_non_object_arguments() {
+        let request = make_request(
+            "tools/call",
+            Some(serde_json::json!({ "name": "search", "arguments": 5 })),
+        );
+        let err = parse_request(&request).expect_err("non-object arguments must be rejected");
+        assert!(
+            err.to_string().contains("arguments must be an object"),
+            "expected invalid-params on arguments, got: {err}"
+        );
+    }
+
+    #[test]
+    fn test_parse_prompts_get_rejects_non_object_arguments() {
+        let request = make_request(
+            "prompts/get",
+            Some(serde_json::json!({ "name": "code-review", "arguments": ["rust"] })),
+        );
+        let err = parse_request(&request).expect_err("non-object arguments must be rejected");
+        assert!(
+            err.to_string().contains("arguments must be an object"),
+            "expected invalid-params on arguments, got: {err}"
+        );
+    }
+
+    #[test]
     fn test_parse_unknown_method() -> Result<(), Box<dyn std::error::Error>> {
         let request = make_request("unknown/method", None);
         let parsed = parse_request(&request)?;

--- a/examples/http-server/src/main.rs
+++ b/examples/http-server/src/main.rs
@@ -336,7 +336,16 @@ async fn handle_request(state: &AppState, session_id: &str, request: &Request) -
 
         "tools/call" => {
             let name = params["name"].as_str().unwrap_or("");
-            let args = params.get("arguments").cloned().unwrap_or(json!({}));
+            let args = match params.get("arguments") {
+                None => json!({}),
+                Some(v) if v.is_object() => v.clone(),
+                Some(_) => {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        JsonRpcError::invalid_params("arguments must be an object"),
+                    );
+                }
+            };
 
             match call_tool(name, &args) {
                 Ok(output) => {

--- a/examples/multi-service/src/tools_service.rs
+++ b/examples/multi-service/src/tools_service.rs
@@ -138,7 +138,16 @@ async fn handle_request(state: &AppState, request: &Request) -> JsonRpcResponse 
         }
         "tools/call" => {
             let name = params["name"].as_str().unwrap_or("");
-            let args = params.get("arguments").cloned().unwrap_or(json!({}));
+            let args = match params.get("arguments") {
+                None => json!({}),
+                Some(v) if v.is_object() => v.clone(),
+                Some(_) => {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        JsonRpcError::invalid_params("arguments must be an object"),
+                    );
+                }
+            };
             match call_tool(name, &args) {
                 Ok(output) => {
                     let result: CallToolResult = output.into();

--- a/examples/websocket-server/src/main.rs
+++ b/examples/websocket-server/src/main.rs
@@ -341,7 +341,16 @@ fn handle_request(state: &ServerState, request: &Request) -> JsonRpcResponse {
 
         "tools/call" => {
             let name = params["name"].as_str().unwrap_or("");
-            let args = params.get("arguments").cloned().unwrap_or(json!({}));
+            let args = match params.get("arguments") {
+                None => json!({}),
+                Some(v) if v.is_object() => v.clone(),
+                Some(_) => {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        JsonRpcError::invalid_params("arguments must be an object"),
+                    );
+                }
+            };
 
             match call_tool(name, &args) {
                 Ok(output) => {

--- a/examples/with-middleware/src/main.rs
+++ b/examples/with-middleware/src/main.rs
@@ -124,7 +124,16 @@ fn handle_request(request: &Request) -> JsonRpcResponse {
 
         "tools/call" => {
             let name = params["name"].as_str().unwrap_or("");
-            let args = params.get("arguments").cloned().unwrap_or(json!({}));
+            let args = match params.get("arguments") {
+                None => json!({}),
+                Some(v) if v.is_object() => v.clone(),
+                Some(_) => {
+                    return JsonRpcResponse::error(
+                        request.id.clone(),
+                        JsonRpcError::invalid_params("arguments must be an object"),
+                    );
+                }
+            };
 
             match call_tool(name, &args) {
                 Ok(output) => {


### PR DESCRIPTION
Follow-ups from the review of #160 (issue #147). No library behavior changes beyond one prelude re-export.

- **Prelude ergonomics:** `Object` is now re-exported from the `mcpkit_core` prelude (and therefore `mcpkit::prelude::*`). `ToolHandler::call_tool` implementors must name `Object` in every signature, and the prelude already carries the rest of the tool surface (`Tool`, `ToolOutput`, `CallToolResult`).
- **Regression tests** pinning the non-object `arguments` rejection introduced by #147, which previously had no test coverage: `tools/call` and `prompts/get` parsing return invalid params, and `Client::call_tool` rejects a non-object/non-null `arguments` locally before anything is sent.
- **Examples:** the four hand-rolled JSON-RPC loops (http-server, websocket-server, multi-service, with-middleware) still silently defaulted a present-but-non-object `arguments` to `{}` — the exact behavior #147 removed from the library, since these examples bypass the router. They now answer with invalid params (`JsonRpcError::invalid_params`), matching the library's boundary behavior.

## Verification

Full local gate: `cargo fmt --all --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --all-features --no-deps`, `cargo test --workspace --all-features --locked` — all green (73 test suites, 0 failures).