### PR TITLE
fix(adapters)!: require mcp-session-id on non-initialize messages (#153 PR 0b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking (behavior):** the HTTP adapters now require `mcp-session-id` on
+  every message except `initialize` — a non-initialize request, notification,
+  or response without it gets `400 Bad Request` (spec: servers assigning
+  session ids do so at initialization; previously any session-id-less POST
+  silently minted a throwaway session and proceeded, leaking one
+  uninitialized session per stray message). Clients that echo the
+  `mcp-session-id` response header (spec MUST once assigned) are unaffected.
+  The warp adapter previously **never returned** `mcp-session-id` on POST
+  responses at all — making the requirement unsatisfiable — and now sets it
+  like the other three adapters
+  ([#153](https://github.com/praxiomlabs/mcpkit/issues/153), PR 0b).
+
 ### Fixed
 
 - The HTTP adapters (axum/actix/warp/rocket) now accept a POSTed JSON-RPC

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -21,6 +21,12 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
+/// Whether this message is an `initialize` request — the only message allowed
+/// to omit `mcp-session-id` (the server assigns the id in its response).
+fn is_initialize(msg: &Message) -> bool {
+    matches!(msg, Message::Request(r) if r.method.as_ref() == "initialize")
+}
+
 /// Handle MCP POST requests.
 ///
 /// This handler processes JSON-RPC messages sent via HTTP POST.
@@ -74,6 +80,11 @@ where
     // middleware via a request extension; mcpkit binds the session to it.
     let user = req.extensions().get::<VerifiedUser>().cloned();
 
+    // Parse the message first: whether a missing session id is acceptable
+    // depends on whether this is an `initialize` request.
+    let msg: Message =
+        serde_json::from_str(&body).map_err(|e| ExtensionError::InvalidMessage(e.to_string()))?;
+
     // Get or create session
     let session_id = req
         .headers()
@@ -94,14 +105,17 @@ where
                 return Ok(HttpResponse::Forbidden().body(e.to_string()));
             }
         },
-        None => state.sessions.create_for_user(user),
+        // Spec: a server assigning session ids does so at initialization;
+        // other requests without `mcp-session-id` are 400 Bad Request.
+        None if is_initialize(&msg) => state.sessions.create_for_user(user),
+        None => {
+            warn!("Rejected: missing mcp-session-id on non-initialize message");
+            return Ok(HttpResponse::BadRequest()
+                .body("missing mcp-session-id (required for all messages after initialize)"));
+        }
     };
 
     debug!(session_id = %session_id, "Processing MCP request");
-
-    // Parse message
-    let msg: Message =
-        serde_json::from_str(&body).map_err(|e| ExtensionError::InvalidMessage(e.to_string()))?;
 
     // Process message
     match msg {

--- a/crates/mcpkit-actix/tests/integration.rs
+++ b/crates/mcpkit-actix/tests/integration.rs
@@ -60,13 +60,46 @@ async fn response_post_is_accepted_with_202() {
     let router = McpRouter::new(TestHandler);
     let app = test::init_service(App::new().configure(router.configure_app())).await;
 
+    // Initialize first (#153 PR 0b: only initialize may omit mcp-session-id).
     let req = test::TestRequest::post()
         .uri("/mcp")
         .insert_header(("content-type", "application/json"))
         .insert_header(("mcp-protocol-version", "2025-11-25"))
+        .set_payload(r#"{"jsonrpc":"2.0","method":"initialize","params":{},"id":0}"#)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    let sid = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("initialize must assign a session id");
+
+    let req = test::TestRequest::post()
+        .uri("/mcp")
+        .insert_header(("content-type", "application/json"))
+        .insert_header(("mcp-protocol-version", "2025-11-25"))
+        .insert_header(("mcp-session-id", sid.as_str()))
         .set_payload(r#"{"jsonrpc":"2.0","id":42,"result":{"roots":[]}}"#)
         .to_request();
     let resp = test::call_service(&app, req).await;
 
     assert_eq!(resp.status(), actix_web::http::StatusCode::ACCEPTED);
+}
+
+/// #153 PR 0b: a non-initialize message without `mcp-session-id` is 400.
+#[actix_rt::test]
+async fn missing_session_id_on_non_initialize_is_400() {
+    let router = McpRouter::new(TestHandler);
+    let app = test::init_service(App::new().configure(router.configure_app())).await;
+
+    let req = test::TestRequest::post()
+        .uri("/mcp")
+        .insert_header(("content-type", "application/json"))
+        .insert_header(("mcp-protocol-version", "2025-11-25"))
+        .set_payload(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+
+    assert_eq!(resp.status(), actix_web::http::StatusCode::BAD_REQUEST);
 }

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -38,6 +38,12 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
+/// Whether this message is an `initialize` request — the only message allowed
+/// to omit `mcp-session-id` (the server assigns the id in its response).
+fn is_initialize(msg: &Message) -> bool {
+    matches!(msg, Message::Request(r) if r.method.as_ref() == "initialize")
+}
+
 /// Handle MCP POST requests.
 ///
 /// This handler processes JSON-RPC messages sent via HTTP POST.
@@ -91,6 +97,16 @@ where
         .into_response();
     }
 
+    // Parse the message first: whether a missing session id is acceptable
+    // depends on whether this is an `initialize` request.
+    let msg: Message = match serde_json::from_str(&body) {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(error = %e, "Failed to parse JSON-RPC message");
+            return ExtensionError::InvalidMessage(e.to_string()).into_response();
+        }
+    };
+
     // Get or create session
     let session_id = headers
         .get("mcp-session-id")
@@ -110,19 +126,20 @@ where
                 return (StatusCode::FORBIDDEN, e.to_string()).into_response();
             }
         },
-        None => state.sessions.create_for_user(user),
+        // Spec: a server assigning session ids does so at initialization;
+        // other requests without `mcp-session-id` are 400 Bad Request.
+        None if is_initialize(&msg) => state.sessions.create_for_user(user),
+        None => {
+            warn!("Rejected: missing mcp-session-id on non-initialize message");
+            return (
+                StatusCode::BAD_REQUEST,
+                "missing mcp-session-id (required for all messages after initialize)",
+            )
+                .into_response();
+        }
     };
 
     debug!(session_id = %session_id, "Processing MCP request");
-
-    // Parse message
-    let msg: Message = match serde_json::from_str(&body) {
-        Ok(m) => m,
-        Err(e) => {
-            warn!(error = %e, "Failed to parse JSON-RPC message");
-            return ExtensionError::InvalidMessage(e.to_string()).into_response();
-        }
-    };
 
     // Process message
     match msg {

--- a/crates/mcpkit-axum/tests/completion.rs
+++ b/crates/mcpkit-axum/tests/completion.rs
@@ -90,6 +90,36 @@ impl CompletionHandler for Comp {
     }
 }
 
+/// Initialize a session, then POST `body` within it, returning the parsed
+/// response (required since #153 PR 0b: only `initialize` may omit
+/// `mcp-session-id`).
+async fn post_in_session(state: McpState<H>, body: String) -> serde_json::Value {
+    use axum::http::HeaderValue;
+    let init = serde_json::json!({
+        "jsonrpc": "2.0", "id": 0, "method": "initialize",
+        "params": { "protocolVersion": "2025-11-25", "capabilities": {} }
+    })
+    .to_string();
+    let response = mcpkit_axum::handle_mcp_post(State(state.clone()), HeaderMap::new(), None, init)
+        .await
+        .into_response();
+    let sid = response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("initialize must assign a session id");
+    let mut headers = HeaderMap::new();
+    headers.insert("mcp-session-id", HeaderValue::from_str(&sid).expect("sid"));
+    let response = mcpkit_axum::handle_mcp_post(State(state), headers, None, body)
+        .await
+        .into_response();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
 #[tokio::test]
 async fn completion_complete_works_through_axum_adapter() {
     let state = McpState::new(H).with_completion(Comp);
@@ -105,13 +135,7 @@ async fn completion_complete_works_through_axum_adapter() {
     })
     .to_string();
 
-    let response = mcpkit_axum::handle_mcp_post(State(state), HeaderMap::new(), None, body)
-        .await
-        .into_response();
-    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("body");
-    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+    let json: serde_json::Value = post_in_session(state, body).await;
 
     // Answered (not method-not-found), and the completion context propagated.
     assert!(json.get("error").is_none(), "response: {json}");
@@ -164,13 +188,7 @@ async fn completion_complete_without_handler_is_method_not_found() {
     })
     .to_string();
 
-    let response = mcpkit_axum::handle_mcp_post(State(state), HeaderMap::new(), None, body)
-        .await
-        .into_response();
-    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("body");
-    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+    let json: serde_json::Value = post_in_session(state, body).await;
 
     assert_eq!(json["error"]["code"], -32601, "response: {json}");
 }

--- a/crates/mcpkit-axum/tests/logging_setlevel.rs
+++ b/crates/mcpkit-axum/tests/logging_setlevel.rs
@@ -72,6 +72,36 @@ impl PromptHandler for H {
     }
 }
 
+/// Initialize a session, then POST `body` within it, returning the parsed
+/// response (required since #153 PR 0b: only `initialize` may omit
+/// `mcp-session-id`).
+async fn post_in_session(state: McpState<H>, body: String) -> serde_json::Value {
+    use axum::http::HeaderValue;
+    let init = serde_json::json!({
+        "jsonrpc": "2.0", "id": 0, "method": "initialize",
+        "params": { "protocolVersion": "2025-11-25", "capabilities": {} }
+    })
+    .to_string();
+    let response = mcpkit_axum::handle_mcp_post(State(state.clone()), HeaderMap::new(), None, init)
+        .await
+        .into_response();
+    let sid = response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("initialize must assign a session id");
+    let mut headers = HeaderMap::new();
+    headers.insert("mcp-session-id", HeaderValue::from_str(&sid).expect("sid"));
+    let response = mcpkit_axum::handle_mcp_post(State(state), headers, None, body)
+        .await
+        .into_response();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    serde_json::from_slice(&bytes).expect("json")
+}
+
 #[tokio::test]
 async fn logging_set_level_works_through_axum_adapter() {
     let seen = Arc::new(Mutex::new(None));
@@ -84,13 +114,7 @@ async fn logging_set_level_works_through_axum_adapter() {
     })
     .to_string();
 
-    let response = mcpkit_axum::handle_mcp_post(State(state), HeaderMap::new(), None, body)
-        .await
-        .into_response();
-    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .expect("body");
-    let json: serde_json::Value = serde_json::from_slice(&bytes).expect("json");
+    let json: serde_json::Value = post_in_session(state, body).await;
 
     assert_eq!(json["result"], serde_json::json!({}), "response: {json}");
     assert_eq!(*seen.lock().unwrap(), Some(LoggingLevel::Warning));

--- a/crates/mcpkit-axum/tests/tasks.rs
+++ b/crates/mcpkit-axum/tests/tasks.rs
@@ -118,6 +118,21 @@ async fn post(
     (json, sid)
 }
 
+/// POST `initialize` and return the session id the server assigned
+/// (required since #153 PR 0b: only `initialize` may omit `mcp-session-id`).
+async fn init_session(state: &McpState<H>) -> String {
+    let (_, sid) = post(
+        state,
+        None,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": { "protocolVersion": "2025-11-25", "capabilities": {} }
+        }),
+    )
+    .await;
+    sid.expect("initialize must assign a session id")
+}
+
 fn call_task(id: u64, name: &str) -> serde_json::Value {
     serde_json::json!({
         "jsonrpc": "2.0", "id": id, "method": "tools/call",
@@ -137,8 +152,8 @@ async fn task_augmented_call_creates_gets_and_results() {
     let (state, _) = state();
 
     // Augmented tools/call returns CreateTaskResult (status "working") immediately.
-    let (resp, sid) = post(&state, None, call_task(1, "echo")).await;
-    let sid = sid.expect("session id");
+    let sid = init_session(&state).await;
+    let (resp, _) = post(&state, Some(&sid), call_task(1, "echo")).await;
     assert!(resp["error"].is_null(), "augmented call errored: {resp}");
     assert_eq!(resp["result"]["task"]["status"], "working");
     let task_id = resp["result"]["task"]["taskId"]
@@ -176,7 +191,8 @@ async fn with_task_ttl_configures_session_store_retention() {
     })
     .with_task_ttl(Some(1234));
 
-    let (resp, _) = post(&state, None, call_task(1, "echo")).await;
+    let sid = init_session(&state).await;
+    let (resp, _) = post(&state, Some(&sid), call_task(1, "echo")).await;
     assert_eq!(
         resp["result"]["task"]["ttl"], 1234,
         "configured task ttl not materialized: {resp}"
@@ -186,7 +202,8 @@ async fn with_task_ttl_configures_session_store_retention() {
 #[tokio::test]
 async fn task_augmented_call_on_forbidden_tool_is_rejected() {
     let (state, _) = state();
-    let (resp, _) = post(&state, None, call_task(1, "plain")).await;
+    let sid = init_session(&state).await;
+    let (resp, _) = post(&state, Some(&sid), call_task(1, "plain")).await;
     // A tool without taskSupport must be rejected, not run as a task.
     // Spec: -32601 (Method not found), not -32602.
     assert_eq!(
@@ -201,8 +218,8 @@ async fn tasks_cancel_trips_ctx_cancelled() {
     let (state, observed) = state();
 
     // Start a task whose tool parks on ctx.cancelled().
-    let (resp, sid) = post(&state, None, call_task(1, "waiter")).await;
-    let sid = sid.expect("session id");
+    let sid = init_session(&state).await;
+    let (resp, _) = post(&state, Some(&sid), call_task(1, "waiter")).await;
     let task_id = resp["result"]["task"]["taskId"]
         .as_str()
         .expect("taskId")
@@ -236,16 +253,16 @@ async fn tasks_are_isolated_per_session() {
     let (state, _) = state();
 
     // Session A creates a task.
-    let (resp, sid_a) = post(&state, None, call_task(1, "echo")).await;
-    let sid_a = sid_a.expect("session A id");
+    let sid_a = init_session(&state).await;
+    let (resp, _) = post(&state, Some(&sid_a), call_task(1, "echo")).await;
     let task_id = resp["result"]["task"]["taskId"]
         .as_str()
         .expect("taskId")
         .to_string();
 
     // Session B is a distinct session (no session header -> new session).
-    let (_probe, sid_b) = post(&state, None, call_task(2, "echo")).await;
-    let sid_b = sid_b.expect("session B id");
+    let sid_b = init_session(&state).await;
+    let (_probe, _) = post(&state, Some(&sid_b), call_task(2, "echo")).await;
     assert_ne!(sid_a, sid_b, "expected two distinct sessions");
 
     // Session B must not be able to read session A's task.
@@ -266,13 +283,35 @@ async fn tasks_are_isolated_per_session() {
 async fn response_post_is_accepted_with_202() {
     use axum::response::IntoResponse;
     let (state, _) = state();
+    let sid = init_session(&state).await;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "mcp-session-id",
+        HeaderValue::from_str(&sid).expect("session header"),
+    );
     let response = mcpkit_axum::handle_mcp_post(
         State(state),
-        HeaderMap::new(),
+        headers,
         None,
         r#"{"jsonrpc":"2.0","id":42,"result":{"roots":[]}}"#.to_string(),
     )
     .await
     .into_response();
     assert_eq!(response.status(), axum::http::StatusCode::ACCEPTED);
+}
+
+/// #153 PR 0b: a non-initialize message without `mcp-session-id` is 400.
+#[tokio::test]
+async fn missing_session_id_on_non_initialize_is_400() {
+    use axum::response::IntoResponse;
+    let (state, _) = state();
+    let response = mcpkit_axum::handle_mcp_post(
+        State(state),
+        HeaderMap::new(),
+        None,
+        call_task(1, "echo").to_string(),
+    )
+    .await
+    .into_response();
+    assert_eq!(response.status(), axum::http::StatusCode::BAD_REQUEST);
 }

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -21,6 +21,12 @@ use std::io::Cursor;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
+/// Whether this message is an `initialize` request — the only message allowed
+/// to omit `mcp-session-id` (the server assigns the id in its response).
+fn is_initialize(msg: &Message) -> bool {
+    matches!(msg, Message::Request(r) if r.method.as_ref() == "initialize")
+}
+
 /// MCP protocol version header.
 pub struct ProtocolVersionHeader(pub Option<String>);
 
@@ -235,6 +241,16 @@ where
         );
     }
 
+    // Parse the message first: whether a missing session id is acceptable
+    // depends on whether this is an `initialize` request.
+    let msg: Message = match serde_json::from_str(body) {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(error = %e, "Failed to parse JSON-RPC message");
+            return McpResponse::error(Status::BadRequest, format!("Invalid message: {e}"));
+        }
+    };
+
     // Get or create session (binding it to the verified user, if any).
     let session_id = match session_id {
         Some(id) => match state.sessions.touch_verified(&id, user.as_ref()) {
@@ -249,19 +265,19 @@ where
                 return McpResponse::error(Status::Forbidden, e.to_string());
             }
         },
-        None => state.sessions.create_for_user(user),
+        // Spec: a server assigning session ids does so at initialization;
+        // other requests without `mcp-session-id` are 400 Bad Request.
+        None if is_initialize(&msg) => state.sessions.create_for_user(user),
+        None => {
+            warn!("Rejected: missing mcp-session-id on non-initialize message");
+            return McpResponse::error(
+                Status::BadRequest,
+                "missing mcp-session-id (required for all messages after initialize)".to_string(),
+            );
+        }
     };
 
     debug!(session_id = %session_id, "Processing MCP request");
-
-    // Parse message
-    let msg: Message = match serde_json::from_str(body) {
-        Ok(m) => m,
-        Err(e) => {
-            warn!(error = %e, "Failed to parse JSON-RPC message");
-            return McpResponse::error(Status::BadRequest, format!("Invalid message: {e}"));
-        }
-    };
 
     // Process message
     match msg {

--- a/crates/mcpkit-rocket/tests/integration.rs
+++ b/crates/mcpkit-rocket/tests/integration.rs
@@ -121,14 +121,32 @@ fn create_test_client() -> Client {
     Client::tracked(rocket).expect("valid rocket instance")
 }
 
+/// POST `initialize` and return the assigned session id (required since
+/// #153 PR 0b: only `initialize` may omit `mcp-session-id`).
+fn init_session(client: &Client) -> String {
+    let response = client
+        .post("/mcp")
+        .header(ContentType::JSON)
+        .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .body(r#"{"jsonrpc":"2.0","method":"initialize","params":{},"id":0}"#)
+        .dispatch();
+    response
+        .headers()
+        .get_one("mcp-session-id")
+        .map(String::from)
+        .expect("initialize must assign a session id")
+}
+
 #[test]
 fn test_ping_request() {
     let client = create_test_client();
+    let sid = init_session(&client);
 
     let response = client
         .post("/mcp")
         .header(ContentType::JSON)
         .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .header(Header::new("mcp-session-id", sid))
         .body(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
         .dispatch();
 
@@ -173,19 +191,9 @@ fn test_unsupported_protocol_version() {
 fn test_session_persistence() {
     let client = create_test_client();
 
-    // First request - get a session
-    let response1 = client
-        .post("/mcp")
-        .header(ContentType::JSON)
-        .header(Header::new("mcp-protocol-version", "2025-11-25"))
-        .body(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
-        .dispatch();
-
-    let session_id = response1
-        .headers()
-        .get_one("mcp-session-id")
-        .unwrap()
-        .to_string();
+    // First request: initialize assigns the session (#153 PR 0b: only
+    // initialize may omit mcp-session-id).
+    let session_id = init_session(&client);
 
     // Second request - reuse session
     let response2 = client
@@ -206,11 +214,13 @@ fn test_session_persistence() {
 #[test]
 fn test_list_tools() {
     let client = create_test_client();
+    let sid = init_session(&client);
 
     let response = client
         .post("/mcp")
         .header(ContentType::JSON)
         .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .header(Header::new("mcp-session-id", sid))
         .body(r#"{"jsonrpc":"2.0","method":"tools/list","id":1}"#)
         .dispatch();
 
@@ -224,11 +234,13 @@ fn test_list_tools() {
 #[test]
 fn test_call_tool() {
     let client = create_test_client();
+    let sid = init_session(&client);
 
     let response = client
         .post("/mcp")
         .header(ContentType::JSON)
         .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .header(Header::new("mcp-session-id", sid))
         .body(
             r#"{"jsonrpc":"2.0","method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}},"id":1}"#,
         )
@@ -243,11 +255,13 @@ fn test_call_tool() {
 #[test]
 fn test_notification() {
     let client = create_test_client();
+    let sid = init_session(&client);
 
     let response = client
         .post("/mcp")
         .header(ContentType::JSON)
         .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .header(Header::new("mcp-session-id", sid))
         .body(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
         .dispatch();
 
@@ -271,11 +285,13 @@ fn test_invalid_json() {
 #[test]
 fn test_method_not_found() {
     let client = create_test_client();
+    let sid = init_session(&client);
 
     let response = client
         .post("/mcp")
         .header(ContentType::JSON)
         .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .header(Header::new("mcp-session-id", sid))
         .body(r#"{"jsonrpc":"2.0","method":"unknown/method","id":1}"#)
         .dispatch();
 
@@ -294,12 +310,14 @@ fn test_cors_headers() {
         .mount("/", rocket::routes![mcp_post, mcp_sse])
         .attach(Cors);
     let client = Client::tracked(rocket).expect("valid rocket instance");
+    let sid = init_session(&client);
 
     // Make a normal request and check CORS headers are present
     let response = client
         .post("/mcp")
         .header(ContentType::JSON)
         .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .header(Header::new("mcp-session-id", sid))
         .header(Header::new("Origin", "http://localhost:3000"))
         .body(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
         .dispatch();
@@ -318,13 +336,30 @@ fn test_cors_headers() {
 #[test]
 fn response_post_is_accepted_with_202() {
     let client = create_test_client();
+    let sid = init_session(&client);
 
     let response = client
         .post("/mcp")
         .header(ContentType::JSON)
         .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .header(Header::new("mcp-session-id", sid))
         .body(r#"{"jsonrpc":"2.0","id":42,"result":{"roots":[]}}"#)
         .dispatch();
 
     assert_eq!(response.status(), Status::Accepted);
+}
+
+/// #153 PR 0b: a non-initialize message without `mcp-session-id` is 400.
+#[test]
+fn missing_session_id_on_non_initialize_is_400() {
+    let client = create_test_client();
+
+    let response = client
+        .post("/mcp")
+        .header(ContentType::JSON)
+        .header(Header::new("mcp-protocol-version", "2025-11-25"))
+        .body(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
+        .dispatch();
+
+    assert_eq!(response.status(), Status::BadRequest);
 }

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -19,8 +19,27 @@ use std::sync::Arc;
 use tokio_stream::wrappers::BroadcastStream;
 use tracing::{debug, info, warn};
 use warp::Filter;
+use warp::Reply as _;
 use warp::http::StatusCode;
 use warp::sse::Event;
+
+/// Whether this message is an `initialize` request — the only message allowed
+/// to omit `mcp-session-id` (the server assigns the id in its response).
+fn is_initialize(msg: &Message) -> bool {
+    matches!(msg, Message::Request(r) if r.method.as_ref() == "initialize")
+}
+
+/// Attach the session id header to a reply (spec: the server communicates the
+/// assigned session id via `mcp-session-id`; warp previously never returned
+/// it on POST responses, leaving clients unable to satisfy the session-id
+/// requirement).
+fn reply_with_session(reply: impl warp::Reply, session_id: &str) -> warp::reply::Response {
+    let mut resp = reply.into_response();
+    if let Ok(v) = warp::http::HeaderValue::from_str(session_id) {
+        resp.headers_mut().insert("mcp-session-id", v);
+    }
+    resp
+}
 
 /// Handle MCP POST requests.
 ///
@@ -32,7 +51,7 @@ pub async fn handle_mcp_post<H>(
     origin: Option<String>,
     user: Option<VerifiedUser>,
     body: String,
-) -> Result<impl warp::Reply, Infallible>
+) -> Result<warp::reply::Response, Infallible>
 where
     H: ServerHandler
         + ToolHandler
@@ -52,10 +71,10 @@ where
         let error_body = serde_json::json!({
             "error": { "code": -32600, "message": "origin not allowed" }
         });
-        return Ok(warp::reply::with_status(
-            warp::reply::json(&error_body),
-            StatusCode::FORBIDDEN,
-        ));
+        return Ok(
+            warp::reply::with_status(warp::reply::json(&error_body), StatusCode::FORBIDDEN)
+                .into_response(),
+        );
     }
 
     // Validate protocol version
@@ -75,40 +94,13 @@ where
         return Ok(warp::reply::with_status(
             warp::reply::json(&error_body),
             StatusCode::BAD_REQUEST,
-        ));
+        )
+        .into_response());
     }
 
     // Get or create session (binding it to the verified user, if any).
-    let session_id = match session_id {
-        Some(id) => match state.sessions.touch_verified(&id, user.as_ref()) {
-            Ok(true) => id,
-            Ok(false) => {
-                warn!(session_id = %id, "Rejected: unknown session id");
-                let error_body = serde_json::json!({
-                    "error": { "code": -32600, "message": "unknown session id" }
-                });
-                return Ok(warp::reply::with_status(
-                    warp::reply::json(&error_body),
-                    StatusCode::NOT_FOUND,
-                ));
-            }
-            Err(e) => {
-                warn!(session_id = %id, error = %e, "Rejected: session binding violation");
-                let error_body = serde_json::json!({
-                    "error": { "code": -32600, "message": e.to_string() }
-                });
-                return Ok(warp::reply::with_status(
-                    warp::reply::json(&error_body),
-                    StatusCode::FORBIDDEN,
-                ));
-            }
-        },
-        None => state.sessions.create_for_user(user),
-    };
-
-    debug!(session_id = %session_id, "Processing MCP request");
-
-    // Parse message
+    // Parse the message first: whether a missing session id is acceptable
+    // depends on whether this is an `initialize` request.
     let msg: Message = match serde_json::from_str(&body) {
         Ok(m) => m,
         Err(e) => {
@@ -122,9 +114,57 @@ where
             return Ok(warp::reply::with_status(
                 warp::reply::json(&error_body),
                 StatusCode::BAD_REQUEST,
-            ));
+            )
+            .into_response());
         }
     };
+
+    let session_id = match session_id {
+        Some(id) => match state.sessions.touch_verified(&id, user.as_ref()) {
+            Ok(true) => id,
+            Ok(false) => {
+                warn!(session_id = %id, "Rejected: unknown session id");
+                let error_body = serde_json::json!({
+                    "error": { "code": -32600, "message": "unknown session id" }
+                });
+                return Ok(warp::reply::with_status(
+                    warp::reply::json(&error_body),
+                    StatusCode::NOT_FOUND,
+                )
+                .into_response());
+            }
+            Err(e) => {
+                warn!(session_id = %id, error = %e, "Rejected: session binding violation");
+                let error_body = serde_json::json!({
+                    "error": { "code": -32600, "message": e.to_string() }
+                });
+                return Ok(warp::reply::with_status(
+                    warp::reply::json(&error_body),
+                    StatusCode::FORBIDDEN,
+                )
+                .into_response());
+            }
+        },
+        // Spec: a server assigning session ids does so at initialization;
+        // other requests without `mcp-session-id` are 400 Bad Request.
+        None if is_initialize(&msg) => state.sessions.create_for_user(user),
+        None => {
+            warn!("Rejected: missing mcp-session-id on non-initialize message");
+            let error_body = serde_json::json!({
+                "error": {
+                    "code": -32600,
+                    "message": "missing mcp-session-id (required for all messages after initialize)"
+                }
+            });
+            return Ok(warp::reply::with_status(
+                warp::reply::json(&error_body),
+                StatusCode::BAD_REQUEST,
+            )
+            .into_response());
+        }
+    };
+
+    debug!(session_id = %session_id, "Processing MCP request");
 
     // Process message
     match msg {
@@ -164,9 +204,9 @@ where
             .await;
 
             match serde_json::to_value(Message::Response(response)) {
-                Ok(body) => Ok(warp::reply::with_status(
-                    warp::reply::json(&body),
-                    StatusCode::OK,
+                Ok(body) => Ok(reply_with_session(
+                    warp::reply::with_status(warp::reply::json(&body), StatusCode::OK),
+                    &session_id,
                 )),
                 Err(e) => {
                     let error_body = serde_json::json!({
@@ -175,9 +215,12 @@ where
                             "message": format!("Internal error: {e}")
                         }
                     });
-                    Ok(warp::reply::with_status(
-                        warp::reply::json(&error_body),
-                        StatusCode::INTERNAL_SERVER_ERROR,
+                    Ok(reply_with_session(
+                        warp::reply::with_status(
+                            warp::reply::json(&error_body),
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                        ),
+                        &session_id,
                     ))
                 }
             }
@@ -188,9 +231,12 @@ where
                 session_id = %session_id,
                 "Received notification"
             );
-            Ok(warp::reply::with_status(
-                warp::reply::json(&serde_json::json!({})),
-                StatusCode::ACCEPTED,
+            Ok(reply_with_session(
+                warp::reply::with_status(
+                    warp::reply::json(&serde_json::json!({})),
+                    StatusCode::ACCEPTED,
+                ),
+                &session_id,
             ))
         }
         // Spec (Streamable HTTP): a client delivers responses to
@@ -206,9 +252,12 @@ where
                 session_id = %session_id,
                 "Received client response (no pending server-initiated request; dropped)"
             );
-            Ok(warp::reply::with_status(
-                warp::reply::json(&serde_json::json!({})),
-                StatusCode::ACCEPTED,
+            Ok(reply_with_session(
+                warp::reply::with_status(
+                    warp::reply::json(&serde_json::json!({})),
+                    StatusCode::ACCEPTED,
+                ),
+                &session_id,
             ))
         }
     }

--- a/crates/mcpkit-warp/tests/integration.rs
+++ b/crates/mcpkit-warp/tests/integration.rs
@@ -107,15 +107,39 @@ impl PromptHandler for TestHandler {
     }
 }
 
+/// POST `initialize` against a filter and yield the assigned session id
+/// (required since #153 PR 0b: only `initialize` may omit `mcp-session-id`).
+/// A macro rather than a fn: `warp::test`'s filter bounds are unnameable.
+macro_rules! init_session {
+    ($filter:expr) => {{
+        let response = warp::test::request()
+            .method("POST")
+            .path("/mcp")
+            .header("content-type", "application/json")
+            .header("mcp-protocol-version", "2025-11-25")
+            .body(r#"{"jsonrpc":"2.0","method":"initialize","params":{},"id":0}"#)
+            .reply($filter)
+            .await;
+        response
+            .headers()
+            .get("mcp-session-id")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from)
+            .expect("initialize must assign a session id")
+    }};
+}
+
 #[tokio::test]
 async fn test_ping_request() {
     let filter = McpRouter::new(TestHandler).into_filter();
+    let sid = init_session!(&filter);
 
     let response = warp::test::request()
         .method("POST")
         .path("/mcp")
         .header("content-type", "application/json")
         .header("mcp-protocol-version", "2025-11-25")
+        .header("mcp-session-id", sid.as_str())
         .body(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
         .reply(&filter)
         .await;
@@ -163,12 +187,14 @@ async fn test_unsupported_protocol_version() {
 #[tokio::test]
 async fn test_list_tools() {
     let filter = McpRouter::new(TestHandler).into_filter();
+    let sid = init_session!(&filter);
 
     let response = warp::test::request()
         .method("POST")
         .path("/mcp")
         .header("content-type", "application/json")
         .header("mcp-protocol-version", "2025-11-25")
+        .header("mcp-session-id", sid.as_str())
         .body(r#"{"jsonrpc":"2.0","method":"tools/list","id":1}"#)
         .reply(&filter)
         .await;
@@ -183,12 +209,14 @@ async fn test_list_tools() {
 #[tokio::test]
 async fn test_call_tool() {
     let filter = McpRouter::new(TestHandler).into_filter();
+    let sid = init_session!(&filter);
 
     let response = warp::test::request()
         .method("POST")
         .path("/mcp")
         .header("content-type", "application/json")
         .header("mcp-protocol-version", "2025-11-25")
+        .header("mcp-session-id", sid.as_str())
         .body(
             r#"{"jsonrpc":"2.0","method":"tools/call","params":{"name":"echo","arguments":{"message":"hello"}},"id":1}"#,
         )
@@ -204,12 +232,14 @@ async fn test_call_tool() {
 #[tokio::test]
 async fn test_notification() {
     let filter = McpRouter::new(TestHandler).into_filter();
+    let sid = init_session!(&filter);
 
     let response = warp::test::request()
         .method("POST")
         .path("/mcp")
         .header("content-type", "application/json")
         .header("mcp-protocol-version", "2025-11-25")
+        .header("mcp-session-id", sid.as_str())
         .body(r#"{"jsonrpc":"2.0","method":"notifications/initialized"}"#)
         .reply(&filter)
         .await;
@@ -236,12 +266,14 @@ async fn test_invalid_json() {
 #[tokio::test]
 async fn test_method_not_found() {
     let filter = McpRouter::new(TestHandler).into_filter();
+    let sid = init_session!(&filter);
 
     let response = warp::test::request()
         .method("POST")
         .path("/mcp")
         .header("content-type", "application/json")
         .header("mcp-protocol-version", "2025-11-25")
+        .header("mcp-session-id", sid.as_str())
         .body(r#"{"jsonrpc":"2.0","method":"unknown/method","id":1}"#)
         .reply(&filter)
         .await;
@@ -256,12 +288,14 @@ async fn test_method_not_found() {
 #[tokio::test]
 async fn test_cors_headers() {
     let filter = McpRouter::new(TestHandler).into_filter();
+    let sid = init_session!(&filter);
 
     let response = warp::test::request()
         .method("POST")
         .path("/mcp")
         .header("content-type", "application/json")
         .header("mcp-protocol-version", "2025-11-25")
+        .header("mcp-session-id", sid.as_str())
         .header("origin", "http://localhost:3000")
         .body(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
         .reply(&filter)
@@ -299,12 +333,14 @@ async fn test_cors_preflight() {
 #[tokio::test]
 async fn test_without_cors() {
     let filter = McpRouter::new(TestHandler).into_filter_without_cors();
+    let sid = init_session!(&filter);
 
     let response = warp::test::request()
         .method("POST")
         .path("/mcp")
         .header("content-type", "application/json")
         .header("mcp-protocol-version", "2025-11-25")
+        .header("mcp-session-id", sid.as_str())
         .body(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
         .reply(&filter)
         .await;
@@ -324,15 +360,34 @@ async fn test_without_cors() {
 #[tokio::test]
 async fn response_post_is_accepted_with_202() {
     let filter = McpRouter::new(TestHandler).into_filter();
+    let sid = init_session!(&filter);
 
     let response = warp::test::request()
         .method("POST")
         .path("/mcp")
         .header("content-type", "application/json")
         .header("mcp-protocol-version", "2025-11-25")
+        .header("mcp-session-id", sid.as_str())
         .body(r#"{"jsonrpc":"2.0","id":42,"result":{"roots":[]}}"#)
         .reply(&filter)
         .await;
 
     assert_eq!(response.status(), 202);
+}
+
+/// #153 PR 0b: a non-initialize message without `mcp-session-id` is 400.
+#[tokio::test]
+async fn missing_session_id_on_non_initialize_is_400() {
+    let filter = McpRouter::new(TestHandler).into_filter();
+
+    let response = warp::test::request()
+        .method("POST")
+        .path("/mcp")
+        .header("content-type", "application/json")
+        .header("mcp-protocol-version", "2025-11-25")
+        .body(r#"{"jsonrpc":"2.0","method":"ping","id":1}"#)
+        .reply(&filter)
+        .await;
+
+    assert_eq!(response.status(), 400);
 }


### PR DESCRIPTION
PR 0b from the #153 design v3 (split from 0a per review round 2, N10, precisely because this half is **breaking**). Leave #153 open.

## What

Spec: session ids are assigned at initialization (`MCP-Session-Id` on the `InitializeResult` response) and *"clients using the Streamable HTTP transport MUST include it in the MCP-Session-Id header on all of their subsequent HTTP requests"*, with 400 as the prescribed response for non-initialize requests lacking one. The adapters instead **minted a fresh session for any session-id-less POST** and proceeded — one leaked uninitialized session per stray message (reaped 30s later), and lenient cover for clients that never echo the header.

Each adapter now parses the message *first* (whether a missing session id is acceptable depends on whether it's `initialize`), then: missing header + `initialize` → mint as before; missing header + anything else → 400. Shared one-line `is_initialize` gate per adapter.

**Breaking (behavior):** clients that ignore the returned `mcp-session-id` stop working. Spec-conforming clients are unaffected. `!` commit + CHANGELOG entry.

## The warp discovery

Bootstrapping the test suites surfaced a pre-existing defect this PR would otherwise have turned fatal: **warp never returned `mcp-session-id` on any POST response** (axum/actix/rocket did) — so a warp client could never learn the id it's now required to present. Warp's handler now returns a concrete `warp::reply::Response` with the session header attached on all post-session-resolution arms (initialize included). This belongs in 0b: strictness without id communication would brick the warp adapter.

## Tests

All four adapter suites now bootstrap via `initialize` and thread the assigned id (test-only change that doubles as a live demonstration of the migration path for lenient clients). New regression tests pin the 400 on all four adapters; rocket's `test_session_persistence` now derives its session from `initialize` rather than from a lenient `ping`.

Full local gate green: fmt, clippy `-D warnings` (1.97 local), rustdoc, 74 test suites.

Refs #153.