### PR TITLE
chore(tests): use assert_eq for error-code assertions (clippy 1.97)

### DIFF
--- a/mcpkit/tests/error_scenarios.rs
+++ b/mcpkit/tests/error_scenarios.rs
@@ -415,10 +415,10 @@ fn test_reserved_error_codes_range() {
     // Standard error codes: -32700, -32600, -32601, -32602, -32603
 
     assert!(codes::PARSE_ERROR < -32600);
-    assert!(codes::INVALID_REQUEST == -32600);
-    assert!(codes::METHOD_NOT_FOUND == -32601);
-    assert!(codes::INVALID_PARAMS == -32602);
-    assert!(codes::INTERNAL_ERROR == -32603);
+    assert_eq!(codes::INVALID_REQUEST, -32600);
+    assert_eq!(codes::METHOD_NOT_FOUND, -32601);
+    assert_eq!(codes::INVALID_PARAMS, -32602);
+    assert_eq!(codes::INTERNAL_ERROR, -32603);
 }
 
 #[test]


### PR DESCRIPTION
Four pre-existing `assert!(a == b)` lines in `mcpkit/tests/error_scenarios.rs` trip Rust 1.97's new `clippy::manual_assert_eq` (found while gating #174 on a local 1.97.1 toolchain; CI pins 1.96 so it is still green today). Fixing ahead of the next toolchain bump. Behavior unchanged; `assert_eq!` additionally prints both values on failure. Verified clean under clippy 1.97 locally.