### PR TITLE
fix(server)!: reject task-augmenting a forbidden tool with -32601

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Task-augmenting a tool whose `execution.taskSupport` is absent or
+  `forbidden` is now rejected with `-32601` (Method not found) per spec,
+  instead of `-32602` (Invalid params), on the stdio runtime and the HTTP
+  adapters ([#165](https://github.com/praxiomlabs/mcpkit/issues/165)).
 - Ten documentation install snippets still pinned `mcpkit-*` subcrates at
   `0.5` (client-guide, extensions, runtimes, wasm) — under 0.x semver those
   resolve to a two-minor-versions-old API. Bumped to the current version, and

--- a/crates/mcpkit-axum/tests/tasks.rs
+++ b/crates/mcpkit-axum/tests/tasks.rs
@@ -188,7 +188,11 @@ async fn task_augmented_call_on_forbidden_tool_is_rejected() {
     let (state, _) = state();
     let (resp, _) = post(&state, None, call_task(1, "plain")).await;
     // A tool without taskSupport must be rejected, not run as a task.
-    assert!(!resp["error"].is_null(), "expected rejection, got: {resp}");
+    // Spec: -32601 (Method not found), not -32602.
+    assert_eq!(
+        resp["error"]["code"], -32601,
+        "expected -32601, got: {resp}"
+    );
     assert!(resp["result"]["task"].is_null());
 }
 

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -801,9 +801,12 @@ pub async fn begin_augmented_task(
         tool_task_support(handler.as_ref(), &name, &ctx).await
     };
     if support == TaskSupport::Forbidden {
-        return AugmentedTaskOutcome::Rejected(McpError::invalid_params(
-            "tools/call",
-            format!("tool '{name}' does not support task-augmented execution"),
+        // Spec: servers SHOULD return -32601 (Method not found) when a client
+        // task-augments a tool whose taskSupport is absent/forbidden.
+        return AugmentedTaskOutcome::Rejected(McpError::JsonRpc(
+            mcpkit_core::error::JsonRpcError::method_not_found(format!(
+                "tool '{name}' does not support task-augmented execution"
+            )),
         ));
     }
 

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -819,10 +819,11 @@ where
             self.server.tool_task_support(&name, &ctx).await
         };
         if support == mcpkit_core::types::TaskSupport::Forbidden {
-            let err = McpError::invalid_params(
-                "tools/call",
+            // Spec: -32601 (Method not found) for task-augmenting a
+            // forbidden tool.
+            let err = McpError::JsonRpc(mcpkit_core::error::JsonRpcError::method_not_found(
                 format!("tool '{name}' does not support task-augmented execution"),
-            );
+            ));
             let _ = self
                 .transport
                 .send(Message::Response(Response::error(
@@ -2559,10 +2560,11 @@ mod tests {
             .await
             .expect("send");
         let resp = next_response(&client).await;
-        assert!(
-            resp.error.is_some(),
-            "a forbidden tool must reject task augmentation"
-        );
+        let err = resp
+            .error
+            .expect("a forbidden tool must reject task augmentation");
+        // Spec: -32601 (Method not found), not -32602.
+        assert_eq!(err.code, -32601, "wrong rejection code: {err:?}");
 
         drop(client);
         let _ = timeout(Duration::from_secs(2), handle).await;


### PR DESCRIPTION
Closes #165 (filed from the #143 design review).

Per the 2025-11-25 tasks spec, *Tool-Level Negotiation*: **"If `execution.taskSupport` is not present or `'forbidden'`, clients MUST NOT attempt to invoke the tool as a task. Servers SHOULD return a `-32601` (Method not found) error if a client attempts to do so."**

Both gate sites — `begin_augmented_task` in the shared router helper (HTTP adapters) and `begin_task` in the stdio runtime — returned `-32602` (Invalid params). They now return `-32601` via the `McpError::JsonRpc` passthrough from #163, so the wire code is exact while the descriptive message is unchanged.

Marked breaking (`!`) out of caution for anyone matching on the wire error code; behavior is otherwise identical. The runtime test and the axum adapter test previously asserted only that *an* error was returned — both now pin `-32601`.

Full local gate green (fmt, clippy `-D warnings`, rustdoc `-D warnings`, full test suite).