### PR TITLE
feat(core): type the task field on CallToolRequest (#166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `CallToolRequest` gains the spec's `task: Option<TaskMetadata>` field
+  (2025-11-25 `CallToolRequestParams extends TaskAugmentedRequestParams`),
+  matching `CreateMessageRequest`; omitted from the wire when unset. The
+  server previously read `task` raw from params (unchanged); the typed field
+  lets clients build task-augmented `tools/call` through the typed request
+  ([#166](https://github.com/praxiomlabs/mcpkit/issues/166)).
+
 ### Fixed
 
 - Task-augmenting a tool whose `execution.taskSupport` is absent or

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -827,6 +827,7 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         let request = CallToolRequest {
             name: name.into(),
             arguments,
+            task: None,
         };
         self.request("tools/call", Some(serde_json::to_value(request)?))
             .await

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -616,6 +616,14 @@ pub struct CallToolRequest {
     /// Arguments to pass to the tool.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub arguments: Option<super::object::Object>,
+    /// Request task-augmented execution (2025-11-25).
+    ///
+    /// When set, a server that declared `tasks.requests.tools.call` (and a
+    /// tool whose `execution.taskSupport` allows it) replies with a
+    /// `CreateTaskResult` immediately; the `CallToolResult` is retrieved
+    /// later via `tasks/result`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<super::task::TaskMetadata>,
 }
 
 #[cfg(test)]

--- a/mcpkit/tests/tool_schema_compatibility.rs
+++ b/mcpkit/tests/tool_schema_compatibility.rs
@@ -405,6 +405,7 @@ fn test_call_tool_request_serialization() -> Result<(), Box<dyn std::error::Erro
     let request = CallToolRequest {
         name: "get_weather".to_string(),
         arguments: Some(serde_json::from_value(json!({"location": "New York"}))?),
+        task: None,
     };
 
     let json = serde_json::to_value(&request)?;
@@ -415,10 +416,35 @@ fn test_call_tool_request_serialization() -> Result<(), Box<dyn std::error::Erro
 }
 
 #[test]
+fn test_call_tool_request_task_field_round_trips_and_omits()
+-> Result<(), Box<dyn std::error::Error>> {
+    // Omitted when unset (wire-compatible with pre-task requests).
+    let request = CallToolRequest {
+        name: "slow".to_string(),
+        arguments: None,
+        task: None,
+    };
+    assert!(serde_json::to_value(&request)?.get("task").is_none());
+
+    // Round-trips when set (2025-11-25 TaskAugmentedRequestParams).
+    let request = CallToolRequest {
+        name: "slow".to_string(),
+        arguments: None,
+        task: Some(mcpkit::types::TaskMetadata { ttl: Some(60_000) }),
+    };
+    let json = serde_json::to_value(&request)?;
+    assert_eq!(json["task"], json!({ "ttl": 60000 }));
+    let back: CallToolRequest = serde_json::from_value(json)?;
+    assert_eq!(back.task.and_then(|t| t.ttl), Some(60_000));
+    Ok(())
+}
+
+#[test]
 fn test_call_tool_request_without_arguments() -> Result<(), Box<dyn std::error::Error>> {
     let request = CallToolRequest {
         name: "ping".to_string(),
         arguments: None,
+        task: None,
     };
 
     let json_str = serde_json::to_string(&request)?;


### PR DESCRIPTION
Closes #166 (filed from the #143 design review).

`CallToolRequestParams extends TaskAugmentedRequestParams` in the 2025-11-25 schema, but `CallToolRequest` had no typed `task` field — the server dispatch reads it raw from params, which still works and is untouched here. This adds `task: Option<TaskMetadata>` (serde-omitted when unset), matching `CreateMessageRequest` from #162, completing type-level `TaskAugmentedRequestParams` fidelity and letting clients build task-augmented `tools/call` through the typed request instead of hand-rolled JSON.

Wire-compatible: requests without `task` serialize byte-identically (pinned by test, alongside a round-trip test). No behavior changes; additive field only (pre-1.0 struct-literal break for anyone constructing `CallToolRequest` exhaustively — the three in-repo sites updated).

Full local gate green (fmt, clippy `-D warnings`, rustdoc `-D warnings`, full test suite).