### PR TITLE
fix(axum)!: unify SSE and POST sessions; serve GET on the MCP endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (axum):** the axum adapter's SSE side now attaches to the same
+  session the POST side creates, fixing two standing spec/security defects
+  (#172, #173) as #153's PR 1 (axum-first; actix/warp/rocket follow in their
+  port PRs):
+  - The MCP endpoint now serves **GET** (spec MUST: one endpoint for POST and
+    GET). Previously SSE lived only at the separate, protocol-undiscoverable
+    `/mcp/sse` path, so a compliant client GETting the MCP endpoint got 405
+    and correctly concluded no stream existed. The old path remains as a
+    deprecated alias.
+  - `Session` now owns its SSE broadcast channel and event store; the
+    separate `SessionManager` registry (with its own id space) is **removed**
+    (`McpState.sse_sessions`, `SessionManager`, and
+    `McpState::with_sessions`' second parameter are gone). The SSE binding
+    check is now enforced against the same registry that holds the user
+    binding, so it can no longer pass vacuously: a GET without
+    `mcp-session-id` is 400, an unknown id is **404** (previously the adapter
+    silently minted a new SSE session under a different id — a
+    client-presented id is never adopted), and a mismatched user is 403
+    ([#172](https://github.com/praxiomlabs/mcpkit/issues/172),
+    [#173](https://github.com/praxiomlabs/mcpkit/issues/173)).
+
 - **Breaking (behavior):** the HTTP adapters now require `mcp-session-id` on
   every message except `initialize` — a non-initialize request, notification,
   or response without it gets `400 Bad Request` (spec: servers assigning

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -451,10 +451,26 @@ where
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
-    // Enforce the session's user binding before replaying any buffered events to
-    // a reconnecting client (a different user must not receive them).
-    if let Some(id) = &session_id {
-        if let Err(e) = state.sessions.get_verified(id, user.as_ref()) {
+    // #153 PR 1: streams attach to the POST-created session. A GET without a
+    // session id is 400 (sessions are assigned at initialize); an unknown id
+    // is 404 per spec (never adopt a client-presented id); a mismatched user
+    // is 403 — enforced against the SAME registry that holds the binding, so
+    // the check can no longer pass vacuously (#173).
+    let Some(id) = session_id else {
+        warn!("Rejected SSE: missing mcp-session-id");
+        return (
+            StatusCode::BAD_REQUEST,
+            "missing mcp-session-id (obtain one via initialize)",
+        )
+            .into_response();
+    };
+    match state.sessions.get_verified(&id, user.as_ref()) {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            warn!(session_id = %id, "Rejected SSE: unknown session id");
+            return (StatusCode::NOT_FOUND, "unknown session id").into_response();
+        }
+        Err(e) => {
             warn!(session_id = %id, error = %e, "Rejected SSE: session binding violation");
             return (StatusCode::FORBIDDEN, e.to_string()).into_response();
         }
@@ -465,40 +481,22 @@ where
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
-    let (id, rx, replay_events) = if let Some(id) = session_id {
-        // Try to reconnect to existing session
-        if let Some(rx) = state.sse_sessions.get_receiver(&id) {
-            // Check if we need to replay events
-            let replay = if let Some(last_id) = &last_event_id {
-                info!(session_id = %id, last_event_id = %last_id, "Reconnecting with Last-Event-ID");
-                state
-                    .sse_sessions
-                    .get_events_for_replay(&id, last_id)
-                    .await
-                    .unwrap_or_default()
-            } else {
-                Vec::new()
-            };
-
-            info!(
-                session_id = %id,
-                replay_count = replay.len(),
-                "Reconnected to SSE session"
-            );
-            (id, rx, replay)
-        } else {
-            // Session not found, create new
-            let (new_id, rx) = state.sse_sessions.create_session();
-            info!(session_id = %new_id, "Created new SSE session (requested not found)");
-            (new_id, rx, Vec::new())
-        }
+    let rx = state
+        .sessions
+        .subscribe(&id)
+        .expect("session verified above");
+    let replay_events = if let Some(last_id) = &last_event_id {
+        info!(session_id = %id, last_event_id = %last_id, "Reconnecting with Last-Event-ID");
+        state
+            .sessions
+            .events_for_replay(&id, last_id)
+            .await
+            .unwrap_or_default()
     } else {
-        let (id, rx) = state.sse_sessions.create_session();
-        info!(session_id = %id, "Created new SSE session");
-        (id, rx, Vec::new())
+        Vec::new()
     };
+    let event_store = state.sessions.events(&id);
 
-    let event_store = state.sse_sessions.get_event_store(&id);
     let stream = create_sse_stream_with_replay(id, rx, replay_events, event_store);
     Sse::new(stream)
         .keep_alive(KeepAlive::default())

--- a/crates/mcpkit-axum/src/lib.rs
+++ b/crates/mcpkit-axum/src/lib.rs
@@ -103,8 +103,7 @@ pub use error::ExtensionError;
 pub use handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
 pub use router::McpRouter;
 pub use session::{
-    DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionManager, SessionStore,
-    StoredEvent,
+    DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionStore, StoredEvent,
 };
 pub use state::{McpState, OAuthState};
 
@@ -120,8 +119,7 @@ pub mod prelude {
     pub use crate::handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
     pub use crate::router::McpRouter;
     pub use crate::session::{
-        DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionManager, SessionStore,
-        StoredEvent,
+        DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionStore, StoredEvent,
     };
     pub use crate::state::{McpState, OAuthState};
 }

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -191,8 +191,13 @@ where
 
     /// Build the router.
     pub fn into_router(self) -> Router {
+        // Spec: a single MCP endpoint serves both POST and GET (#172). The
+        // separate SSE path is kept as a deprecated, undiscoverable alias.
         let mut router = Router::new()
-            .route(&self.post_path, post(handle_mcp_post::<H>))
+            .route(
+                &self.post_path,
+                post(handle_mcp_post::<H>).get(handle_sse::<H>),
+            )
             .route(&self.sse_path, get(handle_sse::<H>))
             .with_state(self.state);
 

--- a/crates/mcpkit-axum/src/session.rs
+++ b/crates/mcpkit-axum/src/session.rs
@@ -33,6 +33,12 @@ pub struct Session {
     /// session so one session cannot read or cancel another's tasks (matching
     /// the stdio runtime's per-connection store).
     pub tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
+    /// Sender for this session's SSE stream(s). Owned by the session (#153
+    /// PR 1): streams attach to the POST-created session rather than a
+    /// separate SSE registry with its own id space.
+    pub tx: broadcast::Sender<String>,
+    /// Stored events for SSE resumability (`Last-Event-ID` replay).
+    pub events: Arc<EventStore>,
 }
 
 impl Session {
@@ -46,6 +52,7 @@ impl Session {
     #[must_use]
     pub fn with_user(id: String, user: Option<VerifiedUser>) -> Self {
         let now = Instant::now();
+        let (tx, _rx) = broadcast::channel(100);
         Self {
             id,
             created_at: now,
@@ -55,6 +62,8 @@ impl Session {
             protocol_version: None,
             user,
             tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
+            tx,
+            events: Arc::new(EventStore::new(EventStoreConfig::default())),
         }
     }
 
@@ -335,178 +344,6 @@ impl EventStore {
     }
 }
 
-/// Session manager for SSE connections.
-///
-/// Manages broadcast channels for pushing messages to SSE clients,
-/// with optional event storage for message resumability.
-#[derive(Debug)]
-pub struct SessionManager {
-    sessions: DashMap<String, broadcast::Sender<String>>,
-    /// Event stores for each session (for SSE resumability).
-    event_stores: DashMap<String, Arc<EventStore>>,
-    /// Configuration for event stores.
-    event_store_config: EventStoreConfig,
-}
-
-impl Default for SessionManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SessionManager {
-    /// Create a new session manager.
-    #[must_use]
-    pub fn new() -> Self {
-        Self {
-            sessions: DashMap::new(),
-            event_stores: DashMap::new(),
-            event_store_config: EventStoreConfig::default(),
-        }
-    }
-
-    /// Create a new session manager with custom event store configuration.
-    #[must_use]
-    pub fn with_event_store_config(config: EventStoreConfig) -> Self {
-        Self {
-            sessions: DashMap::new(),
-            event_stores: DashMap::new(),
-            event_store_config: config,
-        }
-    }
-
-    /// Create a new session and return its ID and receiver.
-    #[must_use]
-    pub fn create_session(&self) -> (String, broadcast::Receiver<String>) {
-        let id = uuid::Uuid::new_v4().to_string();
-        let (tx, rx) = broadcast::channel(100);
-        self.sessions.insert(id.clone(), tx);
-
-        // Create an event store for this session
-        let event_store = Arc::new(EventStore::new(self.event_store_config.clone()));
-        self.event_stores.insert(id.clone(), event_store);
-
-        (id, rx)
-    }
-
-    /// Get a receiver for an existing session.
-    #[must_use]
-    pub fn get_receiver(&self, id: &str) -> Option<broadcast::Receiver<String>> {
-        self.sessions.get(id).map(|tx| tx.subscribe())
-    }
-
-    /// Get the event store for a session.
-    #[must_use]
-    pub fn get_event_store(&self, id: &str) -> Option<Arc<EventStore>> {
-        self.event_stores.get(id).map(|store| Arc::clone(&store))
-    }
-
-    /// Send a message to a specific session.
-    ///
-    /// Returns `true` if the message was sent, `false` if the session doesn't exist.
-    #[must_use]
-    pub fn send_to_session(&self, id: &str, message: String) -> bool {
-        if let Some(tx) = self.sessions.get(id) {
-            // Ignore send errors (no receivers)
-            let _ = tx.send(message);
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Send a message to a specific session and store it for replay.
-    ///
-    /// This method stores the event in the event store before sending,
-    /// enabling message resumability for clients that reconnect.
-    ///
-    /// Returns the event ID if the message was sent and stored, `None` if the session doesn't exist.
-    #[must_use]
-    pub fn send_to_session_with_storage(
-        &self,
-        session_id: &str,
-        event_type: impl Into<String>,
-        message: String,
-    ) -> Option<String> {
-        if let Some(tx) = self.sessions.get(session_id) {
-            // Store the event first
-            let event_id = if let Some(store) = self.event_stores.get(session_id) {
-                store.store_auto_id(event_type, message.clone())
-            } else {
-                // Create a store if it doesn't exist (shouldn't happen normally)
-                let store = Arc::new(EventStore::new(self.event_store_config.clone()));
-                let event_id = store.store_auto_id(event_type, message.clone());
-                self.event_stores.insert(session_id.to_string(), store);
-                event_id
-            };
-
-            // Send the message
-            let _ = tx.send(message);
-            Some(event_id)
-        } else {
-            None
-        }
-    }
-
-    /// Broadcast a message to all sessions.
-    pub fn broadcast(&self, message: String) {
-        for entry in &self.sessions {
-            let _ = entry.value().send(message.clone());
-        }
-    }
-
-    /// Broadcast a message to all sessions with storage.
-    ///
-    /// Stores the event in each session's event store for resumability.
-    pub fn broadcast_with_storage(&self, event_type: impl Into<String> + Clone, message: String) {
-        for entry in &self.sessions {
-            let session_id = entry.key();
-
-            // Store in event store
-            if let Some(store) = self.event_stores.get(session_id) {
-                store.store_auto_id(event_type.clone(), message.clone());
-            }
-
-            // Send
-            let _ = entry.value().send(message.clone());
-        }
-    }
-
-    /// Remove a session.
-    pub fn remove_session(&self, id: &str) {
-        self.sessions.remove(id);
-        self.event_stores.remove(id);
-    }
-
-    /// Get the number of active sessions.
-    #[must_use]
-    pub fn session_count(&self) -> usize {
-        self.sessions.len()
-    }
-
-    /// Clean up expired events across all sessions.
-    pub async fn cleanup_expired_events(&self) {
-        for entry in &self.event_stores {
-            entry.value().cleanup_expired().await;
-        }
-    }
-
-    /// Get events after the specified event ID for replay.
-    ///
-    /// Used when a client reconnects with `Last-Event-ID`.
-    pub async fn get_events_for_replay(
-        &self,
-        session_id: &str,
-        last_event_id: &str,
-    ) -> Option<Vec<StoredEvent>> {
-        if let Some(store) = self.event_stores.get(session_id) {
-            Some(store.get_events_after(last_event_id).await)
-        } else {
-            None
-        }
-    }
-}
-
 /// Default timeout after which a session created but never initialized is
 /// reaped.
 pub const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -522,6 +359,8 @@ pub struct SessionStore {
     /// Default task retention (ms) applied to each session's task store; `None`
     /// means unlimited. Configure via `McpRouter::with_task_ttl`.
     pub(crate) default_task_ttl: Option<u64>,
+    /// Event-store configuration applied to each session's SSE event buffer.
+    event_store_config: EventStoreConfig,
 }
 
 impl SessionStore {
@@ -536,6 +375,7 @@ impl SessionStore {
             timeout,
             init_timeout: DEFAULT_INIT_TIMEOUT,
             default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
+            event_store_config: EventStoreConfig::default(),
         }
     }
 
@@ -551,6 +391,55 @@ impl SessionStore {
     pub const fn with_init_timeout(mut self, init_timeout: Duration) -> Self {
         self.init_timeout = init_timeout;
         self
+    }
+
+    /// Set the event-store configuration applied to each new session's SSE
+    /// event buffer.
+    #[must_use]
+    pub fn with_event_store_config(mut self, config: EventStoreConfig) -> Self {
+        self.event_store_config = config;
+        self
+    }
+
+    /// Subscribe to a session's SSE stream. `None` if the session is unknown.
+    #[must_use]
+    pub fn subscribe(&self, id: &str) -> Option<broadcast::Receiver<String>> {
+        self.sessions.get(id).map(|s| s.tx.subscribe())
+    }
+
+    /// The event store backing a session's SSE resumability. `None` if the
+    /// session is unknown.
+    #[must_use]
+    pub fn events(&self, id: &str) -> Option<Arc<EventStore>> {
+        self.sessions.get(id).map(|s| Arc::clone(&s.events))
+    }
+
+    /// Store `message` for resumability and send it on the session's SSE
+    /// stream, returning the stored event id. `None` if the session is
+    /// unknown.
+    #[must_use]
+    pub fn send_with_storage(
+        &self,
+        id: &str,
+        event_type: impl Into<String>,
+        message: String,
+    ) -> Option<String> {
+        let session = self.sessions.get(id)?;
+        let event_id = session.events.store_auto_id(event_type, message.clone());
+        // Ignore send errors (no receivers): the event is stored for replay.
+        let _ = session.tx.send(message);
+        Some(event_id)
+    }
+
+    /// Get events after `last_event_id` for `Last-Event-ID` replay. `None` if
+    /// the session is unknown.
+    pub async fn events_for_replay(
+        &self,
+        id: &str,
+        last_event_id: &str,
+    ) -> Option<Vec<StoredEvent>> {
+        let store = self.events(id)?;
+        Some(store.get_events_after(last_event_id).await)
     }
 
     /// Create a new session and return its ID.
@@ -574,6 +463,7 @@ impl SessionStore {
         session.tasks = Arc::new(
             mcpkit_server::capability::tasks::TaskManager::with_default_ttl(self.default_task_ttl),
         );
+        session.events = Arc::new(EventStore::new(self.event_store_config.clone()));
         self.sessions.insert(id.clone(), session);
         id
     }
@@ -790,20 +680,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_session_manager() -> Result<(), Box<dyn std::error::Error>> {
-        let manager = SessionManager::new();
-        let (id, mut rx) = manager.create_session();
+    async fn session_stream_send_and_receive() -> Result<(), Box<dyn std::error::Error>> {
+        let store = SessionStore::with_default_timeout();
+        let id = store.create();
+        let mut rx = store.subscribe(&id).ok_or("session missing")?;
 
-        // Send a message
-        assert!(manager.send_to_session(&id, "test message".to_string()));
+        // Send a message (stored + broadcast).
+        assert!(
+            store
+                .send_with_storage(&id, "message", "test message".to_string())
+                .is_some()
+        );
 
-        // Receive the message
         let msg = rx.recv().await?;
         assert_eq!(msg, "test message");
 
-        // Remove session
-        manager.remove_session(&id);
-        assert!(!manager.send_to_session(&id, "another".to_string()));
+        // Unknown session: no subscription, no send.
+        assert!(store.subscribe("nope").is_none());
+        assert!(
+            store
+                .send_with_storage("nope", "message", "x".to_string())
+                .is_none()
+        );
         Ok(())
     }
 
@@ -908,62 +806,50 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_session_manager_with_event_store() -> Result<(), Box<dyn std::error::Error>> {
-        let manager = SessionManager::new();
-        let (id, _rx) = manager.create_session();
+    async fn session_has_event_store() -> Result<(), Box<dyn std::error::Error>> {
+        let store = SessionStore::with_default_timeout();
+        let id = store.create();
 
-        // Event store should be created automatically
-        let store = manager.get_event_store(&id);
-        assert!(store.is_some());
-
-        let store = store.ok_or("Event store not found")?;
-        assert!(store.is_empty().await);
+        // Event store is created with the session.
+        let events = store.events(&id);
+        assert!(events.is_some());
+        assert!(events.ok_or("Event store not found")?.is_empty().await);
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_session_manager_send_with_storage() -> Result<(), Box<dyn std::error::Error>> {
-        let manager = SessionManager::new();
-        let (id, mut rx) = manager.create_session();
+    async fn session_send_with_storage_stores_event() -> Result<(), Box<dyn std::error::Error>> {
+        let store = SessionStore::with_default_timeout();
+        let id = store.create();
+        let mut rx = store.subscribe(&id).ok_or("session missing")?;
 
-        // Send with storage
-        let event_id =
-            manager.send_to_session_with_storage(&id, "message", "test data".to_string());
+        let event_id = store.send_with_storage(&id, "message", "test data".to_string());
         assert!(event_id.is_some());
 
-        // Verify message was received
         let msg = rx.recv().await?;
         assert_eq!(msg, "test data");
 
-        // Verify event was stored
-        let store = manager
-            .get_event_store(&id)
-            .ok_or("Event store not found")?;
-        assert_eq!(store.len().await, 1);
-
-        let events = store.get_all_events().await;
-        assert_eq!(events[0].data, "test data");
-        assert_eq!(events[0].event_type, "message");
+        let events = store.events(&id).ok_or("Event store not found")?;
+        assert_eq!(events.len().await, 1);
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_session_manager_replay() -> Result<(), Box<dyn std::error::Error>> {
-        let manager = SessionManager::new();
-        let (id, _rx) = manager.create_session();
+    async fn session_replay_returns_events_after_last_id() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let store = SessionStore::with_default_timeout();
+        let id = store.create();
 
-        // Send multiple messages with storage
-        let _ = manager.send_to_session_with_storage(&id, "message", "msg1".to_string());
-        let evt2 = manager.send_to_session_with_storage(&id, "message", "msg2".to_string());
-        let _ = manager.send_to_session_with_storage(&id, "message", "msg3".to_string());
+        let _ = store.send_with_storage(&id, "message", "msg1".to_string());
+        let evt2 = store.send_with_storage(&id, "message", "msg2".to_string());
+        let _ = store.send_with_storage(&id, "message", "msg3".to_string());
 
-        // Simulate reconnection - get events after evt2
-        let events = manager
-            .get_events_for_replay(&id, &evt2.ok_or("Failed to get event ID")?)
+        // Simulate reconnection: get events after evt2.
+        let events = store
+            .events_for_replay(&id, &evt2.ok_or("Failed to get event ID")?)
             .await
             .ok_or("Failed to get events for replay")?;
 
-        // Should only get msg3
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].data, "msg3");
         Ok(())

--- a/crates/mcpkit-axum/src/state.rs
+++ b/crates/mcpkit-axum/src/state.rs
@@ -1,6 +1,6 @@
 //! Shared state for MCP Axum handlers.
 
-use crate::session::{SessionManager, SessionStore};
+use crate::session::SessionStore;
 use mcpkit_core::auth::ProtectedResourceMetadata;
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_transport::http::OriginValidator;
@@ -22,7 +22,6 @@ pub struct McpState<H> {
     /// Session store for HTTP request tracking.
     pub sessions: Arc<SessionStore>,
     /// Session manager for SSE streaming.
-    pub sse_sessions: Arc<SessionManager>,
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
@@ -39,7 +38,6 @@ impl<H> Clone for McpState<H> {
             handler: Arc::clone(&self.handler),
             server_info: self.server_info.clone(),
             sessions: Arc::clone(&self.sessions),
-            sse_sessions: Arc::clone(&self.sse_sessions),
             origin_validator: Arc::clone(&self.origin_validator),
             list_page_size: self.list_page_size,
             completion: self.completion.clone(),
@@ -54,7 +52,6 @@ impl<H> fmt::Debug for McpState<H> {
             .field("handler", &format_args!("Arc<H>"))
             .field("server_info", &self.server_info)
             .field("sessions", &self.sessions)
-            .field("sse_sessions", &format_args!("Arc<SessionManager>"))
             .field("origin_validator", &self.origin_validator)
             .field("list_page_size", &self.list_page_size)
             .field(
@@ -76,7 +73,6 @@ impl<H> McpState<H> {
             handler: Arc::new(handler),
             server_info,
             sessions: Arc::new(SessionStore::with_default_timeout()),
-            sse_sessions: Arc::new(SessionManager::new()),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
             completion: None,
@@ -84,7 +80,7 @@ impl<H> McpState<H> {
     }
 
     /// Create new MCP state with custom session configuration.
-    pub fn with_sessions(handler: H, sessions: SessionStore, sse_sessions: SessionManager) -> Self
+    pub fn with_sessions(handler: H, sessions: SessionStore) -> Self
     where
         H: HasServerInfo,
     {
@@ -93,7 +89,6 @@ impl<H> McpState<H> {
             handler: Arc::new(handler),
             server_info,
             sessions: Arc::new(sessions),
-            sse_sessions: Arc::new(sse_sessions),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
             completion: None,

--- a/crates/mcpkit-axum/tests/sse_binding.rs
+++ b/crates/mcpkit-axum/tests/sse_binding.rs
@@ -1,0 +1,179 @@
+//! #153 PR 1 (#172, #173): SSE streams attach to the POST-created session —
+//! the MCP endpoint serves GET, unknown session ids are 404 (never adopted),
+//! mismatched users are 403, and a missing session id is 400.
+
+use axum::Extension;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::response::IntoResponse;
+use mcpkit_axum::McpState;
+use mcpkit_core::auth::VerifiedUser;
+use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{GetPromptResult, Prompt, Resource, ResourceContents, Tool, ToolOutput};
+use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+
+struct H;
+
+impl ServerHandler for H {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("t", "1.0.0")
+    }
+}
+impl ToolHandler for H {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![])
+    }
+    async fn call_tool(
+        &self,
+        name: &str,
+        _args: serde_json::Map<String, serde_json::Value>,
+        _ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        Err(McpError::method_not_found(name))
+    }
+}
+impl ResourceHandler for H {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for H {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Err(McpError::method_not_found(name))
+    }
+}
+
+fn sse_headers(session: Option<&str>) -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    if let Some(s) = session {
+        headers.insert("mcp-session-id", HeaderValue::from_str(s).expect("sid"));
+    }
+    headers
+}
+
+async fn sse_status(
+    state: &McpState<H>,
+    session: Option<&str>,
+    user: Option<VerifiedUser>,
+) -> StatusCode {
+    mcpkit_axum::handle_sse(
+        State(state.clone()),
+        sse_headers(session),
+        user.map(Extension),
+    )
+    .await
+    .into_response()
+    .status()
+}
+
+#[tokio::test]
+async fn sse_without_session_id_is_400() {
+    let state = McpState::new(H);
+    assert_eq!(
+        sse_status(&state, None, None).await,
+        StatusCode::BAD_REQUEST
+    );
+}
+
+#[tokio::test]
+async fn sse_with_unknown_session_id_is_404_and_never_adopts_it() {
+    let state = McpState::new(H);
+    assert_eq!(
+        sse_status(&state, Some("attacker-chosen-id"), None).await,
+        StatusCode::NOT_FOUND
+    );
+    // The presented id must not have been registered as a session.
+    assert!(state.sessions.get("attacker-chosen-id").is_none());
+}
+
+#[tokio::test]
+async fn sse_with_other_users_session_is_403() {
+    let state = McpState::new(H);
+    let alice = VerifiedUser::new("alice").issuer("https://idp");
+    let bob = VerifiedUser::new("bob").issuer("https://idp");
+    let sid = state.sessions.create_for_user(Some(alice));
+
+    assert_eq!(
+        sse_status(&state, Some(&sid), Some(bob)).await,
+        StatusCode::FORBIDDEN
+    );
+    // Anonymous access to a bound session is also rejected.
+    assert_eq!(
+        sse_status(&state, Some(&sid), None).await,
+        StatusCode::FORBIDDEN
+    );
+}
+
+#[tokio::test]
+async fn sse_with_own_session_streams() {
+    let state = McpState::new(H);
+    let sid = state.sessions.create();
+    assert_eq!(sse_status(&state, Some(&sid), None).await, StatusCode::OK);
+}
+
+#[tokio::test]
+async fn get_on_mcp_endpoint_serves_sse() {
+    use tower::util::ServiceExt;
+    // Spec (#172): the MCP endpoint must serve GET; a compliant client GETs
+    // the same path it POSTs to.
+    let router = mcpkit_axum::McpRouter::new(H).into_router();
+
+    // initialize via POST to obtain a session id
+    let resp = router
+        .clone()
+        .oneshot(
+            axum::http::Request::builder()
+                .method("POST")
+                .uri("/mcp")
+                .header("content-type", "application/json")
+                .header("mcp-protocol-version", "2025-11-25")
+                .body(axum::body::Body::from(
+                    r#"{"jsonrpc":"2.0","method":"initialize","params":{},"id":0}"#,
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    let sid = resp
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("session id");
+
+    let resp = router
+        .oneshot(
+            axum::http::Request::builder()
+                .method("GET")
+                .uri("/mcp")
+                .header("mcp-session-id", sid)
+                .body(axum::body::Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|ct| ct.starts_with("text/event-stream")),
+        "GET on the MCP endpoint must open an SSE stream"
+    );
+}


### PR DESCRIPTION
PR 1 of the #153 design v3 (axum-first per review round 2, N13 — actix/warp/rocket adopt the same substrate in their port PRs). **Closes #172 and #173 for axum**; leave #153 open.

## The two defects (review round 1, C1-C3; both verified with file:line in the issues)

1. **Disjoint registries:** `McpState` held `sessions: SessionStore` (user binding, tasks) AND `sse_sessions: SessionManager` (broadcast + events) with no shared id space. Every id that resolved to a live stream was, by construction, unknown to the store holding the user binding — so `handle_sse`'s check passed vacuously (`get_verified` → `Ok(None)` → not an error), and any presented id got a **fresh SSE session minted for it**.
2. **GET not on the MCP endpoint:** SSE lived only at `/mcp/sse`, undiscoverable in-protocol. Spec: *"The server MUST provide a single HTTP endpoint path … that supports both POST and GET methods."* A compliant client GETs `/mcp`, receives 405, and per spec concludes the server offers no stream.

## What changed

- `Session` owns its `broadcast::Sender` and `EventStore`; `SessionManager` is **removed** (breaking: the exported type, `McpState.sse_sessions`, and `McpState::with_sessions`' second parameter). `SessionStore` gains `subscribe` / `events` / `send_with_storage` / `events_for_replay` / `with_event_store_config` — the same surface, now on the one registry that also holds the binding.
- `.route(post_path, post(handle_mcp_post).get(handle_sse))` — GET on the MCP endpoint; `/mcp/sse` retained as a deprecated alias.
- `handle_sse`: **400** missing session id (sessions are assigned at initialize — PR 0b's rule extended to GET, which the spec's session-id MUST covers), **404** unknown id (never adopt a client-presented id; spec §Session Management), **403** mismatched/anonymous user on a bound session — enforced against the unified registry, so the vacuous-pass hole is structurally closed.

Not in this PR (deliberately, per the design's ordering): per-stream `mpsc` routing, `{stream_id}-{seq}` event ids, and the double-id replay fix — that is PR 2, which lands **before** any server-initiated request ever rides the stream. The broadcast fan-out MUST-NOT therefore remains latent for notifications only, exactly as the design sequenced it.

## Tests

New `sse_binding.rs` suite: 400 / 404-and-never-adopts (asserts the presented id was not registered) / 403 for wrong user and for anonymous-on-bound / happy-path 200 / end-to-end `GET /mcp` through the real router returning `text/event-stream` after an initialize.

Full local gate green: fmt, clippy `-D warnings` (1.97), rustdoc, 75 test suites.

Refs #153.