### PR TITLE
docs(adr): record the v0.6.0 release incident and process hardening

### DIFF
--- a/docs/adr/0005-v0.6.0-release-incident.md
+++ b/docs/adr/0005-v0.6.0-release-incident.md
@@ -1,0 +1,81 @@
+# ADR 0005: v0.6.0 Release Incident and Release-Process Hardening
+
+## Status
+
+Accepted
+
+## Context
+
+The v0.6.0 release (2026-06-18) required three tag attempts. This record
+preserves the incident's evidence chain while it is still reconstructible;
+the raw workflow logs for the failed runs have already aged out of retention,
+so failure causes below are attested by the fix PRs rather than by log text.
+
+### Timeline (all times UTC, 2026-06-18; verified against the GitHub record)
+
+| Time | Event |
+|------|-------|
+| 08:05:18 | PR #54 (Dependabot security bumps: rmcp, rand) squash-merged as `1b08fc8` |
+| 08:06:35 | PR #53 (release prep 0.6.0 + publish-job hardening) squash-merged as `ec57845` |
+| 08:28:10 | Release run [27746840387](https://github.com/praxiomlabs/mcpkit/actions/runs/27746840387) — **Validate Release failed**; Publish skipped |
+| 08:53:40 | PR #55 squash-merged as `3c6f3fe`: the validate job's toolchain did not install the `clippy` component |
+| 08:58:02 | Release run [27748428325](https://github.com/praxiomlabs/mcpkit/actions/runs/27748428325) — Validate passed, **Publish to crates.io failed** |
+| 09:20:09 | `CARGO_REGISTRY_TOKEN` repository secret rotated (API-verified `updated_at`) |
+| 09:33:16 | PR #56 squash-merged as `14fd4c6`: publish step made errexit-safe — real errors surface and abort; only `already uploaded` is tolerated on re-run |
+| 09:37:46 | Release run [27750567740](https://github.com/praxiomlabs/mcpkit/actions/runs/27750567740) — **success**; v0.6.0 published |
+
+### Root causes
+
+1. **Missing `clippy` component in the release validate job** (first failure).
+   The main CI installed it; `release.yml` did not — an environment-parity
+   gap that only a real tag run could expose. Fixed at the class level by
+   PR #55 (`components: clippy` in the release toolchain step).
+2. **Stale `CARGO_REGISTRY_TOKEN`** (second failure). The token had been
+   rotated/expired since the previous release; nothing verified it before
+   the tag was pushed. The pre-#53 publish steps carried
+   `continue-on-error: true`, which would have *silently swallowed* this
+   class of failure; #53's hardening replaced them with an ordered script,
+   and #56 fixed that script's error-handling under `bash -e` so the real
+   error surfaced and aborted. The token itself was rotated at 09:20:09Z.
+
+### Provenance notes (squash archaeology)
+
+- PR #53's branch carried commits `5352c2f` (release prep) and `944e3d2`
+  (roadmap/versioning/migration-doc updates). Neither exists on `main`:
+  both landed via the squash `ec57845`. In particular, `944e3d2` resolved
+  the editorial items PR #53's body lists under "Deliberately NOT touched"
+  — the body was written before that commit and never updated, so the
+  deferral it describes was in fact resolved *within the same PR*.
+- PRs #54 and #53 merged one minute apart as a stack
+  (`1b08fc8` → `ec57845` on `main`).
+
+## Decision
+
+Harden the release process at the class level rather than per incident:
+
+1. Release-workflow toolchain parity with CI is mandatory
+   (`components: clippy` in `release.yml` — PR #55).
+2. Publish failures must be loud: a real error aborts the release; only
+   `already uploaded` is tolerated so a re-run after a partial publish
+   skips published crates (PR #56).
+3. Pre-publish checklist gains incident-grounded lines (RELEASING.md,
+   PR #167): verify `CARGO_REGISTRY_TOKEN` freshness and the release
+   toolchain's clippy component *before* tagging.
+4. The stale-doc-version class from #53's item 3 is closed by the widened
+   `version-sync` CI job (PR #167): all snippet-bearing docs, umbrella and
+   subcrate patterns, plus a negative sweep for any other pinned version.
+
+## Consequences
+
+- A tag push now fails fast and loudly on the two failure classes this
+  incident exercised; re-runs after a partial publish are safe.
+- The token class is mitigated (checklist), not eliminated. crates.io
+  Trusted Publishing (OIDC) would remove long-lived tokens at the
+  generator; evaluate its GA status and 11-crate fit before investing in
+  further token tooling.
+- The publish-ordering logic remains a hand-rolled script embedded in
+  `release.yml`. `cargo publish --workspace` (stable since Rust 1.90) may
+  allow deleting it entirely, pending an evaluation of its partial-publish
+  re-run semantics.
+- Unrecoverable: the exact error text of the two failed runs. This record
+  exists so the causal chain does not decay with it.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -14,6 +14,7 @@ An Architecture Decision Record captures an important architectural decision mad
 | [0002](0002-typestate-pattern.md) | Typestate Pattern for Connection Lifecycle | Accepted |
 | [0003](0003-unified-error-type.md) | Unified Error Type | Accepted |
 | [0004](0004-runtime-agnostic-design.md) | Runtime-Agnostic Design | Accepted |
+| [0005](0005-v0.6.0-release-incident.md) | v0.6.0 Release Incident and Release-Process Hardening | Accepted |
 
 ## Creating a New ADR
 


### PR DESCRIPTION
ADR 0005, from the #53 advisory review's record-hygiene recommendation — the one time-decaying item: the failed release runs' log text is already unrecoverable, and the squash-archaeology facts get more expensive to reconstruct weekly.

Everything in the record is verified against primary sources (PR merge timestamps, run job conclusions via the Actions API, the `CARGO_REGISTRY_TOKEN` `updated_at`); failure causes are attested by the fix PRs (#55, #56) since the log text is gone, and the record says so explicitly. Placed in the existing `docs/adr/` (indexed) rather than a new decisions directory. Companion comments with the same provenance facts are posted on PRs #53 and #54.

Docs-only change.