### PR TITLE
feat(server)!: shared per-stream SSE delivery; adopt in axum (#153 PR 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking (axum):** SSE delivery is rebuilt on a shared per-stream module,
+  `mcpkit_server::streams` (`StreamRegistry`/`StreamConfig`/`StoredEvent`),
+  fixing four spec deviations at once (#153 PR 2, axum-first; the other
+  adapters adopt it in their port PRs):
+  - **One message, one stream** (spec MUST NOT broadcast): each GET gets its
+    own bounded `mpsc` channel; every outbound event is stored on and
+    delivered to exactly one *designated* stream (the oldest live one; a
+    resumed stream keeps its identity and designation). Previously a single
+    per-session `broadcast` channel fanned every message out to all
+    connected streams.
+  - **Working resumability**: event ids are `{stream_id}-{seq}`, allocated
+    once at store time, so the wire id always equals the stored id (the old
+    axum code allocated ids twice — store and emit — making `Last-Event-ID`
+    replay return the entire buffer). Replay serves only same-stream events
+    (spec MUST NOT replay across streams); an unknown/expired cursor opens a
+    fresh stream instead.
+  - **No silent loss**: a full channel kills its stream explicitly (the old
+    `broadcast` path silently skipped lagged messages); the killed stream's
+    buffer is retained for `StreamConfig::max_age` (300s default) so the
+    client resumes and replays what it missed.
+  - **`retry: 2000` is emitted** on the first event of every stream (spec:
+    clients MUST respect `retry`), so reconnect cadence is dictated rather
+    than guessed.
+  - Removed from mcpkit-axum: `EventStore`, `EventStoreConfig`, the
+    session's `tx`/`events` fields, and `SessionStore::{subscribe, events,
+    send_with_storage, events_for_replay, with_event_store_config}` —
+    replaced by `Session.streams`, `SessionStore::{streams, send_event,
+    with_stream_config}`, and the re-exported shared types
+    ([#153](https://github.com/praxiomlabs/mcpkit/issues/153)).
+
 - **Breaking (axum):** the axum adapter's SSE side now attaches to the same
   session the POST side creates, fixing two standing spec/security defects
   (#172, #173) as #153's PR 1 (axum-first; actix/warp/rocket follow in their

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -14,7 +14,6 @@
 //! claims.
 
 use crate::error::ExtensionError;
-use crate::session::{EventStore, StoredEvent};
 use crate::state::{HasServerInfo, McpState, OAuthState};
 use crate::{SUPPORTED_VERSIONS, is_supported_version};
 use axum::extract::State;
@@ -29,6 +28,7 @@ use mcpkit_core::protocol::Message;
 use mcpkit_core::protocol_version::ProtocolVersion;
 use mcpkit_server::capability::tasks::{TaskManager, route_task_store};
 use mcpkit_server::context::{Context, NoOpPeer};
+use mcpkit_server::streams::StoredEvent;
 use mcpkit_server::{
     AugmentedTaskOutcome, PromptHandler, ResourceHandler, ServerHandler, ToolHandler,
     begin_augmented_task, route_completion, route_logging, route_prompts, route_resources,
@@ -481,89 +481,69 @@ where
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
-    let rx = state
-        .sessions
-        .subscribe(&id)
-        .expect("session verified above");
-    let replay_events = if let Some(last_id) = &last_event_id {
-        info!(session_id = %id, last_event_id = %last_id, "Reconnecting with Last-Event-ID");
-        state
-            .sessions
-            .events_for_replay(&id, last_id)
-            .await
-            .unwrap_or_default()
-    } else {
-        Vec::new()
-    };
-    let event_store = state.sessions.events(&id);
+    let registry = state.sessions.streams(&id).expect("session verified above");
 
-    let stream = create_sse_stream_with_replay(id, rx, replay_events, event_store);
+    // Resume the named stream (same identity, same-stream replay) or open a
+    // fresh one primed with a `connected` event (#153 PR 2).
+    let (handle, replay_events) = if let Some(last_id) = &last_event_id {
+        info!(session_id = %id, last_event_id = %last_id, "Reconnecting with Last-Event-ID");
+        if let Some((handle, replay)) = registry.resume(last_id) {
+            (handle, replay)
+        } else {
+            // Unknown or expired stream cursor: open a fresh stream rather
+            // than replaying another stream's events (spec MUST NOT).
+            let (handle, prime) = registry.open("connected", id);
+            (handle, vec![prime])
+        }
+    } else {
+        let (handle, prime) = registry.open("connected", id);
+        (handle, vec![prime])
+    };
+
+    let stream = create_sse_stream(handle, replay_events);
     Sse::new(stream)
         .keep_alive(KeepAlive::default())
         .into_response()
 }
 
-/// Create an SSE stream with support for event replay.
-///
-/// This function creates an SSE stream that:
-/// 1. Sends any replay events (from Last-Event-ID reconnection)
-/// 2. Sends the "connected" event with session ID
-/// 3. Streams new messages as they arrive
-///
-/// All events include an `id` field for client-side tracking and reconnection.
-fn create_sse_stream_with_replay(
-    session_id: String,
-    mut rx: tokio::sync::broadcast::Receiver<String>,
+/// Create the SSE event stream for one [`mcpkit_server::streams::StreamHandle`]:
+/// replayed events first (each with its stored id), then live events as the
+/// registry delivers them. The first event carries a `retry` hint (spec: the
+/// client MUST respect `retry`), so client reconnect cadence is dictated
+/// rather than guessed.
+fn create_sse_stream(
+    mut handle: mcpkit_server::streams::StreamHandle,
     replay_events: Vec<StoredEvent>,
-    event_store: Option<Arc<EventStore>>,
 ) -> impl Stream<Item = Result<Event, Infallible>> {
     async_stream::stream! {
-        // First, replay any missed events
+        let mut first = true;
         for stored in replay_events {
-            debug!(event_id = %stored.id, "Replaying missed event");
-            yield Ok(Event::default()
+            debug!(event_id = %stored.id, "Sending stored event");
+            let mut event = Event::default()
                 .id(&stored.id)
                 .event(&stored.event_type)
-                .data(&stored.data));
-        }
-
-        // Send connected event with session ID and an event ID
-        // Per MCP spec: servers MUST immediately send an SSE event with an id
-        // to prime the client for reconnection
-        let connected_event_id = event_store
-            .as_ref()
-            .map_or_else(|| "evt-connected".to_string(), |store| store.next_event_id());
-
-        yield Ok(Event::default()
-            .id(&connected_event_id)
-            .event("connected")
-            .data(&session_id));
-
-        // Stream new messages with event IDs
-        loop {
-            match rx.recv().await {
-                Ok(msg) => {
-                    // Generate event ID for the new message
-                    let event_id = event_store
-                        .as_ref()
-                        .map_or_else(|| format!("evt-{}", uuid::Uuid::new_v4()), |store| store.next_event_id());
-
-                    yield Ok(Event::default()
-                        .id(&event_id)
-                        .event("message")
-                        .data(msg));
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(skipped = n, "SSE client lagged, skipped messages");
-                    // Note: Lagged events may be available in the event store
-                    // for replay on reconnection
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                    debug!("SSE channel closed");
-                    break;
-                }
+                .data(&stored.data);
+            if first {
+                event = event.retry(std::time::Duration::from_secs(2));
+                first = false;
             }
+            yield Ok(event);
         }
+
+        // Live delivery: the registry stores each event (id allocated once)
+        // before queueing it here, so the wire id always equals the stored id.
+        while let Some(stored) = handle.recv().await {
+            let mut event = Event::default()
+                .id(&stored.id)
+                .event(&stored.event_type)
+                .data(&stored.data);
+            if first {
+                event = event.retry(std::time::Duration::from_secs(2));
+                first = false;
+            }
+            yield Ok(event);
+        }
+        debug!("SSE stream closed (stream killed or session dropped)");
     }
 }
 

--- a/crates/mcpkit-axum/src/lib.rs
+++ b/crates/mcpkit-axum/src/lib.rs
@@ -101,10 +101,9 @@ mod state;
 
 pub use error::ExtensionError;
 pub use handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
+pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 pub use router::McpRouter;
-pub use session::{
-    DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionStore, StoredEvent,
-};
+pub use session::{DEFAULT_INIT_TIMEOUT, Session, SessionStore};
 pub use state::{McpState, OAuthState};
 
 /// Prelude module for convenient imports.
@@ -118,10 +117,9 @@ pub mod prelude {
     pub use crate::error::ExtensionError;
     pub use crate::handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
     pub use crate::router::McpRouter;
-    pub use crate::session::{
-        DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionStore, StoredEvent,
-    };
+    pub use crate::session::{DEFAULT_INIT_TIMEOUT, Session, SessionStore};
     pub use crate::state::{McpState, OAuthState};
+    pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 }
 
 /// Protocol versions supported by this extension.

--- a/crates/mcpkit-axum/src/session.rs
+++ b/crates/mcpkit-axum/src/session.rs
@@ -4,12 +4,9 @@ use dashmap::DashMap;
 use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
-use std::collections::VecDeque;
+use mcpkit_server::streams::{StreamConfig, StreamRegistry};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
-use tokio::sync::broadcast;
 
 /// A single MCP session.
 #[derive(Debug, Clone)]
@@ -33,12 +30,11 @@ pub struct Session {
     /// session so one session cannot read or cancel another's tasks (matching
     /// the stdio runtime's per-connection store).
     pub tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
-    /// Sender for this session's SSE stream(s). Owned by the session (#153
-    /// PR 1): streams attach to the POST-created session rather than a
-    /// separate SSE registry with its own id space.
-    pub tx: broadcast::Sender<String>,
-    /// Stored events for SSE resumability (`Last-Event-ID` replay).
-    pub events: Arc<EventStore>,
+    /// This session's SSE stream registry (#153 PR 2): per-stream bounded
+    /// channels, single-stream delivery, `{stream_id}-{seq}` event ids, and
+    /// same-stream `Last-Event-ID` replay — shared adapter logic from
+    /// `mcpkit_server::streams`.
+    pub streams: Arc<StreamRegistry>,
 }
 
 impl Session {
@@ -52,7 +48,6 @@ impl Session {
     #[must_use]
     pub fn with_user(id: String, user: Option<VerifiedUser>) -> Self {
         let now = Instant::now();
-        let (tx, _rx) = broadcast::channel(100);
         Self {
             id,
             created_at: now,
@@ -62,8 +57,7 @@ impl Session {
             protocol_version: None,
             user,
             tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
-            tx,
-            events: Arc::new(EventStore::new(EventStoreConfig::default())),
+            streams: Arc::new(StreamRegistry::new(StreamConfig::default())),
         }
     }
 
@@ -104,246 +98,6 @@ impl Session {
     }
 }
 
-/// A stored SSE event for replay support.
-#[derive(Debug, Clone)]
-pub struct StoredEvent {
-    /// The event ID (globally unique within the session stream).
-    pub id: String,
-    /// The event type (e.g., "message", "connected").
-    pub event_type: String,
-    /// The event data.
-    pub data: String,
-    /// When the event was stored.
-    pub stored_at: Instant,
-}
-
-impl StoredEvent {
-    /// Create a new stored event.
-    #[must_use]
-    pub fn new(id: String, event_type: impl Into<String>, data: impl Into<String>) -> Self {
-        Self {
-            id,
-            event_type: event_type.into(),
-            data: data.into(),
-            stored_at: Instant::now(),
-        }
-    }
-}
-
-/// Configuration for event store retention.
-#[derive(Debug, Clone)]
-pub struct EventStoreConfig {
-    /// Maximum number of events to retain per stream.
-    pub max_events: usize,
-    /// Maximum age of events to retain.
-    pub max_age: Duration,
-}
-
-impl Default for EventStoreConfig {
-    fn default() -> Self {
-        Self {
-            max_events: 1000,
-            max_age: Duration::from_secs(300), // 5 minutes
-        }
-    }
-}
-
-impl EventStoreConfig {
-    /// Create a new event store configuration.
-    #[must_use]
-    pub const fn new(max_events: usize, max_age: Duration) -> Self {
-        Self {
-            max_events,
-            max_age,
-        }
-    }
-
-    /// Set the maximum number of events to retain.
-    #[must_use]
-    pub const fn with_max_events(mut self, max_events: usize) -> Self {
-        self.max_events = max_events;
-        self
-    }
-
-    /// Set the maximum age of events to retain.
-    #[must_use]
-    pub const fn with_max_age(mut self, max_age: Duration) -> Self {
-        self.max_age = max_age;
-        self
-    }
-}
-
-/// Event store for SSE message resumability.
-///
-/// Per the MCP Streamable HTTP specification, servers MAY store events
-/// with IDs to support client reconnection with `Last-Event-ID`.
-///
-/// # Example
-///
-/// ```rust
-/// use mcpkit_axum::{EventStore, EventStoreConfig};
-/// use std::time::Duration;
-///
-/// let config = EventStoreConfig::new(500, Duration::from_secs(120));
-/// let store = EventStore::new(config);
-///
-/// // Store an event
-/// store.store("evt-001", "message", r#"{"jsonrpc":"2.0",...}"#);
-///
-/// // Get events after a specific ID for replay (async)
-/// // let events = store.get_events_after("evt-000").await;
-/// ```
-#[derive(Debug)]
-pub struct EventStore {
-    events: RwLock<VecDeque<StoredEvent>>,
-    config: EventStoreConfig,
-    next_id: AtomicU64,
-}
-
-impl EventStore {
-    /// Create a new event store with the given configuration.
-    #[must_use]
-    pub fn new(config: EventStoreConfig) -> Self {
-        Self {
-            events: RwLock::new(VecDeque::with_capacity(config.max_events)),
-            config,
-            next_id: AtomicU64::new(1),
-        }
-    }
-
-    /// Create a new event store with default configuration.
-    #[must_use]
-    pub fn with_defaults() -> Self {
-        Self::new(EventStoreConfig::default())
-    }
-
-    /// Generate the next event ID.
-    #[must_use]
-    pub fn next_event_id(&self) -> String {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        format!("evt-{id}")
-    }
-
-    /// Store an event with automatic ID generation.
-    ///
-    /// Returns the generated event ID.
-    pub fn store_auto_id(&self, event_type: impl Into<String>, data: impl Into<String>) -> String {
-        let id = self.next_event_id();
-        self.store(id.clone(), event_type, data);
-        id
-    }
-
-    /// Store an event with a specific ID.
-    pub fn store(
-        &self,
-        id: impl Into<String>,
-        event_type: impl Into<String>,
-        data: impl Into<String>,
-    ) {
-        let event = StoredEvent::new(id.into(), event_type, data);
-
-        // Use blocking write since we can't use async in this sync method
-        // In production, consider using parking_lot::RwLock for better sync performance
-        let mut events = futures::executor::block_on(self.events.write());
-
-        // Add the new event
-        events.push_back(event);
-
-        // Enforce max_events limit
-        while events.len() > self.config.max_events {
-            events.pop_front();
-        }
-
-        // Enforce max_age limit
-        let now = Instant::now();
-        while let Some(front) = events.front() {
-            if now.duration_since(front.stored_at) > self.config.max_age {
-                events.pop_front();
-            } else {
-                break;
-            }
-        }
-    }
-
-    /// Store an event asynchronously.
-    pub async fn store_async(
-        &self,
-        id: impl Into<String>,
-        event_type: impl Into<String>,
-        data: impl Into<String>,
-    ) {
-        let event = StoredEvent::new(id.into(), event_type, data);
-        let mut events = self.events.write().await;
-
-        events.push_back(event);
-
-        // Enforce limits
-        while events.len() > self.config.max_events {
-            events.pop_front();
-        }
-
-        let now = Instant::now();
-        while let Some(front) = events.front() {
-            if now.duration_since(front.stored_at) > self.config.max_age {
-                events.pop_front();
-            } else {
-                break;
-            }
-        }
-    }
-
-    /// Get all events after the specified event ID.
-    ///
-    /// Used for replaying events when a client reconnects with `Last-Event-ID`.
-    /// Returns events in chronological order.
-    pub async fn get_events_after(&self, last_event_id: &str) -> Vec<StoredEvent> {
-        let events = self.events.read().await;
-
-        // Find the index of the last event ID
-        // Start from the next event after last_event_id, or 0 if not found
-        let start_idx = events
-            .iter()
-            .position(|e| e.id == last_event_id)
-            .map_or(0, |i| i + 1);
-
-        events.iter().skip(start_idx).cloned().collect()
-    }
-
-    /// Get all stored events.
-    pub async fn get_all_events(&self) -> Vec<StoredEvent> {
-        let events = self.events.read().await;
-        events.iter().cloned().collect()
-    }
-
-    /// Get the number of stored events.
-    pub async fn len(&self) -> usize {
-        self.events.read().await.len()
-    }
-
-    /// Check if the store is empty.
-    pub async fn is_empty(&self) -> bool {
-        self.events.read().await.is_empty()
-    }
-
-    /// Clear all stored events.
-    pub async fn clear(&self) {
-        self.events.write().await.clear();
-    }
-
-    /// Clean up expired events.
-    pub async fn cleanup_expired(&self) {
-        let mut events = self.events.write().await;
-        let now = Instant::now();
-        while let Some(front) = events.front() {
-            if now.duration_since(front.stored_at) > self.config.max_age {
-                events.pop_front();
-            } else {
-                break;
-            }
-        }
-    }
-}
-
 /// Default timeout after which a session created but never initialized is
 /// reaped.
 pub const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(30);
@@ -359,8 +113,8 @@ pub struct SessionStore {
     /// Default task retention (ms) applied to each session's task store; `None`
     /// means unlimited. Configure via `McpRouter::with_task_ttl`.
     pub(crate) default_task_ttl: Option<u64>,
-    /// Event-store configuration applied to each session's SSE event buffer.
-    event_store_config: EventStoreConfig,
+    /// Stream configuration applied to each session's SSE stream registry.
+    stream_config: StreamConfig,
 }
 
 impl SessionStore {
@@ -375,7 +129,7 @@ impl SessionStore {
             timeout,
             init_timeout: DEFAULT_INIT_TIMEOUT,
             default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
-            event_store_config: EventStoreConfig::default(),
+            stream_config: StreamConfig::default(),
         }
     }
 
@@ -393,53 +147,27 @@ impl SessionStore {
         self
     }
 
-    /// Set the event-store configuration applied to each new session's SSE
-    /// event buffer.
+    /// Set the stream configuration applied to each new session's SSE
+    /// stream registry.
     #[must_use]
-    pub fn with_event_store_config(mut self, config: EventStoreConfig) -> Self {
-        self.event_store_config = config;
+    pub fn with_stream_config(mut self, config: StreamConfig) -> Self {
+        self.stream_config = config;
         self
     }
 
-    /// Subscribe to a session's SSE stream. `None` if the session is unknown.
-    #[must_use]
-    pub fn subscribe(&self, id: &str) -> Option<broadcast::Receiver<String>> {
-        self.sessions.get(id).map(|s| s.tx.subscribe())
-    }
-
-    /// The event store backing a session's SSE resumability. `None` if the
-    /// session is unknown.
-    #[must_use]
-    pub fn events(&self, id: &str) -> Option<Arc<EventStore>> {
-        self.sessions.get(id).map(|s| Arc::clone(&s.events))
-    }
-
-    /// Store `message` for resumability and send it on the session's SSE
-    /// stream, returning the stored event id. `None` if the session is
+    /// The SSE stream registry for a session. `None` if the session is
     /// unknown.
     #[must_use]
-    pub fn send_with_storage(
-        &self,
-        id: &str,
-        event_type: impl Into<String>,
-        message: String,
-    ) -> Option<String> {
-        let session = self.sessions.get(id)?;
-        let event_id = session.events.store_auto_id(event_type, message.clone());
-        // Ignore send errors (no receivers): the event is stored for replay.
-        let _ = session.tx.send(message);
-        Some(event_id)
+    pub fn streams(&self, id: &str) -> Option<Arc<StreamRegistry>> {
+        self.sessions.get(id).map(|s| Arc::clone(&s.streams))
     }
 
-    /// Get events after `last_event_id` for `Last-Event-ID` replay. `None` if
-    /// the session is unknown.
-    pub async fn events_for_replay(
-        &self,
-        id: &str,
-        last_event_id: &str,
-    ) -> Option<Vec<StoredEvent>> {
-        let store = self.events(id)?;
-        Some(store.get_events_after(last_event_id).await)
+    /// Store `message` on the session's designated stream and queue it for
+    /// delivery, returning the allocated event id. `None` if the session is
+    /// unknown or has no live stream.
+    #[must_use]
+    pub fn send_event(&self, id: &str, event_type: &str, message: String) -> Option<String> {
+        self.sessions.get(id)?.streams.send(event_type, message)
     }
 
     /// Create a new session and return its ID.
@@ -463,7 +191,7 @@ impl SessionStore {
         session.tasks = Arc::new(
             mcpkit_server::capability::tasks::TaskManager::with_default_ttl(self.default_task_ttl),
         );
-        session.events = Arc::new(EventStore::new(self.event_store_config.clone()));
+        session.streams = Arc::new(StreamRegistry::new(self.stream_config.clone()));
         self.sessions.insert(id.clone(), session);
         id
     }
@@ -683,197 +411,55 @@ mod tests {
     async fn session_stream_send_and_receive() -> Result<(), Box<dyn std::error::Error>> {
         let store = SessionStore::with_default_timeout();
         let id = store.create();
-        let mut rx = store.subscribe(&id).ok_or("session missing")?;
+        let registry = store.streams(&id).ok_or("session missing")?;
+        let (mut handle, prime) = registry.open("connected", id.clone());
+        assert_eq!(prime.event_type, "connected");
 
-        // Send a message (stored + broadcast).
+        // Send an event (stored + queued on the designated stream).
+        let event_id = store.send_event(&id, "message", "test message".to_string());
+        assert!(event_id.is_some());
+
+        let got = handle.recv().await.ok_or("stream closed")?;
+        assert_eq!(got.data, "test message");
+        assert_eq!(Some(got.id), event_id);
+
+        // Unknown session: no registry, no send.
+        assert!(store.streams("nope").is_none());
         assert!(
             store
-                .send_with_storage(&id, "message", "test message".to_string())
-                .is_some()
-        );
-
-        let msg = rx.recv().await?;
-        assert_eq!(msg, "test message");
-
-        // Unknown session: no subscription, no send.
-        assert!(store.subscribe("nope").is_none());
-        assert!(
-            store
-                .send_with_storage("nope", "message", "x".to_string())
+                .send_event("nope", "message", "x".to_string())
                 .is_none()
         );
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_event_store_creation() {
-        let store = EventStore::with_defaults();
-        assert!(store.is_empty().await);
-        assert_eq!(store.len().await, 0);
-    }
-
-    #[tokio::test]
-    async fn test_event_store_store_and_retrieve() {
-        let store = EventStore::with_defaults();
-
-        store.store_async("evt-1", "message", "data1").await;
-        store.store_async("evt-2", "message", "data2").await;
-        store.store_async("evt-3", "message", "data3").await;
-
-        assert_eq!(store.len().await, 3);
-
-        let all_events = store.get_all_events().await;
-        assert_eq!(all_events.len(), 3);
-        assert_eq!(all_events[0].id, "evt-1");
-        assert_eq!(all_events[1].id, "evt-2");
-        assert_eq!(all_events[2].id, "evt-3");
-    }
-
-    #[tokio::test]
-    async fn test_event_store_get_events_after() {
-        let store = EventStore::with_defaults();
-
-        store.store_async("evt-1", "message", "data1").await;
-        store.store_async("evt-2", "message", "data2").await;
-        store.store_async("evt-3", "message", "data3").await;
-
-        // Get events after evt-1
-        let events = store.get_events_after("evt-1").await;
-        assert_eq!(events.len(), 2);
-        assert_eq!(events[0].id, "evt-2");
-        assert_eq!(events[1].id, "evt-3");
-
-        // Get events after evt-2
-        let events = store.get_events_after("evt-2").await;
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].id, "evt-3");
-
-        // Get events after evt-3 (should be empty)
-        let events = store.get_events_after("evt-3").await;
-        assert_eq!(events.len(), 0);
-
-        // Get events after unknown ID (should return all)
-        let events = store.get_events_after("unknown").await;
-        assert_eq!(events.len(), 3);
-    }
-
-    #[tokio::test]
-    async fn test_event_store_auto_id() {
-        let store = EventStore::with_defaults();
-
-        let id1 = store.store_auto_id("message", "data1");
-        let id2 = store.store_auto_id("message", "data2");
-
-        assert!(id1.starts_with("evt-"));
-        assert!(id2.starts_with("evt-"));
-        assert_ne!(id1, id2);
-
-        assert_eq!(store.len().await, 2);
-    }
-
-    #[tokio::test]
-    async fn test_event_store_max_events_limit() {
-        let config = EventStoreConfig::new(3, Duration::from_secs(300));
-        let store = EventStore::new(config);
-
-        store.store_async("evt-1", "message", "data1").await;
-        store.store_async("evt-2", "message", "data2").await;
-        store.store_async("evt-3", "message", "data3").await;
-        store.store_async("evt-4", "message", "data4").await;
-
-        // Should only have 3 events (oldest removed)
-        assert_eq!(store.len().await, 3);
-
-        let events = store.get_all_events().await;
-        assert_eq!(events[0].id, "evt-2"); // evt-1 was evicted
-        assert_eq!(events[1].id, "evt-3");
-        assert_eq!(events[2].id, "evt-4");
-    }
-
-    #[tokio::test]
-    async fn test_event_store_clear() {
-        let store = EventStore::with_defaults();
-
-        store.store_async("evt-1", "message", "data1").await;
-        store.store_async("evt-2", "message", "data2").await;
-
-        assert_eq!(store.len().await, 2);
-
-        store.clear().await;
-
-        assert!(store.is_empty().await);
-        assert_eq!(store.len().await, 0);
-    }
-
-    #[tokio::test]
-    async fn session_has_event_store() -> Result<(), Box<dyn std::error::Error>> {
+    async fn session_without_live_stream_drops_sends() {
+        // The event is not deliverable (send_event -> None) when no GET
+        // stream was ever opened; nothing panics and nothing leaks.
         let store = SessionStore::with_default_timeout();
         let id = store.create();
-
-        // Event store is created with the session.
-        let events = store.events(&id);
-        assert!(events.is_some());
-        assert!(events.ok_or("Event store not found")?.is_empty().await);
-        Ok(())
+        assert!(store.send_event(&id, "message", "x".to_string()).is_none());
     }
 
     #[tokio::test]
-    async fn session_send_with_storage_stores_event() -> Result<(), Box<dyn std::error::Error>> {
+    async fn session_replay_after_stream_death() -> Result<(), Box<dyn std::error::Error>> {
         let store = SessionStore::with_default_timeout();
         let id = store.create();
-        let mut rx = store.subscribe(&id).ok_or("session missing")?;
+        let registry = store.streams(&id).ok_or("session missing")?;
+        let (handle, _prime) = registry.open("connected", id.clone());
 
-        let event_id = store.send_with_storage(&id, "message", "test data".to_string());
-        assert!(event_id.is_some());
+        let evt1 = store
+            .send_event(&id, "message", "msg1".to_string())
+            .ok_or("send failed")?;
+        let _ = store.send_event(&id, "message", "msg2".to_string());
+        drop(handle); // stream dies (client disconnect)
 
-        let msg = rx.recv().await?;
-        assert_eq!(msg, "test data");
-
-        let events = store.events(&id).ok_or("Event store not found")?;
-        assert_eq!(events.len().await, 1);
+        // Resume with Last-Event-ID = evt1: replay only what followed, on the
+        // same stream identity.
+        let (_h2, replay) = registry.resume(&evt1).ok_or("not resumable")?;
+        assert_eq!(replay.len(), 1);
+        assert_eq!(replay[0].data, "msg2");
         Ok(())
-    }
-
-    #[tokio::test]
-    async fn session_replay_returns_events_after_last_id() -> Result<(), Box<dyn std::error::Error>>
-    {
-        let store = SessionStore::with_default_timeout();
-        let id = store.create();
-
-        let _ = store.send_with_storage(&id, "message", "msg1".to_string());
-        let evt2 = store.send_with_storage(&id, "message", "msg2".to_string());
-        let _ = store.send_with_storage(&id, "message", "msg3".to_string());
-
-        // Simulate reconnection: get events after evt2.
-        let events = store
-            .events_for_replay(&id, &evt2.ok_or("Failed to get event ID")?)
-            .await
-            .ok_or("Failed to get events for replay")?;
-
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].data, "msg3");
-        Ok(())
-    }
-
-    #[test]
-    fn test_event_store_config() {
-        let config = EventStoreConfig::default();
-        assert_eq!(config.max_events, 1000);
-        assert_eq!(config.max_age, Duration::from_secs(300));
-
-        let config = EventStoreConfig::new(500, Duration::from_secs(120))
-            .with_max_events(600)
-            .with_max_age(Duration::from_secs(180));
-
-        assert_eq!(config.max_events, 600);
-        assert_eq!(config.max_age, Duration::from_secs(180));
-    }
-
-    #[test]
-    fn test_stored_event() {
-        let event = StoredEvent::new("evt-123".to_string(), "message", "test data");
-        assert_eq!(event.id, "evt-123");
-        assert_eq!(event.event_type, "message");
-        assert_eq!(event.data, "test data");
     }
 }

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -67,6 +67,8 @@ pub mod metrics;
 pub mod router;
 pub mod server;
 pub mod state;
+#[cfg(feature = "tokio")]
+pub mod streams;
 #[cfg(feature = "schema-validation")]
 pub mod validation;
 

--- a/crates/mcpkit-server/src/streams.rs
+++ b/crates/mcpkit-server/src/streams.rs
@@ -1,0 +1,428 @@
+//! Per-session, per-stream SSE delivery (shared by the HTTP adapters).
+//!
+//! The Streamable HTTP spec requires that the server *"MUST send each of its
+//! JSON-RPC messages on only one of the connected streams"*, that SSE event
+//! ids be *"globally unique across all streams within that session"* and
+//! *"SHOULD encode sufficient information to identify the originating
+//! stream"*, and that the server *"MUST NOT replay messages that would have
+//! been delivered on a different stream"*.
+//!
+//! [`StreamRegistry`] implements those rules once, so the four adapters share
+//! one delivery/replay implementation instead of four drifting copies:
+//!
+//! - each GET opens (or resumes) one stream with its own bounded `mpsc`
+//!   channel and its own replay buffer;
+//! - every outbound message is stored on, and delivered to, exactly **one**
+//!   stream — the *designated* stream (the oldest live one, stable while it
+//!   lives; a resumed stream keeps its identity and therefore its
+//!   designation);
+//! - event ids are `{stream_id}-{seq}`, allocated **once at store time**, so
+//!   the id on the wire always equals the id in the buffer and
+//!   `Last-Event-ID` replay works;
+//! - replay serves only events buffered on the stream the cursor names;
+//! - a full channel kills its stream (never a silent skip): the buffer is
+//!   retained for [`StreamConfig::max_age`], so a reconnecting client
+//!   resumes and replays what the dead channel missed.
+
+use std::collections::VecDeque;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+use tokio::sync::mpsc;
+
+/// An event stored for delivery and replay on one stream.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StoredEvent {
+    /// Event id (`{stream_id}-{seq}`), allocated at store time.
+    pub id: String,
+    /// SSE event type (e.g. `connected`, `message`).
+    pub event_type: String,
+    /// Event payload.
+    pub data: String,
+}
+
+/// Configuration for a session's stream registry.
+#[derive(Debug, Clone)]
+pub struct StreamConfig {
+    /// Maximum buffered events retained per stream for replay.
+    pub max_events_per_stream: usize,
+    /// How long a dead stream's replay buffer is retained (spec resumability
+    /// window). Also bounds the age of buffered events on live streams.
+    pub max_age: Duration,
+    /// Per-stream delivery channel capacity. A stream whose channel is full
+    /// is killed explicitly (client resumes via `Last-Event-ID`).
+    pub channel_capacity: usize,
+}
+
+impl Default for StreamConfig {
+    fn default() -> Self {
+        Self {
+            max_events_per_stream: 1000,
+            max_age: Duration::from_secs(300),
+            channel_capacity: 100,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct StreamSlot {
+    id: u64,
+    /// Next sequence number to allocate on this stream.
+    seq: u64,
+    buffer: VecDeque<(Instant, StoredEvent)>,
+    /// Live delivery channel; `None` once the stream has died.
+    sender: Option<mpsc::Sender<StoredEvent>>,
+    opened: Instant,
+    died: Option<Instant>,
+}
+
+impl StreamSlot {
+    fn store(&mut self, event_type: &str, data: String, config: &StreamConfig) -> StoredEvent {
+        let event = StoredEvent {
+            id: format!("{}-{}", self.id, self.seq),
+            event_type: event_type.to_string(),
+            data,
+        };
+        self.seq += 1;
+        self.buffer.push_back((Instant::now(), event.clone()));
+        while self.buffer.len() > config.max_events_per_stream {
+            self.buffer.pop_front();
+        }
+        while self
+            .buffer
+            .front()
+            .is_some_and(|(at, _)| at.elapsed() > config.max_age)
+        {
+            self.buffer.pop_front();
+        }
+        event
+    }
+}
+
+/// Per-session registry of SSE streams. See the module docs for the rules it
+/// enforces.
+#[derive(Debug)]
+pub struct StreamRegistry {
+    inner: Mutex<Inner>,
+    config: StreamConfig,
+}
+
+#[derive(Debug)]
+struct Inner {
+    streams: Vec<StreamSlot>,
+    next_stream_id: u64,
+}
+
+/// One live stream: the receiving half consumed by the adapter's SSE loop.
+///
+/// Dropping the handle marks the stream dead in the registry (its replay
+/// buffer is retained for [`StreamConfig::max_age`]).
+#[derive(Debug)]
+pub struct StreamHandle {
+    stream_id: u64,
+    rx: mpsc::Receiver<StoredEvent>,
+    registry: Arc<StreamRegistry>,
+}
+
+impl StreamHandle {
+    /// This stream's id (the `{stream_id}` half of its event ids).
+    #[must_use]
+    pub const fn stream_id(&self) -> u64 {
+        self.stream_id
+    }
+
+    /// Receive the next event queued for this stream. `None` when the stream
+    /// has been killed (e.g. channel overflow) or the registry dropped.
+    pub async fn recv(&mut self) -> Option<StoredEvent> {
+        self.rx.recv().await
+    }
+}
+
+impl Drop for StreamHandle {
+    fn drop(&mut self) {
+        self.registry.mark_dead(self.stream_id);
+    }
+}
+
+impl StreamRegistry {
+    /// Create a registry with the given configuration.
+    #[must_use]
+    pub fn new(config: StreamConfig) -> Self {
+        Self {
+            inner: Mutex::new(Inner {
+                streams: Vec::new(),
+                next_stream_id: 1,
+            }),
+            config,
+        }
+    }
+
+    /// Open a new stream, storing and queueing a priming event (spec: the
+    /// server SHOULD immediately send an event with an id so the client can
+    /// reconnect with `Last-Event-ID`). Returns the handle and the priming
+    /// event.
+    pub fn open(
+        self: &Arc<Self>,
+        prime_event_type: &str,
+        prime_data: String,
+    ) -> (StreamHandle, StoredEvent) {
+        let (tx, rx) = mpsc::channel(self.config.channel_capacity);
+        let mut inner = self.inner.lock().expect("stream registry lock");
+        Self::reap(&mut inner, &self.config);
+        let id = inner.next_stream_id;
+        inner.next_stream_id += 1;
+        let mut slot = StreamSlot {
+            id,
+            seq: 0,
+            buffer: VecDeque::new(),
+            sender: Some(tx),
+            opened: Instant::now(),
+            died: None,
+        };
+        let prime = slot.store(prime_event_type, prime_data, &self.config);
+        inner.streams.push(slot);
+        drop(inner);
+        (
+            StreamHandle {
+                stream_id: id,
+                rx,
+                registry: Arc::clone(self),
+            },
+            prime,
+        )
+    }
+
+    /// Resume the stream named by `last_event_id` (`{stream_id}-{seq}`),
+    /// returning a fresh handle for the SAME stream identity plus the
+    /// buffered events after the cursor. `None` if the id does not parse, the
+    /// stream is unknown, or its buffer has been reaped.
+    ///
+    /// A resumed stream keeps its id — and therefore its designation if it
+    /// was the designated stream.
+    pub fn resume(
+        self: &Arc<Self>,
+        last_event_id: &str,
+    ) -> Option<(StreamHandle, Vec<StoredEvent>)> {
+        let (stream_id, seq) = parse_event_id(last_event_id)?;
+        let (tx, rx) = mpsc::channel(self.config.channel_capacity);
+        let mut inner = self.inner.lock().expect("stream registry lock");
+        Self::reap(&mut inner, &self.config);
+        let slot = inner.streams.iter_mut().find(|s| s.id == stream_id)?;
+        slot.sender = Some(tx);
+        slot.died = None;
+        let replay = slot
+            .buffer
+            .iter()
+            .filter(|(_, e)| parse_event_id(&e.id).is_some_and(|(_, s)| s > seq))
+            .map(|(_, e)| e.clone())
+            .collect();
+        drop(inner);
+        Some((
+            StreamHandle {
+                stream_id,
+                rx,
+                registry: Arc::clone(self),
+            },
+            replay,
+        ))
+    }
+
+    /// Store `data` on the designated stream (the oldest live one) and queue
+    /// it for delivery, returning the allocated event id. `None` when the
+    /// session has no live stream.
+    ///
+    /// A full channel kills the stream (explicitly, never a silent skip); the
+    /// event stays in that stream's buffer, so the client's resumption GET
+    /// replays it. The event is NOT re-sent on another stream — it belongs to
+    /// the stream it was stored on (spec: no cross-stream replay).
+    #[must_use]
+    pub fn send(&self, event_type: &str, data: String) -> Option<String> {
+        let mut inner = self.inner.lock().expect("stream registry lock");
+        Self::reap(&mut inner, &self.config);
+        let config = &self.config;
+        let slot = inner
+            .streams
+            .iter_mut()
+            .filter(|s| s.sender.is_some())
+            .min_by_key(|s| s.opened)?;
+        let event = slot.store(event_type, data, config);
+        if let Some(sender) = &slot.sender {
+            match sender.try_send(event.clone()) {
+                Ok(()) => {}
+                Err(mpsc::error::TrySendError::Full(_) | mpsc::error::TrySendError::Closed(_)) => {
+                    // Kill the stream; the client resumes and replays from
+                    // the retained buffer.
+                    slot.sender = None;
+                    slot.died = Some(Instant::now());
+                }
+            }
+        }
+        Some(event.id)
+    }
+
+    /// Whether any stream is currently live.
+    #[must_use]
+    pub fn has_live_stream(&self) -> bool {
+        self.inner
+            .lock()
+            .expect("stream registry lock")
+            .streams
+            .iter()
+            .any(|s| s.sender.is_some())
+    }
+
+    fn mark_dead(&self, stream_id: u64) {
+        if let Ok(mut inner) = self.inner.lock() {
+            if let Some(slot) = inner.streams.iter_mut().find(|s| s.id == stream_id) {
+                slot.sender = None;
+                slot.died = Some(Instant::now());
+            }
+        }
+    }
+
+    /// Drop dead streams whose retention window has passed.
+    fn reap(inner: &mut Inner, config: &StreamConfig) {
+        inner.streams.retain(|s| {
+            s.sender.is_some() || s.died.is_none_or(|at| at.elapsed() < config.max_age)
+        });
+    }
+}
+
+/// Parse a `{stream_id}-{seq}` event id.
+fn parse_event_id(id: &str) -> Option<(u64, u64)> {
+    let (stream, seq) = id.split_once('-')?;
+    Some((stream.parse().ok()?, seq.parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry() -> Arc<StreamRegistry> {
+        Arc::new(StreamRegistry::new(StreamConfig::default()))
+    }
+
+    #[tokio::test]
+    async fn send_delivers_to_exactly_one_stream() {
+        let reg = registry();
+        let (mut a, _) = reg.open("connected", "sid".into());
+        let (mut b, _) = reg.open("connected", "sid".into());
+
+        let id = reg.send("message", "hello".into()).expect("live stream");
+        // Designated = oldest live = stream a.
+        let got = a.recv().await.expect("delivered");
+        assert_eq!(got.id, id);
+        assert_eq!(got.data, "hello");
+        // Stream b must NOT receive it (spec MUST-NOT broadcast).
+        assert!(
+            tokio::time::timeout(Duration::from_millis(50), b.recv())
+                .await
+                .is_err(),
+            "second stream must not receive the message"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_ids_encode_stream_and_sequence() {
+        let reg = registry();
+        let (_a, prime) = reg.open("connected", "sid".into());
+        assert_eq!(prime.id, "1-0");
+        let id1 = reg.send("message", "x".into()).unwrap();
+        let id2 = reg.send("message", "y".into()).unwrap();
+        assert_eq!(id1, "1-1");
+        assert_eq!(id2, "1-2");
+    }
+
+    #[tokio::test]
+    async fn resume_replays_only_same_stream_events_after_cursor() {
+        let reg = registry();
+        let (a, _) = reg.open("connected", "sid".into());
+        let id1 = reg.send("message", "one".into()).unwrap();
+        let _id2 = reg.send("message", "two".into()).unwrap();
+        drop(a); // stream dies
+
+        // A different stream's traffic must not appear in stream 1's replay.
+        let (_b, _) = reg.open("connected", "sid".into());
+        let _ = reg.send("message", "other-stream".into()).unwrap();
+
+        let (_a2, replay) = reg.resume(&id1).expect("resumable");
+        assert_eq!(replay.len(), 1, "only events after the cursor: {replay:?}");
+        assert_eq!(replay[0].data, "two");
+    }
+
+    #[tokio::test]
+    async fn resumed_stream_keeps_designation() {
+        let reg = registry();
+        let (a, prime) = reg.open("connected", "sid".into());
+        let (_b, _) = reg.open("connected", "sid".into());
+        drop(a);
+
+        // Stream 1 resumes; as the oldest it is designated again.
+        let (mut a2, _) = reg.resume(&prime.id).expect("resumable");
+        let id = reg.send("message", "after-resume".into()).unwrap();
+        assert!(
+            id.starts_with("1-"),
+            "designated must still be stream 1: {id}"
+        );
+        assert_eq!(a2.recv().await.unwrap().data, "after-resume");
+    }
+
+    #[tokio::test]
+    async fn overflow_kills_stream_and_replay_recovers() {
+        let reg = Arc::new(StreamRegistry::new(StreamConfig {
+            channel_capacity: 2,
+            ..StreamConfig::default()
+        }));
+        let (a, prime) = reg.open("connected", "sid".into());
+
+        // Fill the channel (capacity 2) without a reader, then overflow.
+        let _ = reg.send("message", "m1".into()).unwrap();
+        let _ = reg.send("message", "m2".into()).unwrap();
+        let id3 = reg.send("message", "m3".into()).unwrap();
+        assert!(!reg.has_live_stream(), "overflow must kill the stream");
+
+        // The overflowed event is in the buffer: resume from the prime id
+        // replays everything, including m3.
+        drop(a);
+        let (_a2, replay) = reg.resume(&prime.id).expect("resumable");
+        assert_eq!(replay.last().map(|e| e.id.as_str()), Some(id3.as_str()));
+        assert_eq!(replay.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn no_live_stream_returns_none() {
+        let reg = registry();
+        assert!(reg.send("message", "x".into()).is_none());
+        let (a, _) = reg.open("connected", "sid".into());
+        drop(a);
+        assert!(
+            reg.send("message", "x".into()).is_none(),
+            "a dead stream is not a delivery target"
+        );
+    }
+
+    #[tokio::test]
+    async fn dead_stream_buffer_is_reaped_after_max_age() {
+        let reg = Arc::new(StreamRegistry::new(StreamConfig {
+            max_age: Duration::from_millis(10),
+            ..StreamConfig::default()
+        }));
+        let (a, prime) = reg.open("connected", "sid".into());
+        drop(a);
+        tokio::time::sleep(Duration::from_millis(30)).await;
+        // Access triggers the reap; the stream identity is gone.
+        let _ = reg.send("message", "x".into());
+        assert!(
+            reg.resume(&prime.id).is_none(),
+            "expired dead stream must not be resumable"
+        );
+    }
+
+    #[tokio::test]
+    async fn handle_drop_marks_stream_dead() {
+        let reg = registry();
+        let (a, _) = reg.open("connected", "sid".into());
+        assert!(reg.has_live_stream());
+        drop(a);
+        assert!(!reg.has_live_stream());
+    }
+}


### PR DESCRIPTION
PR 2 of the #153 design v3 (axum-first). Leave #153 open.

## The shared module

`mcpkit_server::streams` — the stream-registry/event-id/replay logic as **one implementation** next to the other shared adapter helpers, per review round 2's Q1 resolution ("don't let PR 2 land four copies of the replay logic, because that is exactly the code where round 1 found a bug"). Enforces, with unit tests for each:

- **One message → exactly one stream** (spec MUST NOT broadcast): bounded per-stream `mpsc` channels; delivery to the *designated* stream — oldest live, stable across later GETs, identity (and designation) preserved across resume.
- **`{stream_id}-{seq}` ids allocated once at store time** — wire id ≡ stored id, so `Last-Event-ID` actually finds its cursor (round 1, C4: axum allocated ids twice and replay returned the whole buffer from index 0).
- **Same-stream-only replay** (spec MUST NOT replay across streams), with dead-stream buffers retained for `max_age` (300s default) and an unknown/expired cursor opening a fresh stream rather than guessing.
- **Explicit stream-kill on overflow** — never a silent skip (round 1, C6); the killed stream's buffer survives, so the client resumes and replays what the dead channel missed (tested end-to-end: overflow → kill → resume → the overflowed event arrives).
- **Bounded channels only** — round 2, N7: no unbounded option on a public endpoint.

## axum adoption

`Session.streams` (registry) replaces PR 1's interim `tx`/`events` pair; the SSE handler opens/resumes registry streams; **`retry: 2000`** rides the first event of every stream (round 2, Q2: the spec says clients MUST respect `retry`, so reconnect cadence is dictated, not guessed — which is what makes the 5s reconnect grace in PR 3 defensible). Selection policy, resumption-inherits-designation, and overflow behavior are exactly §4.5 of the design as pinned in round 2 (N6/N7).

**Breaking (axum):** `EventStore`/`EventStoreConfig` removed; `SessionStore::{subscribe, events, send_with_storage, events_for_replay, with_event_store_config}` → `{streams, send_event, with_stream_config}`; shared types re-exported from mcpkit-axum.

Sequencing note: this lands the MUST-NOT-broadcast fix **before** any server-initiated request ever rides a stream (PR 3+), exactly as the reviewed design ordered — a duplicated notification was latent; a duplicated elicitation would have been a double user prompt with an unresolvable second response.

## Tests

8 registry unit tests (single-delivery, id encoding, same-stream replay-after-cursor, designation-preserving resume, overflow-kill-then-recover, no-live-stream, retention reaping, drop-marks-dead) + rewritten axum session tests (send/receive via registry, no-live-stream drop, replay-after-death) + the existing sse_binding E2E suite unchanged-and-green. Full local gate: fmt, clippy `-D warnings` (1.97), rustdoc, 75 suites.

Refs #153.