### PR TITLE
fix(adapters): accept POSTed JSON-RPC responses with 202 (#153 PR 0a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The HTTP adapters (axum/actix/warp/rocket) now accept a POSTed JSON-RPC
+  *response* with `202 Accepted` per the Streamable HTTP spec, instead of
+  rejecting it as "Expected request or notification". This is how clients
+  deliver responses to server-initiated requests; until the adapter
+  server->client peer lands (#153), an accepted response is logged and
+  dropped — matching the stdio runtime's handling of a response that matches
+  no pending request
+  ([#153](https://github.com/praxiomlabs/mcpkit/issues/153), PR 0a of the
+  reviewed design).
+
 ### Added
 
 - The release publish logic is extracted from `release.yml` into

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -165,11 +165,22 @@ where
                 .insert_header(("mcp-session-id", session_id))
                 .finish())
         }
-        _ => {
-            warn!("Unexpected message type received");
-            Err(ExtensionError::InvalidMessage(
-                "Expected request or notification".to_string(),
-            ))
+        // Spec (Streamable HTTP): a client delivers responses to
+        // server-initiated requests by POSTing them; "if the server accepts
+        // the input, the server MUST return HTTP status code 202 Accepted
+        // with no body". Correlation with a pending server-initiated request
+        // arrives with the session peer (#153); until then this is
+        // log-and-drop, matching the runtime's `route_response` for ids that
+        // match no pending request.
+        Message::Response(response) => {
+            debug!(
+                id = %response.id,
+                session_id = %session_id,
+                "Received client response (no pending server-initiated request; dropped)"
+            );
+            Ok(HttpResponse::Accepted()
+                .insert_header(("mcp-session-id", session_id))
+                .finish())
         }
     }
 }

--- a/crates/mcpkit-actix/tests/integration.rs
+++ b/crates/mcpkit-actix/tests/integration.rs
@@ -1,0 +1,72 @@
+//! Adapter-level HTTP tests for the actix adapter.
+
+use actix_web::{App, test};
+use mcpkit_actix::McpRouter;
+use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{GetPromptResult, Prompt, Resource, ResourceContents, Tool, ToolOutput};
+use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+
+struct TestHandler;
+
+impl ServerHandler for TestHandler {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("t", "1.0.0")
+    }
+}
+impl ToolHandler for TestHandler {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![])
+    }
+    async fn call_tool(
+        &self,
+        name: &str,
+        _args: serde_json::Map<String, serde_json::Value>,
+        _ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        Err(McpError::method_not_found(name))
+    }
+}
+impl ResourceHandler for TestHandler {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for TestHandler {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Err(McpError::method_not_found(name))
+    }
+}
+
+/// Spec (Streamable HTTP): a POSTed JSON-RPC *response* is accepted with
+/// 202, not rejected (#153 PR 0a).
+#[actix_rt::test]
+async fn response_post_is_accepted_with_202() {
+    let router = McpRouter::new(TestHandler);
+    let app = test::init_service(App::new().configure(router.configure_app())).await;
+
+    let req = test::TestRequest::post()
+        .uri("/mcp")
+        .insert_header(("content-type", "application/json"))
+        .insert_header(("mcp-protocol-version", "2025-11-25"))
+        .set_payload(r#"{"jsonrpc":"2.0","id":42,"result":{"roots":[]}}"#)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), actix_web::http::StatusCode::ACCEPTED);
+}

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -194,9 +194,23 @@ where
             )
                 .into_response()
         }
-        _ => {
-            warn!("Unexpected message type received");
-            ExtensionError::InvalidMessage("Expected request or notification".to_string())
+        // Spec (Streamable HTTP): a client delivers responses to
+        // server-initiated requests by POSTing them; "if the server accepts
+        // the input, the server MUST return HTTP status code 202 Accepted
+        // with no body". Correlation with a pending server-initiated request
+        // arrives with the session peer (#153); until then this is
+        // log-and-drop, matching the runtime's `route_response` for ids that
+        // match no pending request.
+        Message::Response(response) => {
+            debug!(
+                id = %response.id,
+                session_id = %session_id,
+                "Received client response (no pending server-initiated request; dropped)"
+            );
+            (
+                StatusCode::ACCEPTED,
+                [("mcp-session-id", session_id.as_str())],
+            )
                 .into_response()
         }
     }

--- a/crates/mcpkit-axum/tests/tasks.rs
+++ b/crates/mcpkit-axum/tests/tasks.rs
@@ -258,3 +258,21 @@ async fn tasks_are_isolated_per_session() {
     let (ga, _) = post(&state, Some(&sid_a), task_method(4, "tasks/get", &task_id)).await;
     assert!(ga["error"].is_null(), "session A lost its own task: {ga}");
 }
+
+/// Spec (Streamable HTTP): a POSTed JSON-RPC *response* is accepted with
+/// 202, not rejected — clients deliver responses to server-initiated
+/// requests this way (#153 PR 0a; correlation lands with the session peer).
+#[tokio::test]
+async fn response_post_is_accepted_with_202() {
+    use axum::response::IntoResponse;
+    let (state, _) = state();
+    let response = mcpkit_axum::handle_mcp_post(
+        State(state),
+        HeaderMap::new(),
+        None,
+        r#"{"jsonrpc":"2.0","id":42,"result":{"roots":[]}}"#.to_string(),
+    )
+    .await
+    .into_response();
+    assert_eq!(response.status(), axum::http::StatusCode::ACCEPTED);
+}

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -316,12 +316,20 @@ where
             );
             McpResponse::accepted(session_id)
         }
-        _ => {
-            warn!("Unexpected message type received");
-            McpResponse::error(
-                Status::BadRequest,
-                "Expected request or notification".to_string(),
-            )
+        // Spec (Streamable HTTP): a client delivers responses to
+        // server-initiated requests by POSTing them; "if the server accepts
+        // the input, the server MUST return HTTP status code 202 Accepted
+        // with no body". Correlation with a pending server-initiated request
+        // arrives with the session peer (#153); until then this is
+        // log-and-drop, matching the runtime's `route_response` for ids that
+        // match no pending request.
+        Message::Response(response) => {
+            debug!(
+                id = %response.id,
+                session_id = %session_id,
+                "Received client response (no pending server-initiated request; dropped)"
+            );
+            McpResponse::accepted(session_id)
         }
     }
 }

--- a/crates/mcpkit-rocket/tests/integration.rs
+++ b/crates/mcpkit-rocket/tests/integration.rs
@@ -312,3 +312,19 @@ fn test_cors_headers() {
             .is_some()
     );
 }
+
+/// Spec (Streamable HTTP): a POSTed JSON-RPC *response* is accepted with
+/// 202, not rejected (#153 PR 0a).
+#[test]
+fn response_post_is_accepted_with_202() {
+    let client = create_test_client();
+
+    let response = client
+        .post("/mcp")
+        .header(ContentType::JSON)
+        .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .body(r#"{"jsonrpc":"2.0","id":42,"result":{"roots":[]}}"#)
+        .dispatch();
+
+    assert_eq!(response.status(), Status::Accepted);
+}

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -193,17 +193,22 @@ where
                 StatusCode::ACCEPTED,
             ))
         }
-        _ => {
-            warn!("Unexpected message type received");
-            let error_body = serde_json::json!({
-                "error": {
-                    "code": -32600,
-                    "message": "Expected request or notification"
-                }
-            });
+        // Spec (Streamable HTTP): a client delivers responses to
+        // server-initiated requests by POSTing them; "if the server accepts
+        // the input, the server MUST return HTTP status code 202 Accepted
+        // with no body". Correlation with a pending server-initiated request
+        // arrives with the session peer (#153); until then this is
+        // log-and-drop, matching the runtime's `route_response` for ids that
+        // match no pending request.
+        Message::Response(response) => {
+            debug!(
+                id = %response.id,
+                session_id = %session_id,
+                "Received client response (no pending server-initiated request; dropped)"
+            );
             Ok(warp::reply::with_status(
-                warp::reply::json(&error_body),
-                StatusCode::BAD_REQUEST,
+                warp::reply::json(&serde_json::json!({})),
+                StatusCode::ACCEPTED,
             ))
         }
     }

--- a/crates/mcpkit-warp/tests/integration.rs
+++ b/crates/mcpkit-warp/tests/integration.rs
@@ -318,3 +318,21 @@ async fn test_without_cors() {
             .is_none()
     );
 }
+
+/// Spec (Streamable HTTP): a POSTed JSON-RPC *response* is accepted with
+/// 202, not rejected (#153 PR 0a).
+#[tokio::test]
+async fn response_post_is_accepted_with_202() {
+    let filter = McpRouter::new(TestHandler).into_filter();
+
+    let response = warp::test::request()
+        .method("POST")
+        .path("/mcp")
+        .header("content-type", "application/json")
+        .header("mcp-protocol-version", "2025-11-25")
+        .body(r#"{"jsonrpc":"2.0","id":42,"result":{"roots":[]}}"#)
+        .reply(&filter)
+        .await;
+
+    assert_eq!(response.status(), 202);
+}


### PR DESCRIPTION
PR 0a from the #153 design (v3, two adversarial review rounds — `.tmp/design-153-adapter-peer.md`). **Leave #153 open** — this is the first slice of the reviewed plan.

## What

Per the Streamable HTTP spec: *"The body of the POST request MUST be a single JSON-RPC request, notification, or response. … If the input is a JSON-RPC response or notification: if the server accepts the input, the server MUST return HTTP status code 202 Accepted with no body."* All four adapters rejected a POSTed `Message::Response` via their catch-all arm ("Expected request or notification") — a standing spec MUST violation, and the delivery path clients will use to answer server-initiated requests once the session peer exists.

Each adapter's catch-all arm is replaced by a `Message::Response` arm (the catch-all became unreachable — `Message` has exactly three variants): log at debug, reply 202 using the adapter's existing notification-arm idiom. Correlation with pending server-initiated requests deliberately does **not** exist yet; log-and-drop matches the stdio runtime's `route_response` for unmatched ids, which is what makes this slice independently shippable (the round-2 reviewer's "genuinely shippable slice … Make that PR 0").

Deliberately excluded (PR 0b, breaking): restricting session auto-create to `initialize` — today a session-id-less POST mints a session; tightening that to 400 changes behavior for lenient clients and ships separately with a `!` commit.

## Tests

One 202 regression test per adapter. actix had no adapter-level HTTP test harness at all — this adds its first (`actix_web::test` + `configure_app`), so the actix arm is pinned rather than assumed.

## Gate note

Local toolchain is 1.97.1 (stable moved ahead of CI's 1.96 pin); 1.97's new `clippy::manual_assert_eq` flags four **pre-existing** lines in `mcpkit/tests/error_scenarios.rs` untouched by this diff — kept out of this PR deliberately, tiny chore PR to follow. fmt/doc/tests all green locally (74 suites); clippy is arbitrated by CI's pinned 1.96.

Refs #153. Related standing-defect issues filed from the same review: #172 (GET not on the MCP endpoint), #173 (vacuous SSE binding check).