### PR TITLE
fix(docs): bump stale 0.5 install snippets and widen the version-sync guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,19 +104,38 @@ jobs:
           MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
 
           echo "Checking documentation references mcpkit version $MAJOR_MINOR..."
+          FAIL=0
 
-          # Check README.md
-          if ! grep -q "mcpkit = \"$MAJOR_MINOR\"" README.md; then
-            echo "ERROR: README.md does not reference mcpkit = \"$MAJOR_MINOR\""
-            exit 1
+          # Every snippet-bearing doc must reference the current version at
+          # least once (umbrella crate or subcrate — all published mcpkit-*
+          # crates share the workspace version).
+          for f in README.md docs/getting-started.md docs/client-guide.md \
+                   docs/extensions.md docs/runtimes.md docs/wasm.md \
+                   docs/migration-from-rmcp.md; do
+            if ! grep -qE "mcpkit(-[a-z]+)? = \"$MAJOR_MINOR\"" "$f"; then
+              echo "ERROR: $f does not reference mcpkit(-*) = \"$MAJOR_MINOR\""
+              FAIL=1
+            fi
+          done
+
+          # No doc may pin any OTHER mcpkit version — this catches partially
+          # bumped files, which the per-file presence check alone would pass.
+          # Allowlisted: files where old versions are intentional (migration
+          # rollback targets, stability policy examples, point-in-time ADRs).
+          STALE=$(grep -rnE "mcpkit(-[a-z]+)? = \"[0-9]" README.md docs/ \
+              --exclude=migration-to-1.0.md \
+              --exclude=api-stability.md \
+              --exclude-dir=adr \
+            | grep -vE "mcpkit(-[a-z]+)? = \"$MAJOR_MINOR\"" || true)
+          if [ -n "$STALE" ]; then
+            echo "ERROR: stale mcpkit version references (expected $MAJOR_MINOR):"
+            echo "$STALE"
+            FAIL=1
           fi
 
-          # Check getting-started.md
-          if ! grep -q "mcpkit = \"$MAJOR_MINOR\"" docs/getting-started.md; then
-            echo "ERROR: docs/getting-started.md does not reference mcpkit = \"$MAJOR_MINOR\""
+          if [ "$FAIL" -ne 0 ]; then
             exit 1
           fi
-
           echo "All version references are correct!"
 
   link-check:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Ten documentation install snippets still pinned `mcpkit-*` subcrates at
+  `0.5` (client-guide, extensions, runtimes, wasm) — under 0.x semver those
+  resolve to a two-minor-versions-old API. Bumped to the current version, and
+  the CI `version-sync` job now checks **all** snippet-bearing docs for the
+  current version (umbrella and subcrate names) plus a repo-wide sweep that
+  fails on any *other* pinned mcpkit version, so a partially-bumped file can
+  no longer pass. Files where old versions are intentional
+  (migration-to-1.0.md rollback targets, api-stability.md policy examples,
+  point-in-time ADRs) are excluded from the sweep; two lines in
+  migration-to-1.0.md that an earlier mechanical bump had corrupted (the
+  "From 0.6.x" before-snippet and the 0.6.x rollback target showed `0.7`)
+  are fixed editorially, and its version matrix now lists 0.7.x as current
+  ([#53](https://github.com/praxiomlabs/mcpkit/issues/53)).
+
 ### Added
 
 - Task-augmented sampling, phase 3 of #143 — the client executes it:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -374,6 +374,12 @@ just publish-dry    # Dry-run publish all crates in dependency order
 - [ ] Run `just publish-dry` - all crates succeed
 - [ ] No unexpected files included in package
 - [ ] Package size is reasonable
+- [ ] `CARGO_REGISTRY_TOKEN` repository secret is still valid (a rotated or
+      expired token fails the publish only after the tag is pushed — the
+      v0.6.0 incident)
+- [ ] The release workflow's toolchain installs the `clippy` component
+      (`release.yml` `components: clippy`) — its absence also surfaced in the
+      v0.6.0 release
 
 ### Cargo.toml Metadata
 

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -23,9 +23,9 @@ For more granular control, use individual crates:
 
 ```toml
 [dependencies]
-mcpkit-client = "0.5"
-mcpkit-transport = "0.5"
-mcpkit-core = "0.5"
+mcpkit-client = "0.7"
+mcpkit-transport = "0.7"
+mcpkit-core = "0.7"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -17,10 +17,10 @@ These crates serve as reference implementations and can be used directly or as p
 
 ```toml
 # For Axum
-mcpkit-axum = "0.5"
+mcpkit-axum = "0.7"
 
 # For Actix-web
-mcpkit-actix = "0.5"
+mcpkit-actix = "0.7"
 ```
 
 ## Overview
@@ -610,8 +610,8 @@ keywords = ["mcp", "extension"]
 categories = ["web-programming", "asynchronous"]
 
 [dependencies]
-mcpkit-core = "0.5"
-mcpkit-server = "0.5"
+mcpkit-core = "0.7"
+mcpkit-server = "0.7"
 axum = "0.8"
 tokio = { version = "1", features = ["sync"] }
 serde = { version = "1", features = ["derive"] }

--- a/docs/migration-to-1.0.md
+++ b/docs/migration-to-1.0.md
@@ -46,7 +46,7 @@ Simply update your dependency:
 
 ```toml
 # Before
-mcpkit = "0.7"
+mcpkit = "0.6"
 
 # After
 mcpkit = "1"
@@ -232,7 +232,7 @@ If migration causes critical issues, you can roll back to your previous version.
 
 ```toml
 # Revert Cargo.toml
-mcpkit = "0.7"
+mcpkit = "0.6"
 ```
 
 ```bash
@@ -331,7 +331,8 @@ If you encounter issues during migration:
 | mcpkit | MCP Protocol | Rust | Status |
 |--------|--------------|------|--------|
 | 1.0.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Stable |
-| 0.6.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Current RC |
+| 0.7.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Current RC |
+| 0.6.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Maintenance |
 | 0.4.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Maintenance |
 | 0.3.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Security Only |
 | 0.2.x  | 2024-11-05 → 2025-06-18 | 1.82+ | End of Life |

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -17,8 +17,8 @@ Tokio is the default runtime and requires no additional configuration:
 
 ```toml
 [dependencies]
-mcpkit-transport = "0.5"
-mcpkit-server = "0.5"
+mcpkit-transport = "0.7"
+mcpkit-server = "0.7"
 tokio = { version = "1", features = ["full"] }
 ```
 

--- a/docs/wasm.md
+++ b/docs/wasm.md
@@ -59,7 +59,7 @@ For WASM-compatible projects:
 
 ```toml
 [dependencies]
-mcpkit-core = "0.5"
+mcpkit-core = "0.7"
 # Don't include transport or server - they have platform dependencies
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
PR 1 from the #53 advisory review (aftermath of the release-prep PR): fix the live defect and close its generator in one change.

## The live defect

Ten install snippets still pin `mcpkit-*` subcrates at `0.5` while the workspace is at 0.7.0 — and under 0.x semver, `^0.5` **never** resolves to 0.7, so these snippets install a two-minor-versions-old API today:

- `docs/client-guide.md:26-28` (`mcpkit-client`, `mcpkit-transport`, `mcpkit-core`)
- `docs/extensions.md:20,23,613-614` (`mcpkit-axum`, `mcpkit-actix`, `mcpkit-core`, `mcpkit-server`)
- `docs/runtimes.md:20-21` (`mcpkit-transport`, `mcpkit-server`)
- `docs/wasm.md:62` (`mcpkit-core`)

All bumped to `0.7`.

## The generator

The CI `version-sync` job guarded only README.md and getting-started.md, and only the umbrella `mcpkit = ` pattern — so every subcrate snippet was invisible to it (the class-vs-instance failure #53's review diagnosed). It now:

1. **Presence:** every snippet-bearing doc (7 files) must reference the current version, with the pattern widened to `mcpkit(-[a-z]+)? = ` — valid because all published `mcpkit-*` crates share the workspace version (verified via `cargo metadata`: everything at 0.7.0; `mcpkit-macros-tests` is an unpublished 0.0.0 internal crate no snippet references).
2. **Negative sweep:** any *other* pinned mcpkit version anywhere in README.md/docs/ fails the job with the offending lines printed. This is the part the presence check alone can't do — `client-guide.md`'s actual pre-fix state was a current umbrella snippet *plus* three stale subcrate lines, which passed the old guard.
3. **Allowlist** for files where old versions are semantically intentional: `migration-to-1.0.md` (rollback targets), `api-stability.md` (policy examples), `docs/adr/` (point-in-time decision records — the survey found `adr/0004` carries a dated 0.5 snippet, correctly left untouched).

**Verified both ways:** the new check exits 0 on this tree and exits 1 on the pre-fix tree, reporting all ten stale lines. Same errexit-safe shell idiom as the existing job (no pipes whose exit status could be masked).

## Editorial fixes (deliberately outside the mechanical guard)

`migration-to-1.0.md` shows why it's allowlisted: a previous mechanical bump corrupted two 0.6-meaning lines to `"0.7"` — the "From 0.6.x to 1.0" *before*-snippet and the "Rolling Back to 0.6.x" target. Both restored to `"0.6"`. The version matrix also still labeled 0.6.x "Current RC"; it now lists 0.7.x as Current RC with 0.6.x in Maintenance (existing vocabulary, no new status labels).

## RELEASING.md

Two incident-grounded pre-publish checklist lines from the v0.6.0 release: registry-token freshness, and the release workflow's `components: clippy`. No rotation cadence invented — just "check before you tag".

No Rust code changes; fmt/clippy green, YAML validated.

Refs #53 (merged PR; advisory follow-up, nothing to auto-close).