### PR TITLE
ci(release): extract publish script and commit its test harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      release-tooling: ${{ steps.filter.outputs.release-tooling }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
@@ -47,6 +48,9 @@ jobs:
               - 'crates/mcpkit-transport/proto/**'
               - 'deny.toml'
               - '.github/workflows/ci.yml'
+            release-tooling:
+              - 'scripts/publish-crates*.sh'
+              - '.github/workflows/release.yml'
 
   # ==========================================================================
   # Fast checks - run first, fail fast
@@ -338,6 +342,16 @@ jobs:
   # never deadlocks a required check.
   # ==========================================================================
 
+  publish-script:
+    name: Publish Script Harness
+    needs: changes
+    if: ${{ needs.changes.outputs.release-tooling == 'true' || github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run publish-script harness (stub cargo, three paths)
+        run: bash scripts/publish-crates-test.sh
+
   ci-success:
     name: CI Success
     if: ${{ always() }}
@@ -355,6 +369,7 @@ jobs:
         msrv,
         test-matrix,
         semver,
+        publish-script,
       ]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,64 +50,13 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
 
-      # Publish crates in dependency order
-      # Order matters: each crate must have its dependencies published first
-      # mcpkit-macros has mcpkit-server as a dev-dependency, so server must come first
-      # A real publish failure aborts the release. The only tolerated error is
-      # "already uploaded", so re-running after a partial publish skips the
-      # crates already on crates.io instead of masking every failure (the old
-      # `continue-on-error: true` hid genuine errors on all but the last crate).
+      # Publish crates in dependency order via the committed script — the
+      # same file scripts/publish-crates-test.sh exercises in CI under the
+      # same `bash -e` invocation, so the tested logic is the released logic.
       - name: Publish crates to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: |
-          # NB: the step shell runs with `bash -e`. Capture the publish output
-          # via an `if` condition so a non-zero cargo exit does NOT trip errexit
-          # before we can print the error and check for "already uploaded".
-          set -uo pipefail
-
-          publish() {
-            echo "::group::publish $1"
-            local out
-            if out=$(cargo publish -p "$1" 2>&1); then
-              echo "$out"
-              echo "::endgroup::"
-              return 0
-            fi
-            echo "$out"
-            echo "::endgroup::"
-            if echo "$out" | grep -qiE "already (exists|uploaded)"; then
-              echo "::notice::$1 already published at this version — skipping"
-              return 0
-            fi
-            echo "::error::failed to publish $1"
-            exit 1
-          }
-
-          # Let the crates.io index propagate before publishing dependents.
-          wait_index() { echo "waiting 30s for crates.io index..."; sleep 30; }
-
-          publish mcpkit-core
-          wait_index
-          publish mcpkit-transport
-          wait_index
-          publish mcpkit-server
-          wait_index
-          publish mcpkit-macros
-          wait_index
-          publish mcpkit-client
-          wait_index
-          publish mcpkit-testing
-          wait_index
-          publish mcpkit-axum
-          wait_index
-          publish mcpkit-actix
-          wait_index
-          publish mcpkit-rocket
-          wait_index
-          publish mcpkit-warp
-          wait_index
-          publish mcpkit
+        run: bash -e scripts/publish-crates.sh
 
   github-release:
     name: Create GitHub Release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- The release publish logic is extracted from `release.yml` into
+  `scripts/publish-crates.sh` and covered by a committed harness
+  (`scripts/publish-crates-test.sh`) that CI runs whenever release tooling
+  changes. The harness exercises the clean-publish, partial-re-run
+  (already-uploaded tolerated), and real-error-aborts paths against a stub
+  `cargo`, invoking the script file exactly as the workflow does
+  (`bash -e`), so the tested shell semantics are the released ones. Native
+  `cargo publish --workspace` was evaluated and rejected: its upfront
+  already-published check hard-fails a partial-publish re-run instead of
+  skipping (verified against cargo's `verify_unpublished`), which is the
+  recovery property the v0.6.0 incident showed matters
+  (see `docs/adr/0005-v0.6.0-release-incident.md`).
+
 - `CallToolRequest` gains the spec's `task: Option<TaskMetadata>` field
   (2025-11-25 `CallToolRequestParams extends TaskAugmentedRequestParams`),
   matching `CreateMessageRequest`; omitted from the wire when unset. The

--- a/scripts/publish-crates-test.sh
+++ b/scripts/publish-crates-test.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Harness for scripts/publish-crates.sh: exercises the success,
+# already-uploaded, and real-error paths against a stub `cargo`, invoking the
+# script exactly as release.yml does (`bash -e`), so what passes here is what
+# runs in a release. No network, no real cargo, no real sleeps.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PUBLISH_SCRIPT="$SCRIPT_DIR/publish-crates.sh"
+
+EXPECTED_ORDER="mcpkit-core mcpkit-transport mcpkit-server mcpkit-macros \
+mcpkit-client mcpkit-testing mcpkit-axum mcpkit-actix mcpkit-rocket \
+mcpkit-warp mcpkit"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+STUB_DIR="$TMP/bin"
+CALL_LOG="$TMP/calls.log"
+mkdir -p "$STUB_DIR"
+
+# Stub cargo: logs each `publish -p <crate>` call, then consults MODE.
+# MODE format, one directive per line in $TMP/mode: "<crate> <behavior>"
+# where behavior is ok | already | fail. Unlisted crates default to ok.
+cat > "$STUB_DIR/cargo" <<'STUB'
+#!/usr/bin/env bash
+crate="$3"   # cargo publish -p <crate>
+echo "$crate" >> "$CALL_LOG"
+behavior=$(awk -v c="$crate" '$1 == c { print $2 }' "$MODE_FILE" 2>/dev/null)
+case "${behavior:-ok}" in
+  ok)      echo "Uploading $crate"; exit 0 ;;
+  already) echo "error: crate $crate@0.0.0 already uploaded" >&2; exit 101 ;;
+  fail)    echo "error: the remote server responded with an error: broken" >&2; exit 101 ;;
+esac
+STUB
+chmod +x "$STUB_DIR/cargo"
+
+run_script() {
+  : > "$CALL_LOG"
+  # Invoke exactly as the release workflow does: `bash -e <script>`.
+  CALL_LOG="$CALL_LOG" MODE_FILE="$TMP/mode" PUBLISH_WAIT_SECS=0 \
+    PATH="$STUB_DIR:$PATH" bash -e "$PUBLISH_SCRIPT" > "$TMP/out.log" 2>&1
+}
+
+fail() { echo "FAIL: $1"; echo "--- output:"; cat "$TMP/out.log"; exit 1; }
+
+# --- Path 1: clean publish — succeeds and hits every crate in order --------
+: > "$TMP/mode"
+run_script || fail "clean publish path exited non-zero"
+[ "$(tr '\n' ' ' < "$CALL_LOG" | sed 's/ $//')" = "$(echo $EXPECTED_ORDER)" ] \
+  || fail "publish order mismatch: $(tr '\n' ' ' < "$CALL_LOG")"
+echo "PASS: clean publish (11 crates, dependency order)"
+
+# --- Path 2: partial re-run — already-uploaded crates are skipped ----------
+cat > "$TMP/mode" <<'MODE'
+mcpkit-core already
+mcpkit-transport already
+mcpkit-server already
+MODE
+run_script || fail "already-uploaded path must be tolerated (re-run support)"
+grep -q "mcpkit-core already published at this version" "$TMP/out.log" \
+  || fail "missing skip notice for already-uploaded crate"
+[ "$(wc -l < "$CALL_LOG")" -eq 11 ] || fail "re-run must still attempt all crates"
+echo "PASS: partial-publish re-run (already-uploaded tolerated)"
+
+# --- Path 3: real error — aborts and does not publish dependents -----------
+cat > "$TMP/mode" <<'MODE'
+mcpkit-server fail
+MODE
+if run_script; then fail "a real publish error must abort the release"; fi
+grep -q "failed to publish mcpkit-server" "$TMP/out.log" \
+  || fail "real error was not surfaced"
+[ "$(wc -l < "$CALL_LOG")" -eq 3 ] \
+  || fail "publishing must stop at the failing crate (got $(wc -l < "$CALL_LOG") calls)"
+grep -q "mcpkit-macros" "$CALL_LOG" && fail "dependent crate was attempted after a real failure"
+echo "PASS: real error aborts before dependents"
+
+echo "All publish-script paths verified."

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Publish all mcpkit crates to crates.io in dependency order.
+#
+# Invoked by .github/workflows/release.yml as `bash -e scripts/publish-crates.sh`
+# and by scripts/publish-crates-test.sh the same way, so the tested shell
+# semantics are the released shell semantics by construction.
+#
+# Order matters: each crate must have its dependencies published first
+# (mcpkit-macros has mcpkit-server as a dev-dependency, so server comes first).
+# A real publish failure aborts the release. The only tolerated error is
+# "already uploaded/exists", so re-running after a partial publish skips the
+# crates already on crates.io instead of masking every failure (the old
+# `continue-on-error: true` hid genuine errors on all but the last crate).
+# Note: native `cargo publish --workspace` was evaluated and rejected — its
+# upfront verify_unpublished check hard-fails on the first already-published
+# crate, so a partial-publish re-run aborts instead of skipping (see
+# docs/adr/0005-v0.6.0-release-incident.md and #53's advisory follow-up).
+
+# NB: callers run this with `bash -e`. Capture the publish output via an `if`
+# condition so a non-zero cargo exit does NOT trip errexit before we can print
+# the error and check for "already uploaded".
+set -uo pipefail
+
+# Seconds to wait for crates.io index propagation between dependent publishes.
+# Overridable so the test harness does not sleep for real.
+WAIT_SECS="${PUBLISH_WAIT_SECS:-30}"
+
+publish() {
+  echo "::group::publish $1"
+  local out
+  if out=$(cargo publish -p "$1" 2>&1); then
+    echo "$out"
+    echo "::endgroup::"
+    return 0
+  fi
+  echo "$out"
+  echo "::endgroup::"
+  if echo "$out" | grep -qiE "already (exists|uploaded)"; then
+    echo "::notice::$1 already published at this version — skipping"
+    return 0
+  fi
+  echo "::error::failed to publish $1"
+  exit 1
+}
+
+# Let the crates.io index propagate before publishing dependents.
+wait_index() { echo "waiting ${WAIT_SECS}s for crates.io index..."; sleep "$WAIT_SECS"; }
+
+publish mcpkit-core
+wait_index
+publish mcpkit-transport
+wait_index
+publish mcpkit-server
+wait_index
+publish mcpkit-macros
+wait_index
+publish mcpkit-client
+wait_index
+publish mcpkit-testing
+wait_index
+publish mcpkit-axum
+wait_index
+publish mcpkit-actix
+wait_index
+publish mcpkit-rocket
+wait_index
+publish mcpkit-warp
+wait_index
+publish mcpkit


### PR DESCRIPTION
PR 2 from the #53 advisory review, resolving its uncertainty #3 first as prescribed.

## The evaluation that decided the shape

`cargo publish --workspace` (stable since 1.90, present on the pinned 1.96 toolchain) was the rival to committing a harness — if a partial-publish re-run cleanly skipped published members, we would delete the hand-rolled loop instead. Verified findings:

- A full `--dry-run --allow-dirty` workspace publish **succeeds end-to-end**: all 11 crates package and verify in correct dependency order, using a local overlay (this also fixes PR #53's documented dry-run limitation for dependent crates — worth knowing for the future).
- **But re-run semantics fail the requirement:** cargo's `verify_unpublished` (ops/registry/publish.rs) runs upfront over every selected package and `bail!`s — *"crate X@V already exists"* — on the first already-published one (downgraded to a warning only under `--dry-run`). Since the 1.90 announcement itself warns publishes are not atomic ("network errors or server-side failures can still lead to a partially published workspace"), a plain re-run after a partial publish **aborts**; recovery means hand-writing `--exclude` flags mid-incident. That is precisely the failure mode the v0.6.0 incident taught us to care about (ADR 0005).

**Verdict: keep the bespoke ordered script; make its verification durable.**

## What changed

- **`scripts/publish-crates.sh`** — the release.yml publish block, extracted. Diffed against the embedded original: byte-identical except a `PUBLISH_WAIT_SECS` env override (default 30) so the harness doesn't sleep 300s. The workflow step becomes `bash -e scripts/publish-crates.sh` — same invocation shape as before (GitHub's run steps use `bash -e`), and the same invocation the harness uses, so tested semantics are released semantics by construction. `CARGO_REGISTRY_TOKEN` stays step-level.
- **`scripts/publish-crates-test.sh`** — the three-path harness (recreating what #53 claimed was "unit-tested against a stub cargo" but lived only in a session log): clean publish asserts all 11 crates in dependency order; partial re-run asserts already-uploaded crates are tolerated and every crate is still attempted; real error asserts the failure is surfaced and **no dependent crate is attempted after it**. Stub `cargo` via PATH shim; no network, no sleeps. (The order assertion earned its keep immediately — it caught an arg-index bug in my first stub.)
- **CI wiring** — new `Publish Script Harness` job, path-filtered to `scripts/publish-crates*.sh` + `release.yml` (trunk pushes always run, matching the existing filter convention), added to the `ci-success` aggregation (skipped passes, failure blocks).

Per the advisory's amendments: the harness executes the committed script file itself (not a logic copy), under the workflow's exact shell invocation; the anti-pattern sweep (part d) was dropped; actionlint/shellcheck left out.

Refs #53 advisory / ADR 0005. No Rust changes.