### PR TITLE
feat(client)!: task-augmented sampling execution (#143 phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Task-augmented sampling, phase 3 of #143 — the client executes it:
+  - A client that declares `tasks.requests.sampling.createMessage`
+    (`ClientBuilder::with_task_sampling()`) answers a task-augmented
+    `sampling/createMessage` with `CreateTaskResult` immediately, runs
+    `ClientHandler::create_message` in the background, and serves the server's
+    `tasks/get` / `tasks/result` / `tasks/list` / `tasks/cancel` against a
+    per-connection task store (the shared `mcpkit_core::tasks` machinery).
+    `tasks/list` and `tasks/cancel` are gated on their own declared
+    capabilities; an undeclared client keeps processing such requests normally
+    with the `task` field ignored (spec).
+  - **Breaking:** `ClientHandler::create_message` gains a
+    `ctx: &RequestContext` parameter carrying the request's cancellation
+    signal — for a task-augmented request it is wired to the task, so a
+    server's `tasks/cancel` can abort the in-flight (expensive) LLM call.
+  - Inbound server requests are now handled off the client's router loop, so
+    a slow handler or a spec-blocking `tasks/result` no longer stalls response
+    routing (or the `tasks/cancel` that would unblock it).
+  - Shared-store hardening (spec): terminal task statuses are now final — a
+    cancelled task stays `cancelled` even if its execution later completes
+    (the late outcome is discarded), and `tasks/cancel` on an already-terminal
+    task is rejected with `-32602`
+    ([#143](https://github.com/praxiomlabs/mcpkit/issues/143)).
 - Task-augmented sampling, phase 2 of #143 — the receiver-side task machinery
   (`TaskManager`, `TaskHandle`, `TaskState`, `route_task_store`,
   `CancellationToken`) moves from mcpkit-server to the new

--- a/crates/mcpkit-client/src/builder.rs
+++ b/crates/mcpkit-client/src/builder.rs
@@ -93,6 +93,22 @@ impl ClientBuilder {
         self
     }
 
+    /// Enable task-augmented sampling (2025-11-25).
+    ///
+    /// Declares `tasks.list`, `tasks.cancel`, and
+    /// `tasks.requests.sampling.createMessage`: the server may then augment
+    /// `sampling/createMessage` with a `task`, receiving a `CreateTaskResult`
+    /// immediately while the client runs
+    /// [`ClientHandler::create_message`](crate::ClientHandler::create_message)
+    /// in the background and serves `tasks/get` / `tasks/result` /
+    /// `tasks/list` / `tasks/cancel` against its own task store. Declare plain
+    /// sampling separately via [`with_sampling`](Self::with_sampling).
+    #[must_use]
+    pub fn with_task_sampling(mut self) -> Self {
+        self.capabilities = self.capabilities.with_tasks().with_task_sampling();
+        self
+    }
+
     /// Enable roots capability.
     ///
     /// When enabled, the client exposes file system roots to the server.

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -43,7 +43,8 @@ use async_lock::RwLock;
 #[cfg(feature = "tokio-runtime")]
 use tokio::sync::mpsc;
 
-use crate::handler::ClientHandler;
+use crate::handler::{ClientHandler, RequestContext};
+use mcpkit_core::tasks::{TaskManager, route_task_store};
 
 /// An MCP client connected to a server.
 ///
@@ -160,6 +161,13 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         // Create channel for outgoing messages
         let (outgoing_tx, outgoing_rx) = mpsc::channel::<Message>(256);
 
+        // Per-connection task store for task-augmented server->client requests
+        // (only when the client declared the `tasks` capability).
+        let tasks = client_caps
+            .tasks
+            .is_some()
+            .then(|| Arc::new(TaskManager::new()));
+
         // Start background message routing task
         let background_handle = Self::spawn_message_router(
             Arc::clone(&transport),
@@ -168,6 +176,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             Arc::clone(&running),
             outgoing_rx,
             Arc::new(client_caps.clone()),
+            tasks,
         );
 
         // Notify handler that connection is established
@@ -208,6 +217,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         running: Arc<AtomicBool>,
         mut outgoing_rx: mpsc::Receiver<Message>,
         client_caps: Arc<ClientCapabilities>,
+        tasks: Option<Arc<TaskManager>>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             debug!("Starting client message router");
@@ -243,6 +253,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
                                     &handler,
                                     &transport,
                                     &client_caps,
+                                    tasks.as_ref(),
                                 ).await;
                             }
                             Ok(None) => {
@@ -279,13 +290,31 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         handler: &Arc<H>,
         transport: &Arc<T>,
         client_caps: &Arc<ClientCapabilities>,
+        tasks: Option<&Arc<TaskManager>>,
     ) {
         match message {
             Message::Response(response) => {
                 Self::route_response(response, pending).await;
             }
             Message::Request(request) => {
-                Self::handle_server_request(request, handler, transport, client_caps).await;
+                // Handle off the router loop: a slow handler (or a spec-blocking
+                // `tasks/result`, which waits for the task to reach a terminal
+                // status) must not stall response routing or the `tasks/cancel`
+                // that would unblock it.
+                let handler = Arc::clone(handler);
+                let transport = Arc::clone(transport);
+                let client_caps = Arc::clone(client_caps);
+                let tasks = tasks.cloned();
+                tokio::spawn(async move {
+                    Self::handle_server_request(
+                        request,
+                        &handler,
+                        &transport,
+                        &client_caps,
+                        tasks.as_ref(),
+                    )
+                    .await;
+                });
             }
             Message::Notification(notification) => {
                 Self::handle_notification(notification, handler).await;
@@ -325,12 +354,16 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         handler: &Arc<H>,
         transport: &Arc<T>,
         client_caps: &Arc<ClientCapabilities>,
+        tasks: Option<&Arc<TaskManager>>,
     ) {
         trace!(method = %request.method, "Handling server request");
 
         let response = match request.method.as_ref() {
             "sampling/createMessage" => {
-                Self::handle_sampling_request(&request, handler, client_caps).await
+                Self::handle_sampling_request(&request, handler, client_caps, tasks).await
+            }
+            method @ ("tasks/get" | "tasks/result" | "tasks/list" | "tasks/cancel") => {
+                Self::handle_tasks_request(&request, method, client_caps, tasks).await
             }
             "elicitation/create" => Self::handle_elicitation_request(&request, handler).await,
             "roots/list" => Self::handle_roots_request(&request, handler).await,
@@ -358,6 +391,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         request: &Request,
         handler: &Arc<H>,
         client_caps: &Arc<ClientCapabilities>,
+        tasks: Option<&Arc<TaskManager>>,
     ) -> Response {
         let mut params = match &request.params {
             Some(p) => match serde_json::from_value::<CreateMessageRequest>(p.clone()) {
@@ -377,13 +411,6 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             }
         };
 
-        // Task-augmented sampling is not supported yet (#143): the client does
-        // not declare `tasks.requests.sampling.createMessage`, and per spec an
-        // undeclared receiver MUST process the request normally, ignoring the
-        // task metadata. Strip it so handlers cannot observe a field the spec
-        // requires us to ignore.
-        params.task = None;
-
         // Per spec, a client MUST reject tool-augmented sampling unless it
         // declared the `sampling.tools` capability.
         if (params.tools.is_some() || params.tool_choice.is_some())
@@ -398,7 +425,60 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             );
         }
 
-        match handler.create_message(params).await {
+        if params.task.is_some() {
+            // Task-augmented path: only when the client declared
+            // `tasks.requests.sampling.createMessage`. Reply with
+            // `CreateTaskResult` immediately and run the sampling in the
+            // background; the store holds the outcome for the server's later
+            // `tasks/get` / `tasks/result`.
+            if let (true, Some(store)) = (client_caps.has_task_sampling(), tasks) {
+                let ttl = params.task.as_ref().and_then(|t| t.ttl);
+                let handle = store.create(ttl);
+                let task = handle
+                    .task()
+                    .unwrap_or_else(|| mcpkit_core::types::Task::new(handle.id().clone()));
+                let create_result =
+                    serde_json::to_value(mcpkit_core::types::CreateTaskResult { task, meta: None })
+                        .unwrap_or_default();
+
+                // The handler never observes the task metadata; its
+                // cancellation arrives through the context instead.
+                params.task = None;
+                let ctx =
+                    RequestContext::with_cancellation(handle.cancel_token().unwrap_or_default());
+                let handler = Arc::clone(handler);
+                tokio::spawn(async move {
+                    match handler.create_message(params, &ctx).await {
+                        Ok(result) => match serde_json::to_value(result) {
+                            Ok(value) => {
+                                // Fails only if the task went terminal first
+                                // (e.g. cancelled) -- the outcome is discarded.
+                                let _ = handle.complete(value);
+                            }
+                            Err(e) => {
+                                let _ = handle.fail(format!("Serialization error: {e}"));
+                            }
+                        },
+                        // tasks/result must reproduce the JSON-RPC error the
+                        // request would have returned.
+                        Err(e) => {
+                            let _ = handle.fail_with_error((&e).into());
+                        }
+                    }
+                });
+                return Response::success(request.id.clone(), create_result);
+            }
+
+            // Undeclared: per spec the request is processed normally, ignoring
+            // the task metadata. Strip it so handlers cannot observe a field
+            // the spec requires us to ignore.
+            params.task = None;
+        }
+
+        match handler
+            .create_message(params, &RequestContext::default())
+            .await
+        {
             Ok(result) => match serde_json::to_value(result) {
                 Ok(value) => Response::success(request.id.clone(), value),
                 Err(e) => Response::error(
@@ -409,6 +489,52 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
             Err(e) => Response::error(
                 request.id.clone(),
                 JsonRpcError::internal_error(e.to_string()),
+            ),
+        }
+    }
+
+    /// Serve a server-initiated `tasks/*` request against the client's own
+    /// task store (tasks created by task-augmented server->client requests).
+    async fn handle_tasks_request(
+        request: &Request,
+        method: &str,
+        client_caps: &Arc<ClientCapabilities>,
+        tasks: Option<&Arc<TaskManager>>,
+    ) -> Response {
+        // No declared `tasks` capability -> unknown method (the pre-tasks
+        // behavior).
+        let Some(store) = tasks else {
+            return Response::error(
+                request.id.clone(),
+                JsonRpcError::method_not_found(format!("Unknown method: {method}")),
+            );
+        };
+        // `tasks/list` and `tasks/cancel` are separately declared operations;
+        // `tasks/get` / `tasks/result` are implied by any `tasks` declaration.
+        let declared = match method {
+            "tasks/list" => client_caps.tasks.as_ref().is_some_and(|t| t.list.is_some()),
+            "tasks/cancel" => client_caps
+                .tasks
+                .as_ref()
+                .is_some_and(|t| t.cancel.is_some()),
+            _ => true,
+        };
+        if !declared {
+            return Response::error(
+                request.id.clone(),
+                JsonRpcError::method_not_found(format!(
+                    "{method} is not declared in the client's tasks capability"
+                )),
+            );
+        }
+        match route_task_store(store, method, request.params.as_ref()).await {
+            Some(Ok(value)) => Response::success(request.id.clone(), value),
+            Some(Err(e)) => Response::error(request.id.clone(), (&e).into()),
+            // The store does not own this id; the client has no fallback
+            // handler, so an unknown taskId is invalid params (spec).
+            None => Response::error(
+                request.id.clone(),
+                JsonRpcError::invalid_params("Unknown task"),
             ),
         }
     }
@@ -1754,7 +1880,7 @@ mod tests {
         // Declared only `sampling` (not `sampling.tools`) -> gate rejects.
         let caps = Arc::new(ClientCapabilities::new().with_sampling());
         let resp = Client::<SilentTransport, crate::handler::NoOpHandler>::handle_sampling_request(
-            &request, &handler, &caps,
+            &request, &handler, &caps, None,
         )
         .await;
         assert!(
@@ -1769,7 +1895,7 @@ mod tests {
         // with a different error).
         let caps = Arc::new(ClientCapabilities::new().with_sampling_tools());
         let resp = Client::<SilentTransport, crate::handler::NoOpHandler>::handle_sampling_request(
-            &request, &handler, &caps,
+            &request, &handler, &caps, None,
         )
         .await;
         assert!(
@@ -1794,6 +1920,7 @@ mod tests {
             async fn create_message(
                 &self,
                 request: CreateMessageRequest,
+                _ctx: &RequestContext,
             ) -> Result<mcpkit_core::types::CreateMessageResult, McpError> {
                 *self.seen.lock().unwrap() = Some(request);
                 Ok(mcpkit_core::types::CreateMessageResult {
@@ -1827,9 +1954,10 @@ mod tests {
         );
         let caps = Arc::new(ClientCapabilities::new().with_sampling());
 
-        let resp =
-            Client::<SilentTransport, TaskSpy>::handle_sampling_request(&request, &handler, &caps)
-                .await;
+        let resp = Client::<SilentTransport, TaskSpy>::handle_sampling_request(
+            &request, &handler, &caps, None,
+        )
+        .await;
 
         // Processed normally: a plain CreateMessageResult, not a task.
         let result = resp.result.expect("normal result");
@@ -1842,5 +1970,252 @@ mod tests {
             request_seen.task.is_none(),
             "handler must not observe the task field"
         );
+    }
+
+    // --- #143 phase 3: task-augmented sampling ------------------------------
+
+    fn assistant_result() -> mcpkit_core::types::CreateMessageResult {
+        mcpkit_core::types::CreateMessageResult {
+            role: mcpkit_core::types::Role::Assistant,
+            content: mcpkit_core::types::OneOrMany::One(mcpkit_core::types::SamplingContent::Text(
+                mcpkit_core::types::TextContent {
+                    text: "ok".into(),
+                    annotations: None,
+                    meta: None,
+                },
+            )),
+            model: "m".into(),
+            stop_reason: None,
+            meta: None,
+        }
+    }
+
+    fn task_caps() -> Arc<ClientCapabilities> {
+        Arc::new(
+            ClientCapabilities::new()
+                .with_sampling()
+                .with_tasks()
+                .with_task_sampling(),
+        )
+    }
+
+    fn sampling_request_with_task() -> Request {
+        Request::with_params(
+            "sampling/createMessage",
+            RequestId::Number(1),
+            serde_json::json!({
+                "messages": [],
+                "maxTokens": 10,
+                "task": { "ttl": 60000 }
+            }),
+        )
+    }
+
+    fn tasks_request(id: u64, method: &'static str, task_id: &str) -> Request {
+        Request::with_params(
+            method,
+            RequestId::Number(id),
+            serde_json::json!({ "taskId": task_id }),
+        )
+    }
+
+    /// A handler whose sampling completes only when released; records whether
+    /// it observed the task field and whether its context was cancelled.
+    struct GatedSampler {
+        release: Arc<tokio::sync::Notify>,
+        saw_task: Arc<std::sync::Mutex<Option<bool>>>,
+        cancelled: Arc<AtomicBool>,
+    }
+    impl crate::handler::ClientHandler for GatedSampler {
+        async fn create_message(
+            &self,
+            request: CreateMessageRequest,
+            ctx: &RequestContext,
+        ) -> Result<mcpkit_core::types::CreateMessageResult, McpError> {
+            *self.saw_task.lock().unwrap() = Some(request.task.is_some());
+            tokio::select! {
+                () = self.release.notified() => Ok(assistant_result()),
+                () = ctx.cancelled() => {
+                    self.cancelled.store(true, Ordering::SeqCst);
+                    Err(McpError::cancelled("sampling"))
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn task_augmented_sampling_returns_task_then_result() {
+        type C = Client<SilentTransport, GatedSampler>;
+        let release = Arc::new(tokio::sync::Notify::new());
+        let saw_task = Arc::new(std::sync::Mutex::new(None));
+        let handler = Arc::new(GatedSampler {
+            release: release.clone(),
+            saw_task: saw_task.clone(),
+            cancelled: Arc::new(AtomicBool::new(false)),
+        });
+        let caps = task_caps();
+        let store = Arc::new(TaskManager::new());
+
+        // Task-augmented request -> immediate CreateTaskResult, status working.
+        let resp = C::handle_sampling_request(
+            &sampling_request_with_task(),
+            &handler,
+            &caps,
+            Some(&store),
+        )
+        .await;
+        let result = resp.result.expect("CreateTaskResult");
+        assert_eq!(result["task"]["status"], "working");
+        assert_eq!(result["task"]["ttl"], 60000);
+        let task_id = result["task"]["taskId"].as_str().expect("id").to_string();
+
+        // tasks/get while the sampling is still gated: working.
+        let got = C::handle_tasks_request(
+            &tasks_request(2, "tasks/get", &task_id),
+            "tasks/get",
+            &caps,
+            Some(&store),
+        )
+        .await;
+        assert_eq!(got.result.expect("task")["status"], "working");
+
+        // tasks/result blocks until the handler is released, then returns the
+        // CreateMessageResult with the related-task metadata attached.
+        let waiter = {
+            let caps = Arc::clone(&caps);
+            let store = Arc::clone(&store);
+            let task_id = task_id.clone();
+            tokio::spawn(async move {
+                C::handle_tasks_request(
+                    &tasks_request(3, "tasks/result", &task_id),
+                    "tasks/result",
+                    &caps,
+                    Some(&store),
+                )
+                .await
+            })
+        };
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !waiter.is_finished(),
+            "tasks/result must block until terminal"
+        );
+        release.notify_one();
+        let resp = tokio::time::timeout(Duration::from_secs(5), waiter)
+            .await
+            .expect("blocked tasks/result never completed")
+            .expect("join");
+        let payload = resp.result.expect("sampling result");
+        assert_eq!(payload["role"], "assistant");
+        assert_eq!(
+            payload["_meta"]["io.modelcontextprotocol/related-task"]["taskId"],
+            task_id.as_str()
+        );
+        // The handler never observed the task field.
+        assert_eq!(*saw_task.lock().unwrap(), Some(false));
+    }
+
+    #[tokio::test]
+    async fn tasks_cancel_cancels_in_flight_sampling() {
+        type C = Client<SilentTransport, GatedSampler>;
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let handler = Arc::new(GatedSampler {
+            release: Arc::new(tokio::sync::Notify::new()),
+            saw_task: Arc::new(std::sync::Mutex::new(None)),
+            cancelled: cancelled.clone(),
+        });
+        let caps = task_caps();
+        let store = Arc::new(TaskManager::new());
+
+        let resp = C::handle_sampling_request(
+            &sampling_request_with_task(),
+            &handler,
+            &caps,
+            Some(&store),
+        )
+        .await;
+        let task_id = resp.result.expect("CreateTaskResult")["task"]["taskId"]
+            .as_str()
+            .expect("id")
+            .to_string();
+
+        // Cancel while the sampling is in flight.
+        let resp = C::handle_tasks_request(
+            &tasks_request(2, "tasks/cancel", &task_id),
+            "tasks/cancel",
+            &caps,
+            Some(&store),
+        )
+        .await;
+        assert_eq!(resp.result.expect("cancel result")["status"], "cancelled");
+
+        // The handler's context observed the cancellation.
+        for _ in 0..100 {
+            if cancelled.load(Ordering::SeqCst) {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(
+            cancelled.load(Ordering::SeqCst),
+            "handler must observe cancellation via its RequestContext"
+        );
+
+        // The task stays cancelled; tasks/result reports no result.
+        let resp = C::handle_tasks_request(
+            &tasks_request(3, "tasks/result", &task_id),
+            "tasks/result",
+            &caps,
+            Some(&store),
+        )
+        .await;
+        let err = resp.error.expect("cancelled task has no result");
+        assert_eq!(err.code, -32602);
+        // Status remains cancelled even though the handler returned an error
+        // after cancellation.
+        let got = C::handle_tasks_request(
+            &tasks_request(4, "tasks/get", &task_id),
+            "tasks/get",
+            &caps,
+            Some(&store),
+        )
+        .await;
+        assert_eq!(got.result.expect("task")["status"], "cancelled");
+    }
+
+    #[tokio::test]
+    async fn tasks_list_and_cancel_are_capability_gated() {
+        type C = Client<SilentTransport, crate::handler::NoOpHandler>;
+        // Declared task sampling but NOT tasks.list / tasks.cancel.
+        let caps = Arc::new(ClientCapabilities::new().with_task_sampling());
+        let store = Arc::new(TaskManager::new());
+
+        let resp = C::handle_tasks_request(
+            &Request::with_params("tasks/list", RequestId::Number(1), serde_json::json!({})),
+            "tasks/list",
+            &caps,
+            Some(&store),
+        )
+        .await;
+        assert_eq!(resp.error.expect("gated").code, -32601);
+
+        let resp = C::handle_tasks_request(
+            &tasks_request(2, "tasks/cancel", "nope"),
+            "tasks/cancel",
+            &caps,
+            Some(&store),
+        )
+        .await;
+        assert_eq!(resp.error.expect("gated").code, -32601);
+
+        // tasks/get is implied by any tasks declaration; unknown id -> -32602.
+        let resp = C::handle_tasks_request(
+            &tasks_request(3, "tasks/get", "nope"),
+            "tasks/get",
+            &caps,
+            Some(&store),
+        )
+        .await;
+        assert_eq!(resp.error.expect("unknown task").code, -32602);
     }
 }

--- a/crates/mcpkit-client/src/handler.rs
+++ b/crates/mcpkit-client/src/handler.rs
@@ -9,11 +9,46 @@
 //! This module defines traits that clients can implement to handle these requests.
 
 use mcpkit_core::error::McpError;
+use mcpkit_core::tasks::{CancellationToken, CancelledFuture};
 use mcpkit_core::types::{
     CreateMessageRequest, CreateMessageResult, ElicitRequest, ElicitResult,
     ProgressNotificationParams, TaskId, TaskProgress, UrlElicitRequest,
 };
 use std::future::Future;
+
+/// Context for a server-initiated request delivered to a [`ClientHandler`].
+///
+/// Carries the request's cancellation signal. For a task-augmented request
+/// (e.g. task-augmented `sampling/createMessage`), the token is wired to the
+/// task, so a `tasks/cancel` from the server cancels the in-flight handler
+/// work; for a plain request the token is currently never cancelled.
+#[derive(Debug, Clone, Default)]
+pub struct RequestContext {
+    cancel: CancellationToken,
+}
+
+impl RequestContext {
+    /// A context with a cancellation token (e.g. a task's token).
+    #[must_use]
+    pub fn with_cancellation(cancel: CancellationToken) -> Self {
+        Self { cancel }
+    }
+
+    /// Check if the request has been cancelled.
+    #[must_use]
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+
+    /// A future that completes when the request is cancelled.
+    ///
+    /// Long-running handlers (LLM sampling in particular) should select
+    /// against this and abandon work when it fires.
+    #[must_use]
+    pub fn cancelled(&self) -> CancelledFuture {
+        self.cancel.cancelled()
+    }
+}
 
 /// Handler trait for server-initiated requests.
 ///
@@ -39,12 +74,18 @@ pub trait ClientHandler: Send + Sync {
     /// The server is asking the client's LLM to generate a response.
     /// This is used for agentic workflows where the server needs LLM capabilities.
     ///
+    /// For a task-augmented request, `ctx` carries the task's cancellation
+    /// signal: a long-running implementation should watch
+    /// [`RequestContext::cancelled`] and abandon the (expensive) LLM call when
+    /// the server cancels the task.
+    ///
     /// # Errors
     ///
     /// Returns an error if sampling is not supported or the request fails.
     fn create_message(
         &self,
         _request: CreateMessageRequest,
+        _ctx: &RequestContext,
     ) -> impl Future<Output = Result<CreateMessageResult, McpError>> + Send {
         async {
             Err(McpError::CapabilityNotSupported {
@@ -217,6 +258,7 @@ where
     fn create_message(
         &self,
         request: CreateMessageRequest,
+        _ctx: &RequestContext,
     ) -> impl Future<Output = Result<CreateMessageResult, McpError>> + Send {
         (self.handler)(request)
     }
@@ -237,20 +279,23 @@ mod tests {
     async fn test_noop_handler() {
         let handler = NoOpHandler;
         let result = handler
-            .create_message(CreateMessageRequest {
-                messages: vec![],
-                model_preferences: None,
-                system_prompt: None,
-                include_context: None,
-                temperature: None,
-                max_tokens: 100,
-                stop_sequences: None,
-                metadata: None,
-                tools: None,
-                tool_choice: None,
-                task: None,
-                meta: None,
-            })
+            .create_message(
+                CreateMessageRequest {
+                    messages: vec![],
+                    model_preferences: None,
+                    system_prompt: None,
+                    include_context: None,
+                    temperature: None,
+                    max_tokens: 100,
+                    stop_sequences: None,
+                    metadata: None,
+                    tools: None,
+                    tool_choice: None,
+                    task: None,
+                    meta: None,
+                },
+                &RequestContext::default(),
+            )
             .await;
         assert!(result.is_err());
     }

--- a/crates/mcpkit-client/src/lib.rs
+++ b/crates/mcpkit-client/src/lib.rs
@@ -76,7 +76,7 @@ pub mod pool;
 pub use builder::ClientBuilder;
 pub use client::Client;
 pub use discovery::{DiscoveredServer, ServerDiscovery};
-pub use handler::ClientHandler;
+pub use handler::{ClientHandler, RequestContext};
 pub use pool::{ClientPool, ClientPoolBuilder, PoolConfig, PoolStats};
 
 /// Prelude module for convenient imports.
@@ -84,6 +84,6 @@ pub mod prelude {
     pub use crate::builder::ClientBuilder;
     pub use crate::client::Client;
     pub use crate::discovery::{DiscoveredServer, ServerDiscovery};
-    pub use crate::handler::ClientHandler;
+    pub use crate::handler::{ClientHandler, RequestContext};
     pub use crate::pool::{ClientPool, ClientPoolBuilder, PoolConfig, PoolStats};
 }

--- a/crates/mcpkit-core/src/tasks.rs
+++ b/crates/mcpkit-core/src/tasks.rs
@@ -394,6 +394,9 @@ impl TaskManager {
     }
 
     /// Cancel a task.
+    ///
+    /// Cancelling a task already in a terminal status is rejected with
+    /// *invalid params* (spec).
     pub fn cancel(&self, id: &TaskId) -> Result<(), McpError> {
         let mut tasks = self
             .tasks
@@ -401,6 +404,15 @@ impl TaskManager {
             .map_err(|_| McpError::internal("Failed to acquire task lock"))?;
 
         if let Some(state) = tasks.get_mut(id) {
+            if state.task.status.is_terminal() {
+                return Err(McpError::invalid_params(
+                    "tasks/cancel",
+                    format!(
+                        "Cannot cancel task: already in terminal status '{}'",
+                        state.task.status
+                    ),
+                ));
+            }
             state.cancel_token.cancel();
             state.task.set_status(TaskStatus::Cancelled);
             state.last_access = Instant::now();
@@ -427,6 +439,18 @@ impl TaskManager {
             .map_err(|_| McpError::internal("Failed to acquire task lock"))?;
 
         if let Some(state) = tasks.get_mut(id) {
+            // Terminal statuses are final (spec): in particular, a cancelled
+            // task stays cancelled even if its execution later finishes.
+            if state.task.status.is_terminal() {
+                return Err(McpError::invalid_params(
+                    "tasks/get",
+                    format!(
+                        "task {} is already terminal ('{}')",
+                        id.as_str(),
+                        state.task.status
+                    ),
+                ));
+            }
             state.task.set_status(status);
             if message.is_some() {
                 state.task.status_message = message;
@@ -458,6 +482,19 @@ impl TaskManager {
             .map_err(|_| McpError::internal("Failed to acquire task lock"))?;
 
         if let Some(state) = tasks.get_mut(id) {
+            // Terminal statuses are final (spec): a cancelled task stays
+            // cancelled even if its execution later completes or fails, and
+            // its outcome is discarded.
+            if state.task.status.is_terminal() {
+                return Err(McpError::invalid_params(
+                    "tasks/result",
+                    format!(
+                        "task {} is already terminal ('{}')",
+                        id.as_str(),
+                        state.task.status
+                    ),
+                ));
+            }
             state.task.set_status(status);
             if message.is_some() {
                 state.task.status_message = message;
@@ -612,7 +649,10 @@ pub async fn route_task_store(
                 )));
             };
             if store.get(&id).is_some() {
-                let _ = store.cancel(&id);
+                // Cancelling an already-terminal task is -32602 (spec).
+                if let Err(e) = store.cancel(&id) {
+                    return Some(Err(e));
+                }
                 Some(Ok(store
                     .get(&id)
                     .map(|s| {
@@ -956,6 +996,44 @@ mod tests {
         .expect("owned task");
         assert!(outcome.is_err(), "cancelled task has no result");
         canceller.await.unwrap();
+    }
+
+    // --- terminal-state immutability (spec: terminal statuses are final) ---
+
+    #[test]
+    fn cancelled_task_stays_cancelled_when_execution_completes() {
+        let manager = Arc::new(TaskManager::new());
+        let handle = manager.create(None);
+        let id = handle.id().clone();
+        manager.cancel(&id).unwrap();
+
+        // The background execution finishes anyway; the outcome is discarded.
+        assert!(handle.complete(serde_json::json!({ "late": 1 })).is_err());
+        assert!(handle.fail("late failure").is_err());
+
+        let state = manager.get(&id).unwrap();
+        assert_eq!(state.task.status, TaskStatus::Cancelled);
+        assert!(state.payload.is_none(), "late outcome must be discarded");
+    }
+
+    #[tokio::test]
+    async fn cancel_on_terminal_task_is_invalid_params() {
+        let manager = Arc::new(TaskManager::new());
+        let handle = manager.create(None);
+        let id = handle.id().clone();
+        handle.complete(serde_json::json!({})).unwrap();
+
+        // Direct store call.
+        let err = manager.cancel(&id).expect_err("terminal cancel rejected");
+        assert_eq!(err.code(), -32602);
+
+        // And through the route.
+        let params = result_params(&id);
+        let err = route_task_store(&manager, "tasks/cancel", Some(&params))
+            .await
+            .expect("owned task")
+            .expect_err("terminal cancel rejected");
+        assert_eq!(err.code(), -32602);
     }
 
     // --- cancellation token (moved with the token from mcpkit-server) ------

--- a/crates/mcpkit-macros/src/client.rs
+++ b/crates/mcpkit-macros/src/client.rs
@@ -155,6 +155,7 @@ fn generate_client_handler(
                 fn create_message(
                     &self,
                     request: ::mcpkit::types::CreateMessageRequest,
+                    _ctx: &::mcpkit::client::RequestContext,
                 ) -> impl std::future::Future<Output = Result<::mcpkit::types::CreateMessageResult, ::mcpkit::error::McpError>> + Send {
                     async move {
                         #call
@@ -166,6 +167,7 @@ fn generate_client_handler(
                 fn create_message(
                     &self,
                     request: ::mcpkit::types::CreateMessageRequest,
+                    _ctx: &::mcpkit::client::RequestContext,
                 ) -> impl std::future::Future<Output = Result<::mcpkit::types::CreateMessageResult, ::mcpkit::error::McpError>> + Send {
                     async move {
                         Ok(#call)


### PR DESCRIPTION
Phase 3 of #143, completing the reviewed design (types → shared store → **client runtime**). Closes #143.

## What changed

**The task-augmented sampling path.** A client that declares `tasks.requests.sampling.createMessage` (new `ClientBuilder::with_task_sampling()`, which declares `tasks.list` + `tasks.cancel` + the sampling request) now:
- answers a `sampling/createMessage` carrying `task` with a **`CreateTaskResult` immediately** (status `working`, requested TTL materialized),
- runs `ClientHandler::create_message` in the background (`tokio::spawn`, same mechanism as the client's own router),
- serves the server's `tasks/get` / `tasks/result` / `tasks/list` / `tasks/cancel` against a **per-connection task store** — the shared `mcpkit_core::tasks` machinery from #163, so blocking `tasks/result`, verbatim JSON-RPC error reproduction, and `related-task` `_meta` behavior are identical on both sides.

Capability gating per spec: `tasks/list` and `tasks/cancel` answer method-not-found unless their own capability markers are declared; `tasks/get`/`tasks/result` are implied by any `tasks` declaration; unknown task ids are `-32602`. A client that did **not** declare task sampling keeps processing such requests normally with the `task` field stripped (spec MUST — pinned in phase 1, still tested).

**Breaking: `ClientHandler::create_message(request, ctx: &RequestContext)`.** The design's §6 option B, per reviewer consensus (named `RequestContext`, not `SamplingContext`, since task-augmented elicitation will need the same surface). The context carries the request's cancellation signal — for a task-augmented request it is the task's token, so a server's `tasks/cancel` aborts the in-flight (expensive) LLM call. `SamplingHandler`, `NoOpHandler`, and the `#[mcp_client]` macro's generated impl are updated (the macro gap was caught by the trybuild expand fixtures).

**Inbound requests handled off the router loop.** Previously every server-initiated request was awaited inline in the client's select loop; a spec-blocking `tasks/result` would have stalled all routing — including the `tasks/cancel` that would unblock it (soft-deadlock identified in design review). Requests are now spawned; responses to the client's own outbound requests keep routing while a handler runs.

**Shared-store hardening** (spec MUSTs found while wiring cancellation, exercised directly by this path):
- Terminal statuses are final: a cancelled task stays `cancelled` even if its execution later completes or fails — the late outcome is discarded (previously a late `complete()` flipped the status).
- `tasks/cancel` on an already-terminal task is rejected with `-32602` (previously re-cancelled and answered success), propagated through `route_task_store` — this also applies to the server runtime and HTTP adapters.

## Tests

End-to-end over the dispatch functions: augmented request → immediate `CreateTaskResult` → `tasks/get` `working` → blocking `tasks/result` (asserted still pending mid-flight) → released → `CreateMessageResult` with `related-task` `_meta`, handler never observing `task`; `tasks/cancel` mid-sampling → handler's `RequestContext` observes cancellation, task stays `cancelled`, `tasks/result` is `-32602`; capability gating for list/cancel; store guards (terminal immutability, terminal-cancel rejection at both store and route level). Full local gate green: fmt, clippy `-D warnings`, rustdoc `-D warnings`, 73 test suites.

Closes #143.