### PR TITLE
feat(axum): wire the session peer — server-initiated requests over HTTP (#153 PR 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Server-initiated requests work over the axum adapter** (#153 PR 4) — the
+  design's headline defect closed: `Context` in the request path now carries
+  a real `SessionPeer` instead of `NoOpPeer`, so a plain tool handler can
+  `ctx.elicit()` / `ctx.list_roots()` (and sampling) over HTTP. The JSON-RPC
+  request rides the session's SSE stream; the client answers with a response
+  POST, which is now correlated against the session's pending
+  server-initiated requests (previously logged and dropped). Inbound client
+  notifications dispatch to the `ServerHandler` hooks (`on_initialized`,
+  `on_roots_list_changed`) off the request path via a per-session task set —
+  the shared `dispatch_notification_hooks` helper now backs the stdio
+  runtime's routing too, so the hook surface is wired identically
+  everywhere. New: a DELETE handler terminates the session per spec (204;
+  pending server-initiated requests fail immediately via the session's
+  `OutboundOwner`; subsequent requests 404), and
+  `McpRouter::with_peer_timeouts` configures the per-method-class request
+  timeouts. Mid-`tools/call` elicitation on the GET stream is a documented
+  SHOULD-deviation until a POST-SSE upgrade exists
+  ([#153](https://github.com/praxiomlabs/mcpkit/issues/153)).
+
+### Added
+
 - `mcpkit_server::adapter_peer` — the server->client request/response peer
   primitive for the HTTP adapters (#153 PR 3): `SessionOutbound` (per-session
   outbound-id allocation + oneshot response correlation; the stdio runtime's

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -38,6 +38,82 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
+/// Delivers peer messages onto the session's SSE stream registry.
+struct SessionStreamSink {
+    registry: Arc<mcpkit_server::streams::StreamRegistry>,
+}
+
+impl mcpkit_server::adapter_peer::SessionSink for SessionStreamSink {
+    fn send_notification(
+        &self,
+        message: Message,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), mcpkit_server::adapter_peer::SinkError>>
+                + Send
+                + '_,
+        >,
+    > {
+        Box::pin(async move {
+            let json = serde_json::to_string(&message).map_err(|e| {
+                mcpkit_server::adapter_peer::SinkError::Serialization(e.to_string())
+            })?;
+            // Best-effort: with no live stream the notification is dropped
+            // (runtime parity — a client without a stream misses it).
+            let _ = self.registry.send("message", json);
+            Ok(())
+        })
+    }
+
+    fn send_request(
+        &self,
+        message: Message,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = Result<(), mcpkit_server::adapter_peer::SinkError>>
+                + Send
+                + '_,
+        >,
+    > {
+        Box::pin(async move {
+            let json = serde_json::to_string(&message).map_err(|e| {
+                mcpkit_server::adapter_peer::SinkError::Serialization(e.to_string())
+            })?;
+            self.registry
+                .send("message", json)
+                .map(|_| ())
+                .ok_or(mcpkit_server::adapter_peer::SinkError::NoClientStream)
+        })
+    }
+
+    fn has_live_stream(&self) -> bool {
+        self.registry.has_live_stream()
+    }
+}
+
+/// Build the request-capable peer for a session (#153 PR 4).
+///
+/// Takes the session's parts rather than a `Session` snapshot so callers can
+/// drop the snapshot before awaiting: a snapshot holds the session's
+/// `Arc<OutboundOwner>`, and a request awaiting a peer response while holding
+/// one would keep the owner alive — preventing DELETE/reap from failing that
+/// very request.
+fn session_peer<H>(
+    state: &McpState<H>,
+    streams: Arc<mcpkit_server::streams::StreamRegistry>,
+    outbound: Arc<mcpkit_server::adapter_peer::SessionOutbound>,
+) -> mcpkit_server::adapter_peer::SessionPeer
+where
+    H: HasServerInfo + Send + Sync + 'static,
+{
+    mcpkit_server::adapter_peer::SessionPeer::new(
+        Arc::new(SessionStreamSink { registry: streams }),
+        outbound,
+        state.peer_timeouts,
+    )
+    .with_reconnect_grace(state.reconnect_grace)
+}
+
 /// Whether this message is an `initialize` request — the only message allowed
 /// to omit `mcp-session-id` (the server assigns the id in its response).
 fn is_initialize(msg: &Message) -> bool {
@@ -172,17 +248,33 @@ where
             // This session's task store (per-session isolation for `tasks/*`).
             let task_store = session.as_ref().map(|s| s.tasks.clone());
             let client_caps = session
-                .and_then(|s| s.client_capabilities)
+                .as_ref()
+                .and_then(|s| s.client_capabilities.clone())
                 .unwrap_or_default();
 
-            // Create a basic response using the handler's capabilities
-            // In a full implementation, this would route to the handler's methods
+            // Route with a request-capable peer (#153 PR 4): handlers can
+            // call ctx.elicit()/ctx.list_roots()/sampling; the request rides
+            // the session's SSE stream and the client answers via a response
+            // POST correlated below.
+            let peer: Box<dyn mcpkit_server::Peer> = match &session {
+                Some(s) => Box::new(session_peer(
+                    &state,
+                    Arc::clone(&s.streams),
+                    Arc::clone(s.outbound_owner.outbound()),
+                )),
+                None => Box::new(NoOpPeer),
+            };
+            // Release the snapshot before awaiting: it holds the session's
+            // OutboundOwner, and a request blocked in ctx.elicit() must not
+            // keep DELETE/reap from failing its own pending request.
+            drop(session);
             let response = create_response_for_request(
                 &state,
                 &request,
                 protocol_version,
                 &client_caps,
                 task_store.as_ref(),
+                peer.as_ref(),
             )
             .await;
 
@@ -205,6 +297,43 @@ where
                 session_id = %session_id,
                 "Received notification"
             );
+            // Dispatch to the ServerHandler hooks off the request path
+            // (#153 PR 4): a hook may call ctx.list_roots(), whose response
+            // arrives via a separate POST — the 202 must not wait for that
+            // round-trip. Spawned into the session's JoinSet, whose teardown
+            // aborts in-flight hooks (deliberate: the session is gone).
+            if let Some(session) = state.sessions.get(&session_id) {
+                let state2 = state.clone();
+                let sid = session_id.clone();
+                let method = notification.method.to_string();
+                if let Ok(mut hooks) = session.hooks.lock() {
+                    hooks.spawn(async move {
+                        let Some(session) = state2.sessions.get(&sid) else {
+                            return;
+                        };
+                        let peer = session_peer(
+                            &state2,
+                            Arc::clone(&session.streams),
+                            Arc::clone(session.outbound_owner.outbound()),
+                        );
+                        let client_caps = session.client_capabilities.clone().unwrap_or_default();
+                        let server_caps = state2.effective_capabilities();
+                        let version = session.protocol_version.unwrap_or(ProtocolVersion::LATEST);
+                        // Release the snapshot: a hook blocked in
+                        // ctx.list_roots() must not hold the OutboundOwner.
+                        drop(session);
+                        let ctx =
+                            Context::for_notification(&client_caps, &server_caps, version, &peer);
+                        mcpkit_server::dispatch_notification_hooks(
+                            state2.handler.as_ref(),
+                            &method,
+                            &ctx,
+                        )
+                        .await;
+                        debug!(method = %method, "notification hook completed");
+                    });
+                }
+            }
             (
                 StatusCode::ACCEPTED,
                 [("mcp-session-id", session_id.as_str())],
@@ -219,11 +348,19 @@ where
         // log-and-drop, matching the runtime's `route_response` for ids that
         // match no pending request.
         Message::Response(response) => {
-            debug!(
-                id = %response.id,
-                session_id = %session_id,
-                "Received client response (no pending server-initiated request; dropped)"
-            );
+            // Correlate with a pending server-initiated request (#153 PR 4);
+            // an unmatched id is logged and dropped (runtime parity), and the
+            // spec-mandated 202 is returned either way.
+            let resolved = state
+                .sessions
+                .outbound(&session_id)
+                .is_some_and(|outbound| outbound.resolve(response));
+            if !resolved {
+                debug!(
+                    session_id = %session_id,
+                    "client response matched no pending server-initiated request; dropped"
+                );
+            }
             (
                 StatusCode::ACCEPTED,
                 [("mcp-session-id", session_id.as_str())],
@@ -263,6 +400,7 @@ async fn create_response_for_request<H>(
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
     task_store: Option<&Arc<TaskManager>>,
+    peer: &dyn mcpkit_server::Peer,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -276,14 +414,13 @@ where
     // Create a context for the request
     let req_id = request.id.clone();
     let server_caps = state.effective_capabilities();
-    let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
         None,
         client_caps,
         &server_caps,
         protocol_version,
-        &peer,
+        peer,
     );
 
     match method {
@@ -404,6 +541,41 @@ where
             )
         }
     }
+}
+
+/// Handle MCP DELETE requests: explicit session termination.
+///
+/// Per spec (§Session Management item 5). Removing the session drops its
+/// `OutboundOwner`, so every pending server-initiated request fails
+/// immediately; subsequent requests with the id get 404.
+pub async fn handle_mcp_delete<H>(
+    State(state): State<McpState<H>>,
+    headers: HeaderMap,
+    user: Option<Extension<VerifiedUser>>,
+) -> impl IntoResponse
+where
+    H: HasServerInfo + Send + Sync + 'static,
+{
+    let origin = headers.get("origin").and_then(|v| v.to_str().ok());
+    if !state.origin_validator.is_allowed(origin) {
+        return (StatusCode::FORBIDDEN, "origin not allowed").into_response();
+    }
+    let user = user.map(|Extension(u)| u);
+    let Some(id) = headers
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+    else {
+        return (StatusCode::BAD_REQUEST, "missing mcp-session-id").into_response();
+    };
+    match state.sessions.get_verified(&id, user.as_ref()) {
+        Ok(Some(_)) => {}
+        Ok(None) => return (StatusCode::NOT_FOUND, "unknown session id").into_response(),
+        Err(e) => return (StatusCode::FORBIDDEN, e.to_string()).into_response(),
+    }
+    let _ = state.sessions.remove(&id);
+    info!(session_id = %id, "Session terminated by client DELETE");
+    StatusCode::NO_CONTENT.into_response()
 }
 
 /// Handle SSE connections for server-to-client streaming.

--- a/crates/mcpkit-axum/src/lib.rs
+++ b/crates/mcpkit-axum/src/lib.rs
@@ -100,7 +100,9 @@ mod session;
 mod state;
 
 pub use error::ExtensionError;
-pub use handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
+pub use handler::{
+    handle_mcp_delete, handle_mcp_post, handle_oauth_protected_resource, handle_sse,
+};
 pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 pub use router::McpRouter;
 pub use session::{DEFAULT_INIT_TIMEOUT, Session, SessionStore};
@@ -115,7 +117,9 @@ pub use state::{McpState, OAuthState};
 /// ```
 pub mod prelude {
     pub use crate::error::ExtensionError;
-    pub use crate::handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
+    pub use crate::handler::{
+        handle_mcp_delete, handle_mcp_post, handle_oauth_protected_resource, handle_sse,
+    };
     pub use crate::router::McpRouter;
     pub use crate::session::{DEFAULT_INIT_TIMEOUT, Session, SessionStore};
     pub use crate::state::{McpState, OAuthState};

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -1,6 +1,8 @@
 //! Router builder for MCP endpoints.
 
-use crate::handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
+use crate::handler::{
+    handle_mcp_delete, handle_mcp_post, handle_oauth_protected_resource, handle_sse,
+};
 use crate::state::{HasServerInfo, McpState, OAuthState};
 use axum::Router;
 use axum::routing::{get, post};
@@ -189,6 +191,35 @@ where
         self
     }
 
+    /// Set the timeouts for server-initiated (peer) requests.
+    #[must_use]
+    pub fn with_peer_timeouts(
+        mut self,
+        timeouts: mcpkit_server::adapter_peer::PeerTimeouts,
+    ) -> Self {
+        self.state.peer_timeouts = timeouts;
+        self
+    }
+
+    /// Override the peer reconnect grace. Test hook — the grace is a fixed
+    /// constant by design.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_reconnect_grace(mut self, grace: std::time::Duration) -> Self {
+        self.state.reconnect_grace = grace;
+        self
+    }
+
+    /// The router's shared state. Test hook.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn state(&self) -> McpState<H>
+    where
+        McpState<H>: Clone,
+    {
+        self.state.clone()
+    }
+
     /// Build the router.
     pub fn into_router(self) -> Router {
         // Spec: a single MCP endpoint serves both POST and GET (#172). The
@@ -196,7 +227,9 @@ where
         let mut router = Router::new()
             .route(
                 &self.post_path,
-                post(handle_mcp_post::<H>).get(handle_sse::<H>),
+                post(handle_mcp_post::<H>)
+                    .get(handle_sse::<H>)
+                    .delete(handle_mcp_delete::<H>),
             )
             .route(&self.sse_path, get(handle_sse::<H>))
             .with_state(self.state);

--- a/crates/mcpkit-axum/src/session.rs
+++ b/crates/mcpkit-axum/src/session.rs
@@ -4,6 +4,7 @@ use dashmap::DashMap;
 use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
+use mcpkit_server::adapter_peer::{OutboundOwner, SessionOutbound};
 use mcpkit_server::streams::{StreamConfig, StreamRegistry};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -35,6 +36,15 @@ pub struct Session {
     /// same-stream `Last-Event-ID` replay — shared adapter logic from
     /// `mcpkit_server::streams`.
     pub streams: Arc<StreamRegistry>,
+    /// Owner of this session's outbound-request registry (#153 PR 4). When
+    /// the session is removed (reap or DELETE) the owner drops and every
+    /// pending server-initiated request fails immediately, so waiting hooks
+    /// and tools resolve instead of running out their timeout.
+    pub outbound_owner: Arc<OutboundOwner>,
+    /// In-flight notification-hook tasks for this session. Dropped (and
+    /// thereby ABORTED — deliberate) on session teardown: the session and
+    /// its peer are gone, so a hook mid-request has nothing valid to await.
+    pub hooks: Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>,
 }
 
 impl Session {
@@ -58,6 +68,8 @@ impl Session {
             user,
             tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
             streams: Arc::new(StreamRegistry::new(StreamConfig::default())),
+            outbound_owner: Arc::new(OutboundOwner::new()),
+            hooks: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
         }
     }
 
@@ -168,6 +180,15 @@ impl SessionStore {
     #[must_use]
     pub fn send_event(&self, id: &str, event_type: &str, message: String) -> Option<String> {
         self.sessions.get(id)?.streams.send(event_type, message)
+    }
+
+    /// The outbound-request registry for a session (server-initiated request
+    /// correlation). `None` if the session is unknown.
+    #[must_use]
+    pub fn outbound(&self, id: &str) -> Option<Arc<SessionOutbound>> {
+        self.sessions
+            .get(id)
+            .map(|s| Arc::clone(s.outbound_owner.outbound()))
     }
 
     /// Create a new session and return its ID.

--- a/crates/mcpkit-axum/src/state.rs
+++ b/crates/mcpkit-axum/src/state.rs
@@ -25,6 +25,11 @@ pub struct McpState<H> {
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
+    /// Timeouts for server-initiated (peer) requests, by method class.
+    pub peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts,
+    /// Reconnect grace for peer requests. Fixed by design; overridable only
+    /// for tests via `McpRouter::with_reconnect_grace`.
+    pub(crate) reconnect_grace: std::time::Duration,
     /// Page size for `*/list` results; `None` disables pagination.
     pub list_page_size: Option<usize>,
     /// Optional completion handler for `completion/complete`.
@@ -39,6 +44,8 @@ impl<H> Clone for McpState<H> {
             server_info: self.server_info.clone(),
             sessions: Arc::clone(&self.sessions),
             origin_validator: Arc::clone(&self.origin_validator),
+            peer_timeouts: self.peer_timeouts,
+            reconnect_grace: self.reconnect_grace,
             list_page_size: self.list_page_size,
             completion: self.completion.clone(),
         }
@@ -53,6 +60,8 @@ impl<H> fmt::Debug for McpState<H> {
             .field("server_info", &self.server_info)
             .field("sessions", &self.sessions)
             .field("origin_validator", &self.origin_validator)
+            .field("peer_timeouts", &self.peer_timeouts)
+            .field("reconnect_grace", &self.reconnect_grace)
             .field("list_page_size", &self.list_page_size)
             .field(
                 "completion",
@@ -74,6 +83,8 @@ impl<H> McpState<H> {
             server_info,
             sessions: Arc::new(SessionStore::with_default_timeout()),
             origin_validator: Arc::new(OriginValidator::default()),
+            peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts::default(),
+            reconnect_grace: mcpkit_server::adapter_peer::RECONNECT_GRACE,
             list_page_size: None,
             completion: None,
         }
@@ -90,6 +101,8 @@ impl<H> McpState<H> {
             server_info,
             sessions: Arc::new(sessions),
             origin_validator: Arc::new(OriginValidator::default()),
+            peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts::default(),
+            reconnect_grace: mcpkit_server::adapter_peer::RECONNECT_GRACE,
             list_page_size: None,
             completion: None,
         }

--- a/crates/mcpkit-axum/tests/peer_e2e.rs
+++ b/crates/mcpkit-axum/tests/peer_e2e.rs
@@ -1,0 +1,386 @@
+//! #153 PR 4 end-to-end: server-initiated requests over the axum adapter.
+//!
+//! The flow these tests pin IS the feature: a handler calls
+//! `ctx.elicit()`/`ctx.list_roots()`, the JSON-RPC request rides the
+//! session's SSE stream, the client answers with a response POST, and the
+//! waiting handler resumes.
+
+use axum::Extension;
+use axum::extract::State;
+use axum::http::{HeaderMap, HeaderValue};
+use axum::response::IntoResponse;
+use mcpkit_axum::{McpRouter, McpState};
+use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    ElicitRequest, ElicitationSchema, GetPromptResult, Prompt, Resource, ResourceContents, Root,
+    Tool, ToolOutput,
+};
+use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Clone, Default)]
+struct Observed {
+    initialized: Arc<AtomicBool>,
+    roots: Arc<Mutex<Option<Result<Vec<Root>, String>>>>,
+}
+
+#[derive(Clone)]
+struct H(Observed);
+
+impl ServerHandler for H {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("t", "1.0.0")
+    }
+    async fn on_initialized(&self, _ctx: &Context<'_>) {
+        self.0.initialized.store(true, Ordering::SeqCst);
+    }
+    async fn on_roots_list_changed(&self, ctx: &Context<'_>) {
+        let result = ctx.list_roots().await.map_err(|e| e.to_string());
+        *self.0.roots.lock().unwrap() = Some(result);
+    }
+}
+impl ToolHandler for H {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![Tool::new("ask")])
+    }
+    async fn call_tool(
+        &self,
+        name: &str,
+        _args: serde_json::Map<String, serde_json::Value>,
+        ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        match name {
+            "ask" => {
+                let schema = serde_json::from_value::<ElicitationSchema>(
+                    serde_json::json!({ "type": "object", "properties": {} }),
+                )
+                .expect("schema");
+                match ctx.elicit(ElicitRequest::new("pick a color", schema)).await {
+                    Ok(result) => Ok(ToolOutput::text(format!(
+                        "elicited: {}",
+                        serde_json::to_value(&result)
+                            .unwrap_or_default()
+                            .get("content")
+                            .and_then(|c| c.get("answer"))
+                            .and_then(|a| a.as_str())
+                            .unwrap_or("<none>")
+                    ))),
+                    Err(e) => Ok(ToolOutput::text(format!("elicit failed: {e}"))),
+                }
+            }
+            other => Err(McpError::method_not_found(other)),
+        }
+    }
+}
+impl ResourceHandler for H {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for H {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Err(McpError::method_not_found(name))
+    }
+}
+
+fn test_state() -> (McpState<H>, Observed) {
+    let observed = Observed::default();
+    let state = McpRouter::new(H(observed.clone()))
+        .with_reconnect_grace(Duration::from_millis(100))
+        .state();
+    (state, observed)
+}
+
+async fn post(
+    state: &McpState<H>,
+    session: Option<&str>,
+    body: serde_json::Value,
+) -> (serde_json::Value, Option<String>) {
+    let mut headers = HeaderMap::new();
+    if let Some(s) = session {
+        headers.insert("mcp-session-id", HeaderValue::from_str(s).expect("sid"));
+    }
+    let response = mcpkit_axum::handle_mcp_post(
+        State(state.clone()),
+        headers,
+        None::<Extension<mcpkit_core::auth::VerifiedUser>>,
+        body.to_string(),
+    )
+    .await
+    .into_response();
+    let sid = response
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body");
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (json, sid)
+}
+
+async fn init(state: &McpState<H>) -> String {
+    let (_, sid) = post(
+        state,
+        None,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": { "roots": {}, "elicitation": {} }
+            }
+        }),
+    )
+    .await;
+    sid.expect("session id")
+}
+
+/// Pull the next JSON-RPC message off the session's SSE stream.
+async fn next_stream_request(
+    handle: &mut mcpkit_server::streams::StreamHandle,
+) -> serde_json::Value {
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), handle.recv())
+            .await
+            .expect("stream event within 5s")
+            .expect("stream open");
+        if event.event_type == "message" {
+            return serde_json::from_str(&event.data).expect("json-rpc message");
+        }
+    }
+}
+
+/// The §4.7 headline: a plain tool elicits over HTTP and completes when the
+/// client POSTs the response.
+#[tokio::test]
+async fn tool_elicitation_round_trips_over_the_stream() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+
+    // "Connect" the client's SSE stream.
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    // Call the tool concurrently; it blocks in ctx.elicit().
+    let call = {
+        let state = state.clone();
+        let sid = sid.clone();
+        tokio::spawn(async move {
+            post(
+                &state,
+                Some(&sid),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": { "name": "ask", "arguments": {} }
+                }),
+            )
+            .await
+            .0
+        })
+    };
+
+    // The elicitation request appears on the stream.
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+    let request_id = request["id"].clone();
+
+    // The client answers via a response POST -> 202.
+    let (resp, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "action": "accept", "content": { "answer": "blue" } }
+        }),
+    )
+    .await;
+    assert_eq!(resp, serde_json::Value::Null, "202 has no body");
+
+    // The tool resumed with the elicited value.
+    let result = call.await.expect("join");
+    let text = result["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert_eq!(text, "elicited: blue", "tool result: {result}");
+}
+
+/// The #141/#153 notification consumer: roots/list_changed -> hook ->
+/// ctx.list_roots() -> stream -> response POST -> hook observes the roots.
+#[tokio::test]
+async fn roots_hook_round_trips_over_the_stream() {
+    let (state, observed) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let (_, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/roots/list_changed" }),
+    )
+    .await;
+
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "roots/list");
+    let request_id = request["id"].clone();
+
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "roots": [{ "uri": "file:///w", "name": "w" }] }
+        }),
+    )
+    .await;
+
+    // The hook observed the client's roots.
+    for _ in 0..100 {
+        if observed.roots.lock().unwrap().is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let roots = observed
+        .roots
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("hook ran")
+        .expect("list_roots succeeded");
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].uri, "file:///w");
+}
+
+#[tokio::test]
+async fn on_initialized_hook_fires() {
+    let (state, observed) = test_state();
+    let sid = init(&state).await;
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+    )
+    .await;
+    for _ in 0..100 {
+        if observed.initialized.load(Ordering::SeqCst) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("on_initialized hook never fired");
+}
+
+/// Without any SSE stream, a peer request fails fast (send-time grace) and
+/// the tool degrades instead of hanging for the request timeout.
+#[tokio::test]
+async fn elicit_without_stream_fails_fast() {
+    let (state, _) = test_state(); // 100ms grace
+    let sid = init(&state).await;
+
+    let started = std::time::Instant::now();
+    let (resp, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "ask", "arguments": {} }
+        }),
+    )
+    .await;
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.starts_with("elicit failed:"), "got: {resp}");
+    assert!(
+        started.elapsed() < Duration::from_secs(30),
+        "must fail at the grace, not the elicitation timeout"
+    );
+}
+
+/// DELETE terminates the session: pending server-initiated requests fail
+/// immediately and the id is gone (404 afterwards).
+#[tokio::test]
+async fn delete_fails_pending_and_forgets_the_session() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let call = {
+        let state = state.clone();
+        let sid = sid.clone();
+        tokio::spawn(async move {
+            post(
+                &state,
+                Some(&sid),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": { "name": "ask", "arguments": {} }
+                }),
+            )
+            .await
+            .0
+        })
+    };
+    // The elicitation is in flight (visible on the stream), unanswered.
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+
+    // Client terminates the session.
+    let mut headers = HeaderMap::new();
+    headers.insert("mcp-session-id", HeaderValue::from_str(&sid).expect("sid"));
+    let resp = mcpkit_axum::handle_mcp_delete(
+        State(state.clone()),
+        headers,
+        None::<Extension<mcpkit_core::auth::VerifiedUser>>,
+    )
+    .await
+    .into_response();
+    assert_eq!(resp.status(), axum::http::StatusCode::NO_CONTENT);
+
+    // The pending elicitation failed immediately; the tool degraded.
+    let result = tokio::time::timeout(Duration::from_secs(5), call)
+        .await
+        .expect("pending request must fail on DELETE, not run out its timeout")
+        .expect("join");
+    let text = result["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.starts_with("elicit failed:"), "got: {result}");
+
+    // The session id is gone.
+    let (resp, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "id": 9, "method": "ping" }),
+    )
+    .await;
+    assert!(
+        resp.get("result").is_none(),
+        "expected session-not-found, got: {resp}"
+    );
+}

--- a/crates/mcpkit-server/src/lib.rs
+++ b/crates/mcpkit-server/src/lib.rs
@@ -85,8 +85,9 @@ pub use health::{
 };
 pub use metrics::{MethodStats, MetricsSnapshot, ServerMetrics};
 pub use router::{
-    AugmentedTaskOutcome, begin_augmented_task, call_tool_json, route_completion, route_logging,
-    route_prompts, route_resources, route_tools, run_augmented_tool, tool_task_support,
+    AugmentedTaskOutcome, begin_augmented_task, call_tool_json, dispatch_notification_hooks,
+    route_completion, route_logging, route_prompts, route_resources, route_tools,
+    run_augmented_tool, tool_task_support,
 };
 pub use server::{
     RequestRouter, RuntimeConfig, ServerNotifier, ServerRuntime, ServerState, TransportPeer,

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -654,6 +654,28 @@ pub async fn tool_task_support(
         .unwrap_or(TaskSupport::Forbidden)
 }
 
+/// Dispatch an inbound client notification to the server's lifecycle hooks.
+///
+/// Covers `on_initialized` and `on_roots_list_changed`; unknown methods are
+/// a no-op. Shared by the stdio runtime's `RequestRouter::route_notification`
+/// and the HTTP adapters (#153), so the hook surface is wired identically
+/// everywhere.
+pub async fn dispatch_notification_hooks<H: crate::handler::ServerHandler>(
+    handler: &H,
+    method: &str,
+    ctx: &Context<'_>,
+) {
+    match method {
+        "notifications/initialized" => handler.on_initialized(ctx).await,
+        // Only meaningful from a client that advertised the `roots`
+        // capability; ignore it otherwise.
+        "notifications/roots/list_changed" if ctx.client_caps.has_roots() => {
+            handler.on_roots_list_changed(ctx).await;
+        }
+        _ => {}
+    }
+}
+
 /// Run a tool and return its `CallToolResult` as JSON (the `tasks/result`
 /// payload shape). Shared by the stdio runtime and the HTTP adapters.
 pub async fn call_tool_json(

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -1216,15 +1216,7 @@ where
         _params: Option<&serde_json::Value>,
         ctx: &Context<'_>,
     ) {
-        match method {
-            "notifications/initialized" => self.handler().on_initialized(ctx).await,
-            // Only meaningful from a client that advertised the `roots`
-            // capability; ignore it otherwise.
-            "notifications/roots/list_changed" if ctx.client_caps.has_roots() => {
-                self.handler().on_roots_list_changed(ctx).await;
-            }
-            _ => {}
-        }
+        crate::router::dispatch_notification_hooks(self.handler(), method, ctx).await;
     }
 
     async fn route(


### PR DESCRIPTION
PR 4 of the #153 design v3 — the payoff slice. Leave #153 open (PR 5 ports the other adapters; PR 6 injects the peer into background tasks).

## What works now (and is E2E-tested)

**A plain tool calling `ctx.elicit()` over the axum adapter completes**: the elicitation request rides the session's SSE stream, the client POSTs the JSON-RPC response, the correlation registry resolves it, and the tool resumes with the elicited value. This was §1's headline bullet and review round 2's N1 ("as sliced, a plain tool handler calling ctx.elicit() over HTTP is still broken after PR 6") — now §4.7, wired and pinned by its defining E2E.

Also wired:
- **Response POSTs correlate** against the session's `SessionOutbound` (0a's log-and-drop upgraded now that there is something to correlate with).
- **Notification hooks dispatch**: `on_initialized` / `on_roots_list_changed` fire off the request path (spawned into the session's `JoinSet`; teardown aborts in-flight hooks — stated intent per N9). The hook match is extracted into `dispatch_notification_hooks`, which the stdio runtime's `RequestRouter::route_notification` now delegates to — the #141 hook surface is wired identically on both paths, closing #153's original scope.
- **Lifecycle**: `Session` owns the `OutboundOwner`; DELETE (new handler, spec §Session Management item 5) → 204, pending requests fail immediately, id 404s afterwards; reap gets the same for free via `Drop`.
- `McpRouter::with_peer_timeouts` (60s default / 300s elicitation, resolved per method inside the peer).

## The bug the E2E caught

The DELETE test hung: the request handler's own `Session` **snapshot** holds the session's `Arc<OutboundOwner>`, so a request blocked in `ctx.elicit()` kept the owner alive — DELETE removed the map entry but could not fail *that request's own* pending entry. Same self-defeating-`Drop` class as review round 2's N2, one level up. Fixed by extracting the needed `Arc`s (`streams`, inner `SessionOutbound`) and dropping the snapshot before awaiting, in both the request path and the hook tasks; the DELETE E2E went from a 5s hang to 0.10s and now asserts the pending elicitation fails immediately.

## E2E matrix (new `peer_e2e.rs`)

elicit round-trip (headline) · roots/list_changed → hook → `ctx.list_roots()` round-trip · `on_initialized` fires · no-stream elicit fails fast at the grace (not the 300s elicitation timeout) · DELETE fails pending + 404s after. Plus all prior suites green (76 total).

Mid-`tools/call` elicitation on the GET stream remains the documented SHOULD-deviation (§5) until a POST-SSE upgrade exists.

Full local gate: fmt, clippy `-D warnings` (1.97), rustdoc, 76 suites.

Refs #153.