### PR TITLE
feat(core)!: task-augmented sampling types and tasks capability (#143 phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Task-augmented sampling, phase 1 of #143 — types and capabilities:
+  - `CreateMessageRequest` gains the spec's `task: Option<TaskMetadata>` field
+    (2025-11-25 `CreateMessageRequestParams extends TaskAugmentedRequestParams`)
+    plus a `with_task` builder. Omitted from the wire when unset.
+  - New spec-shaped `TasksCapability` (`{ list, cancel, requests: { sampling,
+    elicitation, tools } }`) shared by both sides. `ClientCapabilities` gains
+    `tasks` with `with_tasks()` / `with_task_sampling()` / `has_task_sampling()`.
+  - **Breaking:** `ServerCapabilities.tasks` migrates from the non-spec
+    `TaskCapability { cancellable }` (no such key exists in the schema) to
+    `TasksCapability`. `ServerCapabilities::with_tasks()` now declares
+    `{ list: {}, cancel: {} }`; task-augmented `tools/call` is declared via the
+    new `with_task_tools()`. The `#[mcp_server]` macro (for tools declaring
+    `task_support`) and `ServerBuilder` advertise the full shape — the builder
+    upgrades to `requests.tools.call` when both tool and task handlers are
+    registered, in either registration order.
+  - Per spec, a receiver that has not declared task support for a request type
+    MUST process it normally, ignoring task metadata: the client now strips
+    `task` before invoking `ClientHandler::create_message`, so handlers cannot
+    observe a field the spec requires the client to ignore. (The task-augmented
+    execution path — client task store, `tasks/*` serving, `CreateTaskResult`
+    responses — is phase 2/3 of
+    [#143](https://github.com/praxiomlabs/mcpkit/issues/143).)
 - `Object` is re-exported from the `mcpkit_core` prelude (and therefore
   `mcpkit::prelude::*`), since `ToolHandler::call_tool` implementors now need it
   in every signature (follow-up to #147). Also from the #147 review: regression

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -359,7 +359,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         handler: &Arc<H>,
         client_caps: &Arc<ClientCapabilities>,
     ) -> Response {
-        let params = match &request.params {
+        let mut params = match &request.params {
             Some(p) => match serde_json::from_value::<CreateMessageRequest>(p.clone()) {
                 Ok(req) => req,
                 Err(e) => {
@@ -376,6 +376,13 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
                 );
             }
         };
+
+        // Task-augmented sampling is not supported yet (#143): the client does
+        // not declare `tasks.requests.sampling.createMessage`, and per spec an
+        // undeclared receiver MUST process the request normally, ignoring the
+        // task metadata. Strip it so handlers cannot observe a field the spec
+        // requires us to ignore.
+        params.task = None;
 
         // Per spec, a client MUST reject tool-augmented sampling unless it
         // declared the `sampling.tools` capability.
@@ -1772,6 +1779,68 @@ mod tests {
                 .message
                 .contains("sampling.tools"),
             "gate should pass once sampling.tools is declared"
+        );
+    }
+
+    /// Per spec, a receiver that has not declared task support for a request
+    /// type must process it normally, ignoring the task metadata — the handler
+    /// must never observe `task`.
+    #[tokio::test]
+    async fn undeclared_task_augmented_sampling_is_processed_normally() {
+        struct TaskSpy {
+            seen: Arc<std::sync::Mutex<Option<CreateMessageRequest>>>,
+        }
+        impl crate::handler::ClientHandler for TaskSpy {
+            async fn create_message(
+                &self,
+                request: CreateMessageRequest,
+            ) -> Result<mcpkit_core::types::CreateMessageResult, McpError> {
+                *self.seen.lock().unwrap() = Some(request);
+                Ok(mcpkit_core::types::CreateMessageResult {
+                    role: mcpkit_core::types::Role::Assistant,
+                    content: mcpkit_core::types::OneOrMany::One(
+                        mcpkit_core::types::SamplingContent::Text(
+                            mcpkit_core::types::TextContent {
+                                text: "ok".into(),
+                                annotations: None,
+                                meta: None,
+                            },
+                        ),
+                    ),
+                    model: "m".into(),
+                    stop_reason: None,
+                    meta: None,
+                })
+            }
+        }
+
+        let seen = Arc::new(std::sync::Mutex::new(None));
+        let handler = Arc::new(TaskSpy { seen: seen.clone() });
+        let request = Request::with_params(
+            "sampling/createMessage",
+            RequestId::Number(1),
+            serde_json::json!({
+                "messages": [],
+                "maxTokens": 10,
+                "task": { "ttl": 60000 }
+            }),
+        );
+        let caps = Arc::new(ClientCapabilities::new().with_sampling());
+
+        let resp =
+            Client::<SilentTransport, TaskSpy>::handle_sampling_request(&request, &handler, &caps)
+                .await;
+
+        // Processed normally: a plain CreateMessageResult, not a task.
+        let result = resp.result.expect("normal result");
+        assert!(result.get("task").is_none());
+        assert_eq!(result["role"], "assistant");
+        // The handler observed the request with `task` stripped.
+        let seen = seen.lock().unwrap();
+        let request_seen = seen.as_ref().expect("handler was invoked");
+        assert!(
+            request_seen.task.is_none(),
+            "handler must not observe the task field"
         );
     }
 }

--- a/crates/mcpkit-client/src/handler.rs
+++ b/crates/mcpkit-client/src/handler.rs
@@ -248,6 +248,7 @@ mod tests {
                 metadata: None,
                 tools: None,
                 tool_choice: None,
+                task: None,
                 meta: None,
             })
             .await;

--- a/crates/mcpkit-core/src/capability.rs
+++ b/crates/mcpkit-core/src/capability.rs
@@ -20,9 +20,9 @@ pub struct ServerCapabilities {
     /// Prompt capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompts: Option<PromptCapability>,
-    /// Task capabilities.
+    /// Task capabilities (2025-11-25).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub tasks: Option<TaskCapability>,
+    pub tasks: Option<TasksCapability>,
     /// Logging capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub logging: Option<LoggingCapability>,
@@ -81,10 +81,31 @@ impl ServerCapabilities {
         self
     }
 
-    /// Enable task support.
+    /// Enable task support (`tasks/list` and `tasks/cancel`).
+    ///
+    /// This declares the base task operations only. It does **not** advertise
+    /// task augmentation for any request type — a server whose tools accept
+    /// task-augmented `tools/call` must additionally declare it via
+    /// [`with_task_tools`](Self::with_task_tools).
     #[must_use]
     pub fn with_tasks(mut self) -> Self {
-        self.tasks = Some(TaskCapability::default());
+        let tasks = self.tasks.get_or_insert_with(TasksCapability::default);
+        tasks.list = Some(serde_json::json!({}));
+        tasks.cancel = Some(serde_json::json!({}));
+        self
+    }
+
+    /// Declare task-augmented `tools/call` support
+    /// (`tasks.requests.tools.call`).
+    #[must_use]
+    pub fn with_task_tools(mut self) -> Self {
+        self.tasks
+            .get_or_insert_with(TasksCapability::default)
+            .requests
+            .get_or_insert_with(TaskRequestsCapability::default)
+            .tools
+            .get_or_insert_with(ToolsTaskCapability::default)
+            .call = Some(serde_json::json!({}));
         self
     }
 
@@ -214,6 +235,10 @@ pub struct ClientCapabilities {
     /// Elicitation capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub elicitation: Option<ElicitationCapability>,
+    /// Task capabilities (2025-11-25): which client-handled requests accept
+    /// task augmentation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tasks: Option<TasksCapability>,
     /// Experimental capabilities.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<serde_json::Value>,
@@ -303,6 +328,46 @@ impl ClientCapabilities {
             .get_or_insert_with(ElicitationCapability::default)
             .url = Some(serde_json::json!({}));
         self
+    }
+
+    /// Enable task support (`tasks/list` and `tasks/cancel`).
+    ///
+    /// This declares the base task operations only; declare which requests
+    /// accept task augmentation via
+    /// [`with_task_sampling`](Self::with_task_sampling).
+    #[must_use]
+    pub fn with_tasks(mut self) -> Self {
+        let tasks = self.tasks.get_or_insert_with(TasksCapability::default);
+        tasks.list = Some(serde_json::json!({}));
+        tasks.cancel = Some(serde_json::json!({}));
+        self
+    }
+
+    /// Declare task-augmented `sampling/createMessage` support
+    /// (`tasks.requests.sampling.createMessage`).
+    ///
+    /// Declare plain sampling support separately via
+    /// [`with_sampling`](Self::with_sampling).
+    #[must_use]
+    pub fn with_task_sampling(mut self) -> Self {
+        self.tasks
+            .get_or_insert_with(TasksCapability::default)
+            .requests
+            .get_or_insert_with(TaskRequestsCapability::default)
+            .sampling
+            .get_or_insert_with(SamplingTaskCapability::default)
+            .create_message = Some(serde_json::json!({}));
+        self
+    }
+
+    /// Check if task-augmented `sampling/createMessage` is declared.
+    #[must_use]
+    pub fn has_task_sampling(&self) -> bool {
+        self.tasks
+            .as_ref()
+            .and_then(|t| t.requests.as_ref())
+            .and_then(|r| r.sampling.as_ref())
+            .is_some_and(|s| s.create_message.is_some())
     }
 
     /// Check if form-mode elicitation is supported.
@@ -412,12 +477,62 @@ pub struct PromptCapability {
     pub list_changed: Option<bool>,
 }
 
-/// Task capability flags.
+/// `capabilities.tasks` (2025-11-25).
+///
+/// Declared by whichever side *receives* task-augmented requests: servers
+/// declare it for `tools/call`, clients for `sampling/createMessage` /
+/// `elicitation/create`. Per the spec, the `requests` set is exhaustive —
+/// a request type not listed does not support task augmentation.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct TaskCapability {
-    /// If true, the server supports task cancellation.
+pub struct TasksCapability {
+    /// Whether this party supports `tasks/list`.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub cancellable: Option<bool>,
+    pub list: Option<serde_json::Value>,
+    /// Whether this party supports `tasks/cancel`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cancel: Option<serde_json::Value>,
+    /// Which request types can be augmented with tasks.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requests: Option<TaskRequestsCapability>,
+}
+
+/// `capabilities.tasks.requests`: the request types that accept a `task`
+/// field, by category.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TaskRequestsCapability {
+    /// Task support for sampling requests (declared by clients).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sampling: Option<SamplingTaskCapability>,
+    /// Task support for elicitation requests (declared by clients).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub elicitation: Option<ElicitationTaskCapability>,
+    /// Task support for tool requests (declared by servers).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<ToolsTaskCapability>,
+}
+
+/// `capabilities.tasks.requests.sampling`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct SamplingTaskCapability {
+    /// Whether task-augmented `sampling/createMessage` is supported.
+    #[serde(rename = "createMessage", skip_serializing_if = "Option::is_none")]
+    pub create_message: Option<serde_json::Value>,
+}
+
+/// `capabilities.tasks.requests.elicitation`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ElicitationTaskCapability {
+    /// Whether task-augmented `elicitation/create` is supported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub create: Option<serde_json::Value>,
+}
+
+/// `capabilities.tasks.requests.tools`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ToolsTaskCapability {
+    /// Whether task-augmented `tools/call` is supported.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub call: Option<serde_json::Value>,
 }
 
 /// Logging capability flags.

--- a/crates/mcpkit-core/src/types/sampling.rs
+++ b/crates/mcpkit-core/src/types/sampling.rs
@@ -227,6 +227,15 @@ pub struct CreateMessageRequest {
     /// Controls whether/how the model may call `tools`.
     #[serde(rename = "toolChoice", skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
+    /// Request task-augmented execution (2025-11-25).
+    ///
+    /// When set, a client that declared
+    /// `tasks.requests.sampling.createMessage` replies with a
+    /// `CreateTaskResult` immediately and the `CreateMessageResult` is
+    /// retrieved later via `tasks/result`. A client that did not declare it
+    /// processes the request normally, ignoring this field (per spec).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<super::task::TaskMetadata>,
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
@@ -247,6 +256,7 @@ impl CreateMessageRequest {
             metadata: None,
             tools: None,
             tool_choice: None,
+            task: None,
             meta: None,
         }
     }
@@ -291,6 +301,13 @@ impl CreateMessageRequest {
         self.stop_sequences
             .get_or_insert_with(Vec::new)
             .push(seq.into());
+        self
+    }
+
+    /// Request task-augmented execution (2025-11-25).
+    #[must_use]
+    pub const fn with_task(mut self, task: super::task::TaskMetadata) -> Self {
+        self.task = Some(task);
         self
     }
 }
@@ -402,6 +419,21 @@ impl std::fmt::Display for StopReason {
 mod tests {
     use super::*;
     use crate::types::Content;
+
+    #[test]
+    fn create_message_task_field_round_trips_and_omits() {
+        // Omitted when unset (wire-compatible with pre-task requests).
+        let req = CreateMessageRequest::simple("hi", 10);
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("task").is_none());
+
+        // Round-trips when set.
+        let req = req.with_task(crate::types::task::TaskMetadata { ttl: Some(60_000) });
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["task"], serde_json::json!({ "ttl": 60000 }));
+        let back: CreateMessageRequest = serde_json::from_value(json).unwrap();
+        assert_eq!(back.task.unwrap().ttl, Some(60_000));
+    }
 
     #[test]
     fn test_sampling_message() {

--- a/crates/mcpkit-macros/src/server.rs
+++ b/crates/mcpkit-macros/src/server.rs
@@ -508,9 +508,10 @@ fn generate_server_handler(
         capability_chain.push(quote!(.with_prompts()));
     }
     // A tool declaring `task_support` other than "forbidden" makes the server
-    // task-augmentable, so advertise the `tasks` capability.
+    // task-augmentable, so advertise the `tasks` capability including
+    // task-augmented `tools/call`.
     if has_task_tools {
-        capability_chain.push(quote!(.with_tasks()));
+        capability_chain.push(quote!(.with_tasks().with_task_tools()));
     }
 
     // Join the capability chain

--- a/crates/mcpkit-server/src/builder.rs
+++ b/crates/mcpkit-server/src/builder.rs
@@ -158,13 +158,19 @@ where
         self,
         tools: TH,
     ) -> ServerBuilder<H, Registered<TH>, R, P, K> {
+        // Task-augmented `tools/call` needs both sides; upgrade the tasks
+        // capability regardless of registration order.
+        let mut capabilities = self.capabilities.with_tools();
+        if capabilities.tasks.is_some() {
+            capabilities = capabilities.with_task_tools();
+        }
         ServerBuilder {
             handler: self.handler,
             tools: Registered(tools),
             resources: self.resources,
             prompts: self.prompts,
             tasks: self.tasks,
-            capabilities: self.capabilities.with_tools(),
+            capabilities,
         }
     }
 }
@@ -291,13 +297,19 @@ where
         self,
         tasks: KH,
     ) -> ServerBuilder<H, T, R, P, Registered<KH>> {
+        // Task-augmented `tools/call` needs both sides; upgrade the tasks
+        // capability regardless of registration order.
+        let mut capabilities = self.capabilities.with_tasks();
+        if capabilities.tools.is_some() {
+            capabilities = capabilities.with_task_tools();
+        }
         ServerBuilder {
             handler: self.handler,
             tools: self.tools,
             resources: self.resources,
             prompts: self.prompts,
             tasks: Registered(tasks),
-            capabilities: self.capabilities.with_tasks(),
+            capabilities,
         }
     }
 }
@@ -554,6 +566,41 @@ mod tests {
             .build();
 
         assert!(server.capabilities().has_tasks());
+    }
+
+    #[test]
+    fn tasks_capability_shape_is_registration_order_independent() {
+        // Task-augmented `tools/call` (`tasks.requests.tools.call`) must be
+        // advertised when both handlers are registered, in either order.
+        fn tools_call(caps: &mcpkit_core::capability::ServerCapabilities) -> serde_json::Value {
+            serde_json::to_value(caps).unwrap()["tasks"].clone()
+        }
+
+        let tasks_first = ServerBuilder::new(TestHandler)
+            .with_tasks(TestTaskHandler)
+            .with_tools(TestToolHandler)
+            .build();
+        let tools_first = ServerBuilder::new(TestHandler)
+            .with_tools(TestToolHandler)
+            .with_tasks(TestTaskHandler)
+            .build();
+
+        let expected = serde_json::json!({
+            "list": {},
+            "cancel": {},
+            "requests": { "tools": { "call": {} } }
+        });
+        assert_eq!(tools_call(tasks_first.capabilities()), expected);
+        assert_eq!(tools_call(tools_first.capabilities()), expected);
+
+        // A TaskHandler alone must not claim task-augmented tools/call.
+        let tasks_only = ServerBuilder::new(TestHandler)
+            .with_tasks(TestTaskHandler)
+            .build();
+        assert_eq!(
+            tools_call(tasks_only.capabilities()),
+            serde_json::json!({ "list": {}, "cancel": {} })
+        );
     }
 
     #[test]

--- a/mcpkit/tests/capability_negotiation_compatibility.rs
+++ b/mcpkit/tests/capability_negotiation_compatibility.rs
@@ -14,7 +14,7 @@ use mcpkit::capability::{
     ClientCapabilities, ClientInfo, CompletionCapability, ElicitationCapability, InitializeRequest,
     InitializeResult, LoggingCapability, PROTOCOL_VERSION, PromptCapability, ResourceCapability,
     RootsCapability, SUPPORTED_PROTOCOL_VERSIONS, SamplingCapability, ServerCapabilities,
-    ServerInfo, TaskCapability, ToolCapability, VersionNegotiationResult, is_version_supported,
+    ServerInfo, TasksCapability, ToolCapability, VersionNegotiationResult, is_version_supported,
     negotiate_version, negotiate_version_detailed,
 };
 use serde_json::json;
@@ -514,14 +514,32 @@ fn test_prompt_capability_serialization() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
-fn test_task_capability_serialization() -> Result<(), Box<dyn std::error::Error>> {
-    let cap = TaskCapability {
-        cancellable: Some(true),
-    };
+fn test_tasks_capability_serialization() -> Result<(), Box<dyn std::error::Error>> {
+    // Server shape from the 2025-11-25 tasks spec page.
+    let caps = ServerCapabilities::new().with_tasks().with_task_tools();
+    let json = serde_json::to_value(&caps)?;
+    assert_eq!(
+        json["tasks"],
+        json!({ "list": {}, "cancel": {}, "requests": { "tools": { "call": {} } } })
+    );
 
-    let json = serde_json::to_value(&cap)?;
+    // Client shape from the same page (sampling only here).
+    let caps = ClientCapabilities::new().with_tasks().with_task_sampling();
+    let json = serde_json::to_value(&caps)?;
+    assert_eq!(
+        json["tasks"],
+        json!({
+            "list": {},
+            "cancel": {},
+            "requests": { "sampling": { "createMessage": {} } }
+        })
+    );
+    assert!(caps.has_task_sampling());
+    assert!(!ClientCapabilities::new().has_task_sampling());
 
-    assert_eq!(json["cancellable"], true);
+    // Round-trips.
+    let back: TasksCapability = serde_json::from_value(json["tasks"].clone())?;
+    assert_eq!(serde_json::to_value(&back)?, json["tasks"]);
     Ok(())
 }
 
@@ -598,7 +616,9 @@ fn test_server_capabilities_deserialization_from_rmcp() -> Result<(), Box<dyn st
             "listChanged": false
         },
         "tasks": {
-            "cancellable": true
+            "list": {},
+            "cancel": {},
+            "requests": { "tools": { "call": {} } }
         },
         "logging": {},
         "completions": {},
@@ -939,7 +959,7 @@ fn test_empty_capability_structs_serialize_to_empty_object()
     assert_eq!(serde_json::to_string(&ToolCapability::default())?, "{}");
     assert_eq!(serde_json::to_string(&ResourceCapability::default())?, "{}");
     assert_eq!(serde_json::to_string(&PromptCapability::default())?, "{}");
-    assert_eq!(serde_json::to_string(&TaskCapability::default())?, "{}");
+    assert_eq!(serde_json::to_string(&TasksCapability::default())?, "{}");
     assert_eq!(serde_json::to_string(&RootsCapability::default())?, "{}");
     Ok(())
 }


### PR DESCRIPTION
Phase 1 of #143 (task-augmented sampling, client side) — the types and capability negotiation, per the reviewed design (three-PR slicing: types → shared store extraction → client runtime). **Do not auto-close #143**; phases 2–3 follow.

## What changed

- **`CreateMessageRequest.task`** — the 2025-11-25 schema's `CreateMessageRequestParams extends TaskAugmentedRequestParams`, so sampling requests can carry `task?: TaskMetadata`. Now modeled (`Option<TaskMetadata>`, omitted when unset) with a `with_task` builder.
- **Spec-shaped `TasksCapability`** — `{ list, cancel, requests: { sampling: { createMessage }, elicitation: { create }, tools: { call } } }`, shared by both sides, matching the schema and the tasks spec page examples verbatim (serde-tested against them). `ClientCapabilities` gains `tasks` with `with_tasks()` / `with_task_sampling()` / `has_task_sampling()`.
- **Breaking: `ServerCapabilities.tasks` migration** — the existing `TaskCapability { cancellable }` does not exist in the schema (no such key). It is replaced by `TasksCapability`. `with_tasks()` now declares `{ list: {}, cancel: {} }`; task-augmented `tools/call` is declared via the new `with_task_tools()`.
  - The `#[mcp_server]` macro advertises the full shape when a tool declares `task_support`.
  - `ServerBuilder` upgrades to `requests.tools.call` when both tool and task handlers are registered, **in either registration order** (review finding: the builder accumulates capabilities per call, so neither method alone can decide the shape). Regression-tested for both orders, and that a `TaskHandler` alone does not claim `requests.tools.call`.
- **Spec-mandated ignore behavior** — per the tasks spec, *"receivers that do not declare the task capability for a request type MUST process requests of that type normally, ignoring any task-augmentation metadata."* Typing the field would otherwise leak `Some(task)` to user handlers (before this PR serde silently dropped it — accidentally compliant). The client now strips `task` before invoking `ClientHandler::create_message`, tested with a spy handler: the request is processed normally and the handler observes `task == None`.

## Wire compatibility

- Sampling requests without `task`: byte-identical.
- Servers that advertised `"tasks": {}` (or with the never-spec'd `cancellable`) now advertise `"tasks": { "list": {}, "cancel": {} }` (+ `requests.tools.call` where task tools exist) — the spec-correct shape; unknown-field-tolerant peers parse both.

## Verification

Full local gate green: `cargo fmt --all --check`, `cargo clippy --workspace --all-features --all-targets -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo test --workspace --all-features --locked` (73 suites, 0 failures). New tests: capability shapes vs spec JSON, round-trip, builder order-independence, `task` field serde, handler strip behavior.

Refs #143 (phase 1 of 3 — leave open).