### PR TITLE
feat(actix)!: port to the unified session + stream registry + peer (#153 PR 5a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The actix adapter reaches the axum baseline** (#153 PR 5, first of the
+  three ports): unified session registry (SSE binding enforced against the
+  registry holding the user binding — 400 missing id / 404 unknown-and-never-
+  adopted / 403 mismatched user), GET and DELETE served on the MCP endpoint
+  (old SSE path kept as deprecated alias), per-stream delivery with
+  `{stream_id}-{seq}` event ids, working `Last-Event-ID` replay and
+  `retry: 2000` via the shared `mcpkit_server::streams` registry (actix
+  previously emitted SSE frames with **no event ids at all**), and the
+  session peer: `ctx.elicit()`/`ctx.list_roots()`/sampling work over actix,
+  response POSTs correlate, notification hooks dispatch, and DELETE fails
+  pending requests immediately. The adapter sink is now the shared
+  `StreamRegistrySink` in `mcpkit_server::adapter_peer` (axum refactored onto
+  it too — one sink implementation for all adapters). **Breaking (actix):**
+  `SessionManager`, `EventStore`, `EventStoreConfig`, `McpState.sse_sessions`
+  and `McpState::with_sessions`' second parameter are removed, mirroring the
+  axum migration
+  ([#153](https://github.com/praxiomlabs/mcpkit/issues/153)).
+
+### Added
+
 - **Server-initiated requests work over the axum adapter** (#153 PR 4) — the
   design's headline defect closed: `Context` in the request path now carries
   a real `SessionPeer` instead of `NoOpPeer`, so a plain tool handler can

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -21,6 +21,31 @@ use std::sync::Arc;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
+/// Build the request-capable peer for a session (#153).
+///
+/// Takes the session's parts rather than a `Session` snapshot so callers can
+/// drop the snapshot before awaiting: a snapshot holds the session's
+/// `Arc<OutboundOwner>`, and a request awaiting a peer response while holding
+/// one would keep the owner alive — preventing DELETE/reap from failing that
+/// very request.
+fn session_peer<H>(
+    state: &McpState<H>,
+    streams: Arc<mcpkit_server::streams::StreamRegistry>,
+    outbound: Arc<mcpkit_server::adapter_peer::SessionOutbound>,
+) -> mcpkit_server::adapter_peer::SessionPeer
+where
+    H: HasServerInfo + Send + Sync + 'static,
+{
+    mcpkit_server::adapter_peer::SessionPeer::new(
+        Arc::new(mcpkit_server::adapter_peer::StreamRegistrySink::new(
+            streams,
+        )),
+        outbound,
+        state.peer_timeouts,
+    )
+    .with_reconnect_grace(state.reconnect_grace)
+}
+
 /// Whether this message is an `initialize` request — the only message allowed
 /// to omit `mcp-session-id` (the server assigns the id in its response).
 fn is_initialize(msg: &Message) -> bool {
@@ -148,16 +173,33 @@ where
             // This session's task store (per-session isolation for `tasks/*`).
             let task_store = session.as_ref().map(|s| s.tasks.clone());
             let client_caps = session
-                .and_then(|s| s.client_capabilities)
+                .as_ref()
+                .and_then(|s| s.client_capabilities.clone())
                 .unwrap_or_default();
 
-            // Create a basic response using the handler's capabilities
+            // Route with a request-capable peer (#153): handlers can call
+            // ctx.elicit()/ctx.list_roots()/sampling; the request rides the
+            // session's SSE stream and the client answers via a response POST
+            // correlated below.
+            let peer: Box<dyn mcpkit_server::Peer> = match &session {
+                Some(s) => Box::new(session_peer(
+                    &state,
+                    Arc::clone(&s.streams),
+                    Arc::clone(s.outbound_owner.outbound()),
+                )),
+                None => Box::new(NoOpPeer),
+            };
+            // Release the snapshot before awaiting: it holds the session's
+            // OutboundOwner, and a request blocked in ctx.elicit() must not
+            // keep DELETE/reap from failing its own pending request.
+            drop(session);
             let response = create_response_for_request(
                 &state,
                 &request,
                 protocol_version,
                 &client_caps,
                 task_store.as_ref(),
+                peer.as_ref(),
             )
             .await;
 
@@ -175,23 +217,62 @@ where
                 session_id = %session_id,
                 "Received notification"
             );
+            // Dispatch to the ServerHandler hooks off the request path
+            // (#153): a hook may call ctx.list_roots(), whose response
+            // arrives via a separate POST — the 202 must not wait for that
+            // round-trip.
+            if let Some(session) = state.sessions.get(&session_id) {
+                let state2 = McpState::clone(&state);
+                let sid = session_id.clone();
+                let method = notification.method.to_string();
+                if let Ok(mut hooks) = session.hooks.lock() {
+                    hooks.spawn(async move {
+                        let Some(session) = state2.sessions.get(&sid) else {
+                            return;
+                        };
+                        let peer = session_peer(
+                            &state2,
+                            Arc::clone(&session.streams),
+                            Arc::clone(session.outbound_owner.outbound()),
+                        );
+                        let client_caps = session.client_capabilities.clone().unwrap_or_default();
+                        let server_caps = state2.effective_capabilities();
+                        let version = session.protocol_version.unwrap_or(ProtocolVersion::LATEST);
+                        // Release the snapshot: a hook blocked in
+                        // ctx.list_roots() must not hold the OutboundOwner.
+                        drop(session);
+                        let ctx =
+                            Context::for_notification(&client_caps, &server_caps, version, &peer);
+                        mcpkit_server::dispatch_notification_hooks(
+                            state2.handler.as_ref(),
+                            &method,
+                            &ctx,
+                        )
+                        .await;
+                        debug!(method = %method, "notification hook completed");
+                    });
+                }
+            }
             Ok(HttpResponse::Accepted()
                 .insert_header(("mcp-session-id", session_id))
                 .finish())
         }
         // Spec (Streamable HTTP): a client delivers responses to
-        // server-initiated requests by POSTing them; "if the server accepts
-        // the input, the server MUST return HTTP status code 202 Accepted
-        // with no body". Correlation with a pending server-initiated request
-        // arrives with the session peer (#153); until then this is
-        // log-and-drop, matching the runtime's `route_response` for ids that
-        // match no pending request.
+        // server-initiated requests by POSTing them; the server MUST return
+        // 202 Accepted with no body. Correlated against the session's
+        // pending server-initiated requests (#153); an unmatched id is
+        // logged and dropped (runtime parity).
         Message::Response(response) => {
-            debug!(
-                id = %response.id,
-                session_id = %session_id,
-                "Received client response (no pending server-initiated request; dropped)"
-            );
+            let resolved = state
+                .sessions
+                .outbound(&session_id)
+                .is_some_and(|outbound| outbound.resolve(response));
+            if !resolved {
+                debug!(
+                    session_id = %session_id,
+                    "client response matched no pending server-initiated request; dropped"
+                );
+            }
             Ok(HttpResponse::Accepted()
                 .insert_header(("mcp-session-id", session_id))
                 .finish())
@@ -229,6 +310,7 @@ async fn create_response_for_request<H>(
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
     task_store: Option<&Arc<TaskManager>>,
+    peer: &dyn mcpkit_server::Peer,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -242,14 +324,13 @@ where
     // Create a context for the request
     let req_id = request.id.clone();
     let server_caps = state.effective_capabilities();
-    let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
         None,
         client_caps,
         &server_caps,
         protocol_version,
-        &peer,
+        peer,
     );
 
     match method {
@@ -371,6 +452,38 @@ where
     }
 }
 
+/// Handle MCP DELETE requests: explicit session termination.
+///
+/// Per spec (§Session Management item 5). Removing the session drops its
+/// `OutboundOwner`, so every pending server-initiated request fails
+/// immediately; subsequent requests with the id get 404.
+pub async fn handle_mcp_delete<H>(req: HttpRequest, state: web::Data<McpState<H>>) -> HttpResponse
+where
+    H: HasServerInfo + Send + Sync + 'static,
+{
+    let origin = req.headers().get("origin").and_then(|v| v.to_str().ok());
+    if !state.origin_validator.is_allowed(origin) {
+        return HttpResponse::Forbidden().body("origin not allowed");
+    }
+    let user = req.extensions().get::<VerifiedUser>().cloned();
+    let Some(id) = req
+        .headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+    else {
+        return HttpResponse::BadRequest().body("missing mcp-session-id");
+    };
+    match state.sessions.get_verified(&id, user.as_ref()) {
+        Ok(Some(_)) => {}
+        Ok(None) => return HttpResponse::NotFound().body("unknown session id"),
+        Err(e) => return HttpResponse::Forbidden().body(e.to_string()),
+    }
+    let _ = state.sessions.remove(&id);
+    info!(session_id = %id, "Session terminated by client DELETE");
+    HttpResponse::NoContent().finish()
+}
+
 /// Handle SSE connections for server-to-client streaming.
 ///
 /// This handler establishes a Server-Sent Events connection that can be used
@@ -405,33 +518,50 @@ where
         .and_then(|v| v.to_str().ok())
         .map(String::from);
 
-    // Enforce the session's user binding before replaying buffered events.
-    if let Some(id) = &session_id {
-        if let Err(e) = state.sessions.get_verified(id, user.as_ref()) {
+    // #153: streams attach to the POST-created session. A GET without a
+    // session id is 400 (sessions are assigned at initialize); an unknown id
+    // is 404 per spec (never adopt a client-presented id); a mismatched user
+    // is 403 — enforced against the same registry that holds the binding.
+    let Some(id) = session_id else {
+        warn!("Rejected SSE: missing mcp-session-id");
+        return HttpResponse::BadRequest()
+            .body("missing mcp-session-id (obtain one via initialize)");
+    };
+    match state.sessions.get_verified(&id, user.as_ref()) {
+        Ok(Some(_)) => {}
+        Ok(None) => {
+            warn!(session_id = %id, "Rejected SSE: unknown session id");
+            return HttpResponse::NotFound().body("unknown session id");
+        }
+        Err(e) => {
             warn!(session_id = %id, error = %e, "Rejected SSE: session binding violation");
             return HttpResponse::Forbidden().body(e.to_string());
         }
     }
 
-    let (id, rx) = if let Some(id) = session_id {
-        // Try to reconnect to existing session
-        if let Some(rx) = state.sse_sessions.get_receiver(&id) {
-            info!(session_id = %id, "Reconnected to SSE session");
-            (id, rx)
+    let last_event_id = req
+        .headers()
+        .get("last-event-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from);
+
+    let registry = state.sessions.streams(&id).expect("session verified above");
+    let (handle, replay_events) = if let Some(last_id) = &last_event_id {
+        info!(session_id = %id, last_event_id = %last_id, "Reconnecting with Last-Event-ID");
+        if let Some((handle, replay)) = registry.resume(last_id) {
+            (handle, replay)
         } else {
-            // Session not found, create new
-            let (new_id, rx) = state.sse_sessions.create_session();
-            info!(session_id = %new_id, "Created new SSE session (requested not found)");
-            (new_id, rx)
+            // Unknown or expired stream cursor: open a fresh stream rather
+            // than replaying another stream's events (spec MUST NOT).
+            let (handle, prime) = registry.open("connected", id);
+            (handle, vec![prime])
         }
     } else {
-        let (id, rx) = state.sse_sessions.create_session();
-        info!(session_id = %id, "Created new SSE session");
-        (id, rx)
+        let (handle, prime) = registry.open("connected", id);
+        (handle, vec![prime])
     };
 
-    // Create the SSE stream
-    let stream = create_sse_stream(id, rx);
+    let stream = create_sse_stream(handle, replay_events);
 
     HttpResponse::Ok()
         .content_type("text/event-stream")
@@ -440,40 +570,41 @@ where
         .streaming(stream)
 }
 
+fn sse_frame(stored: &mcpkit_server::streams::StoredEvent, first: bool) -> web::Bytes {
+    // The first event of every stream carries a `retry` hint (spec: the
+    // client MUST respect `retry`), so reconnect cadence is dictated.
+    let retry = if first { "retry: 2000\n" } else { "" };
+    web::Bytes::from(format!(
+        "{retry}id: {}\nevent: {}\ndata: {}\n\n",
+        stored.id, stored.event_type, stored.data
+    ))
+}
+
 fn create_sse_stream(
-    session_id: String,
-    rx: tokio::sync::broadcast::Receiver<String>,
+    handle: mcpkit_server::streams::StreamHandle,
+    replay_events: Vec<mcpkit_server::streams::StoredEvent>,
 ) -> impl futures::Stream<Item = Result<web::Bytes, actix_web::error::Error>> {
-    // First, send the connected event
-    let connected_event = format!("event: connected\ndata: {session_id}\n\n");
+    // Replayed/prime events first (each with its stored id — allocated once,
+    // so the wire id always equals the buffered id).
+    let mut first = true;
+    let replay_frames: Vec<Result<web::Bytes, actix_web::error::Error>> = replay_events
+        .iter()
+        .map(|stored| {
+            let frame = sse_frame(stored, first);
+            first = false;
+            Ok(frame)
+        })
+        .collect();
+    let replay = stream::iter(replay_frames);
 
-    // Create a stream that first yields the connected event, then messages
-    let connected = stream::once(async move { Ok(web::Bytes::from(connected_event)) });
-
-    // Create message stream
-    let messages = stream::unfold(rx, |mut rx| async move {
-        loop {
-            match rx.recv().await {
-                Ok(msg) => {
-                    let event = format!("event: message\ndata: {msg}\n\n");
-                    return Some((
-                        Ok::<_, actix_web::error::Error>(web::Bytes::from(event)),
-                        rx,
-                    ));
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(skipped = n, "SSE client lagged, skipped messages");
-                    // Loop continues naturally
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                    debug!("SSE channel closed");
-                    return None;
-                }
-            }
-        }
+    // Live delivery off the session's per-stream channel.
+    let messages = stream::unfold((handle, first), |(mut handle, first)| async move {
+        let stored = handle.recv().await?;
+        let frame = sse_frame(&stored, first);
+        Some((Ok::<_, actix_web::error::Error>(frame), (handle, false)))
     });
 
-    // Add periodic keep-alive comments
+    // Periodic keep-alive comments.
     let keepalive = stream::unfold((), |()| async {
         tokio::time::sleep(Duration::from_secs(15)).await;
         Some((
@@ -482,8 +613,7 @@ fn create_sse_stream(
         ))
     });
 
-    // Merge the streams (connected first, then interleave messages and keepalive)
-    connected.chain(stream::select(messages, keepalive))
+    replay.chain(stream::select(messages, keepalive))
 }
 
 /// Handle `.well-known/oauth-protected-resource` requests.

--- a/crates/mcpkit-actix/src/lib.rs
+++ b/crates/mcpkit-actix/src/lib.rs
@@ -89,11 +89,13 @@ mod session;
 mod state;
 
 pub use error::ExtensionError;
-pub use handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
+pub use handler::{
+    handle_mcp_delete, handle_mcp_post, handle_oauth_protected_resource, handle_sse,
+};
+pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 pub use router::McpRouter;
 pub use session::{
-    DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionManager, SessionStore,
-    StoredEvent,
+    DEFAULT_INIT_TIMEOUT, DEFAULT_SESSION_TIMEOUT, DEFAULT_SSE_CAPACITY, Session, SessionStore,
 };
 pub use state::{McpState, OAuthState};
 
@@ -106,13 +108,15 @@ pub use state::{McpState, OAuthState};
 /// ```
 pub mod prelude {
     pub use crate::error::ExtensionError;
-    pub use crate::handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
+    pub use crate::handler::{
+        handle_mcp_delete, handle_mcp_post, handle_oauth_protected_resource, handle_sse,
+    };
     pub use crate::router::McpRouter;
     pub use crate::session::{
-        DEFAULT_INIT_TIMEOUT, EventStore, EventStoreConfig, Session, SessionManager, SessionStore,
-        StoredEvent,
+        DEFAULT_INIT_TIMEOUT, DEFAULT_SESSION_TIMEOUT, DEFAULT_SSE_CAPACITY, Session, SessionStore,
     };
     pub use crate::state::{McpState, OAuthState};
+    pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 }
 
 /// Protocol versions supported by this extension.

--- a/crates/mcpkit-actix/src/router.rs
+++ b/crates/mcpkit-actix/src/router.rs
@@ -1,6 +1,8 @@
 //! Router builder for MCP endpoints.
 
-use crate::handler::{handle_mcp_post, handle_oauth_protected_resource, handle_sse};
+use crate::handler::{
+    handle_mcp_delete, handle_mcp_post, handle_oauth_protected_resource, handle_sse,
+};
 use crate::state::{HasServerInfo, McpState, OAuthState};
 use actix_cors::Cors;
 use actix_web::middleware::Logger;
@@ -190,6 +192,32 @@ where
         self
     }
 
+    /// Set the timeouts for server-initiated (peer) requests.
+    #[must_use]
+    pub fn with_peer_timeouts(
+        mut self,
+        timeouts: mcpkit_server::adapter_peer::PeerTimeouts,
+    ) -> Self {
+        self.state.peer_timeouts = timeouts;
+        self
+    }
+
+    /// Override the peer reconnect grace. Test hook — the grace is a fixed
+    /// constant by design.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_reconnect_grace(mut self, grace: std::time::Duration) -> Self {
+        self.state.reconnect_grace = grace;
+        self
+    }
+
+    /// The router's shared state. Test hook.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn state(&self) -> McpState<H> {
+        self.state.clone()
+    }
+
     /// Configure an Actix App with MCP routes.
     ///
     /// This is useful when you need to integrate MCP routes with an existing Actix application.
@@ -200,8 +228,12 @@ where
         let oauth_metadata = self.oauth_metadata.clone();
 
         move |cfg: &mut web::ServiceConfig| {
+            // Spec: a single MCP endpoint serves POST, GET, and DELETE
+            // (#172). The separate SSE path is kept as a deprecated alias.
             cfg.app_data(web::Data::new(state.clone()))
                 .route(&post_path, web::post().to(handle_mcp_post::<H>))
+                .route(&post_path, web::get().to(handle_sse::<H>))
+                .route(&post_path, web::delete().to(handle_mcp_delete::<H>))
                 .route(&sse_path, web::get().to(handle_sse::<H>));
 
             // Add OAuth discovery endpoint if configured

--- a/crates/mcpkit-actix/src/session.rs
+++ b/crates/mcpkit-actix/src/session.rs
@@ -4,21 +4,17 @@ use dashmap::DashMap;
 use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
-use std::collections::VecDeque;
+use mcpkit_server::adapter_peer::{OutboundOwner, SessionOutbound};
+use mcpkit_server::streams::{StreamConfig, StreamRegistry};
 use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use tokio::sync::RwLock;
-use tokio::sync::broadcast;
 
 /// Default session timeout duration (1 hour).
 pub const DEFAULT_SESSION_TIMEOUT: Duration = Duration::from_secs(3600);
 
-/// Default timeout after which a session created but never initialized is
-/// reaped.
-pub const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Default SSE broadcast channel capacity.
+/// Default SSE broadcast channel capacity (superseded by
+/// [`mcpkit_server::streams::StreamConfig::channel_capacity`]; kept for API
+/// continuity).
 pub const DEFAULT_SSE_CAPACITY: usize = 100;
 
 /// A single MCP session.
@@ -43,6 +39,20 @@ pub struct Session {
     /// session so one session cannot read or cancel another's tasks (matching
     /// the stdio runtime's per-connection store).
     pub tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
+    /// This session's SSE stream registry (#153 PR 2): per-stream bounded
+    /// channels, single-stream delivery, `{stream_id}-{seq}` event ids, and
+    /// same-stream `Last-Event-ID` replay — shared adapter logic from
+    /// `mcpkit_server::streams`.
+    pub streams: Arc<StreamRegistry>,
+    /// Owner of this session's outbound-request registry (#153 PR 4). When
+    /// the session is removed (reap or DELETE) the owner drops and every
+    /// pending server-initiated request fails immediately, so waiting hooks
+    /// and tools resolve instead of running out their timeout.
+    pub outbound_owner: Arc<OutboundOwner>,
+    /// In-flight notification-hook tasks for this session. Dropped (and
+    /// thereby ABORTED — deliberate) on session teardown: the session and
+    /// its peer are gone, so a hook mid-request has nothing valid to await.
+    pub hooks: Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>,
 }
 
 impl Session {
@@ -65,6 +75,9 @@ impl Session {
             protocol_version: None,
             user,
             tasks: Arc::new(mcpkit_server::capability::tasks::TaskManager::new()),
+            streams: Arc::new(StreamRegistry::new(StreamConfig::default())),
+            outbound_owner: Arc::new(OutboundOwner::new()),
+            hooks: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
         }
     }
 
@@ -105,392 +118,9 @@ impl Session {
     }
 }
 
-/// A stored SSE event for replay support.
-#[derive(Debug, Clone)]
-pub struct StoredEvent {
-    /// The event ID (globally unique within the session stream).
-    pub id: String,
-    /// The event type (e.g., "message", "connected").
-    pub event_type: String,
-    /// The event data.
-    pub data: String,
-    /// When the event was stored.
-    pub stored_at: Instant,
-}
-
-impl StoredEvent {
-    /// Create a new stored event.
-    #[must_use]
-    pub fn new(id: String, event_type: impl Into<String>, data: impl Into<String>) -> Self {
-        Self {
-            id,
-            event_type: event_type.into(),
-            data: data.into(),
-            stored_at: Instant::now(),
-        }
-    }
-}
-
-/// Configuration for event store retention.
-#[derive(Debug, Clone)]
-pub struct EventStoreConfig {
-    /// Maximum number of events to retain per stream.
-    pub max_events: usize,
-    /// Maximum age of events to retain.
-    pub max_age: Duration,
-}
-
-impl Default for EventStoreConfig {
-    fn default() -> Self {
-        Self {
-            max_events: 1000,
-            max_age: Duration::from_secs(300), // 5 minutes
-        }
-    }
-}
-
-impl EventStoreConfig {
-    /// Create a new event store configuration.
-    #[must_use]
-    pub const fn new(max_events: usize, max_age: Duration) -> Self {
-        Self {
-            max_events,
-            max_age,
-        }
-    }
-
-    /// Set the maximum number of events to retain.
-    #[must_use]
-    pub const fn with_max_events(mut self, max_events: usize) -> Self {
-        self.max_events = max_events;
-        self
-    }
-
-    /// Set the maximum age of events to retain.
-    #[must_use]
-    pub const fn with_max_age(mut self, max_age: Duration) -> Self {
-        self.max_age = max_age;
-        self
-    }
-}
-
-/// Event store for SSE message resumability.
-///
-/// Per the MCP Streamable HTTP specification, servers MAY store events
-/// with IDs to support client reconnection with `Last-Event-ID`.
-#[derive(Debug)]
-pub struct EventStore {
-    events: RwLock<VecDeque<StoredEvent>>,
-    config: EventStoreConfig,
-    next_id: AtomicU64,
-}
-
-impl EventStore {
-    /// Create a new event store with the given configuration.
-    #[must_use]
-    pub fn new(config: EventStoreConfig) -> Self {
-        Self {
-            events: RwLock::new(VecDeque::with_capacity(config.max_events)),
-            config,
-            next_id: AtomicU64::new(1),
-        }
-    }
-
-    /// Create a new event store with default configuration.
-    #[must_use]
-    pub fn with_defaults() -> Self {
-        Self::new(EventStoreConfig::default())
-    }
-
-    /// Generate the next event ID.
-    #[must_use]
-    pub fn next_event_id(&self) -> String {
-        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
-        format!("evt-{id}")
-    }
-
-    /// Store an event with automatic ID generation.
-    ///
-    /// Returns the generated event ID.
-    pub fn store_auto_id(&self, event_type: impl Into<String>, data: impl Into<String>) -> String {
-        let id = self.next_event_id();
-        self.store(id.clone(), event_type, data);
-        id
-    }
-
-    /// Store an event with a specific ID.
-    pub fn store(
-        &self,
-        id: impl Into<String>,
-        event_type: impl Into<String>,
-        data: impl Into<String>,
-    ) {
-        let event = StoredEvent::new(id.into(), event_type, data);
-
-        // Use blocking write since we can't use async in this sync method
-        let mut events = futures::executor::block_on(self.events.write());
-
-        events.push_back(event);
-
-        // Enforce max_events limit
-        while events.len() > self.config.max_events {
-            events.pop_front();
-        }
-
-        // Enforce max_age limit
-        let now = Instant::now();
-        while let Some(front) = events.front() {
-            if now.duration_since(front.stored_at) > self.config.max_age {
-                events.pop_front();
-            } else {
-                break;
-            }
-        }
-    }
-
-    /// Store an event asynchronously.
-    pub async fn store_async(
-        &self,
-        id: impl Into<String>,
-        event_type: impl Into<String>,
-        data: impl Into<String>,
-    ) {
-        let event = StoredEvent::new(id.into(), event_type, data);
-        let mut events = self.events.write().await;
-
-        events.push_back(event);
-
-        // Enforce limits
-        while events.len() > self.config.max_events {
-            events.pop_front();
-        }
-
-        let now = Instant::now();
-        while let Some(front) = events.front() {
-            if now.duration_since(front.stored_at) > self.config.max_age {
-                events.pop_front();
-            } else {
-                break;
-            }
-        }
-    }
-
-    /// Get all events after the specified event ID.
-    ///
-    /// Used for replaying events when a client reconnects with `Last-Event-ID`.
-    pub async fn get_events_after(&self, last_event_id: &str) -> Vec<StoredEvent> {
-        let events = self.events.read().await;
-
-        let start_idx = events
-            .iter()
-            .position(|e| e.id == last_event_id)
-            .map_or(0, |i| i + 1);
-
-        events.iter().skip(start_idx).cloned().collect()
-    }
-
-    /// Get all stored events.
-    pub async fn get_all_events(&self) -> Vec<StoredEvent> {
-        let events = self.events.read().await;
-        events.iter().cloned().collect()
-    }
-
-    /// Get the number of stored events.
-    pub async fn len(&self) -> usize {
-        self.events.read().await.len()
-    }
-
-    /// Check if the store is empty.
-    pub async fn is_empty(&self) -> bool {
-        self.events.read().await.is_empty()
-    }
-
-    /// Clear all stored events.
-    pub async fn clear(&self) {
-        self.events.write().await.clear();
-    }
-
-    /// Clean up expired events.
-    pub async fn cleanup_expired(&self) {
-        let mut events = self.events.write().await;
-        let now = Instant::now();
-        while let Some(front) = events.front() {
-            if now.duration_since(front.stored_at) > self.config.max_age {
-                events.pop_front();
-            } else {
-                break;
-            }
-        }
-    }
-}
-
-/// Session manager for SSE connections.
-///
-/// Manages broadcast channels for pushing messages to SSE clients,
-/// with optional event storage for message resumability.
-#[derive(Debug)]
-pub struct SessionManager {
-    sessions: DashMap<String, broadcast::Sender<String>>,
-    /// Event stores for each session (for SSE resumability).
-    event_stores: DashMap<String, Arc<EventStore>>,
-    /// Configuration for event stores.
-    event_store_config: EventStoreConfig,
-    capacity: usize,
-}
-
-impl Default for SessionManager {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl SessionManager {
-    /// Create a new session manager.
-    #[must_use]
-    pub fn new() -> Self {
-        Self::with_capacity(DEFAULT_SSE_CAPACITY)
-    }
-
-    /// Create a new session manager with custom channel capacity.
-    #[must_use]
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            sessions: DashMap::new(),
-            event_stores: DashMap::new(),
-            event_store_config: EventStoreConfig::default(),
-            capacity,
-        }
-    }
-
-    /// Create a new session manager with custom event store configuration.
-    #[must_use]
-    pub fn with_event_store_config(config: EventStoreConfig) -> Self {
-        Self {
-            sessions: DashMap::new(),
-            event_stores: DashMap::new(),
-            event_store_config: config,
-            capacity: DEFAULT_SSE_CAPACITY,
-        }
-    }
-
-    /// Create a new session and return its ID and receiver.
-    #[must_use]
-    pub fn create_session(&self) -> (String, broadcast::Receiver<String>) {
-        let id = uuid::Uuid::new_v4().to_string();
-        let (tx, rx) = broadcast::channel(self.capacity);
-        self.sessions.insert(id.clone(), tx);
-
-        // Create an event store for this session
-        let event_store = Arc::new(EventStore::new(self.event_store_config.clone()));
-        self.event_stores.insert(id.clone(), event_store);
-
-        (id, rx)
-    }
-
-    /// Get a receiver for an existing session.
-    #[must_use]
-    pub fn get_receiver(&self, id: &str) -> Option<broadcast::Receiver<String>> {
-        self.sessions.get(id).map(|tx| tx.subscribe())
-    }
-
-    /// Get the event store for a session.
-    #[must_use]
-    pub fn get_event_store(&self, id: &str) -> Option<Arc<EventStore>> {
-        self.event_stores.get(id).map(|store| Arc::clone(&store))
-    }
-
-    /// Send a message to a specific session.
-    ///
-    /// Returns `true` if the message was sent, `false` if the session doesn't exist.
-    #[must_use]
-    pub fn send_to_session(&self, id: &str, message: String) -> bool {
-        if let Some(tx) = self.sessions.get(id) {
-            let _ = tx.send(message);
-            true
-        } else {
-            false
-        }
-    }
-
-    /// Send a message to a specific session and store it for replay.
-    ///
-    /// Returns the event ID if the message was sent and stored, `None` if the session doesn't exist.
-    #[must_use]
-    pub fn send_to_session_with_storage(
-        &self,
-        session_id: &str,
-        event_type: impl Into<String>,
-        message: String,
-    ) -> Option<String> {
-        if let Some(tx) = self.sessions.get(session_id) {
-            let event_id = if let Some(store) = self.event_stores.get(session_id) {
-                store.store_auto_id(event_type, message.clone())
-            } else {
-                let store = Arc::new(EventStore::new(self.event_store_config.clone()));
-                let event_id = store.store_auto_id(event_type, message.clone());
-                self.event_stores.insert(session_id.to_string(), store);
-                event_id
-            };
-
-            let _ = tx.send(message);
-            Some(event_id)
-        } else {
-            None
-        }
-    }
-
-    /// Broadcast a message to all sessions.
-    pub fn broadcast(&self, message: String) {
-        for entry in &self.sessions {
-            let _ = entry.value().send(message.clone());
-        }
-    }
-
-    /// Broadcast a message to all sessions with storage.
-    pub fn broadcast_with_storage(&self, event_type: impl Into<String> + Clone, message: String) {
-        for entry in &self.sessions {
-            let session_id = entry.key();
-
-            if let Some(store) = self.event_stores.get(session_id) {
-                store.store_auto_id(event_type.clone(), message.clone());
-            }
-
-            let _ = entry.value().send(message.clone());
-        }
-    }
-
-    /// Remove a session.
-    pub fn remove_session(&self, id: &str) {
-        self.sessions.remove(id);
-        self.event_stores.remove(id);
-    }
-
-    /// Get the number of active sessions.
-    #[must_use]
-    pub fn session_count(&self) -> usize {
-        self.sessions.len()
-    }
-
-    /// Clean up expired events across all sessions.
-    pub async fn cleanup_expired_events(&self) {
-        for entry in &self.event_stores {
-            entry.value().cleanup_expired().await;
-        }
-    }
-
-    /// Get events after the specified event ID for replay.
-    pub async fn get_events_for_replay(
-        &self,
-        session_id: &str,
-        last_event_id: &str,
-    ) -> Option<Vec<StoredEvent>> {
-        if let Some(store) = self.event_stores.get(session_id) {
-            Some(store.get_events_after(last_event_id).await)
-        } else {
-            None
-        }
-    }
-}
+/// Default timeout after which a session created but never initialized is
+/// reaped.
+pub const DEFAULT_INIT_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Thread-safe session store with automatic cleanup.
 ///
@@ -503,6 +133,8 @@ pub struct SessionStore {
     /// Default task retention (ms) applied to each session's task store; `None`
     /// means unlimited. Configure via `McpRouter::with_task_ttl`.
     pub(crate) default_task_ttl: Option<u64>,
+    /// Stream configuration applied to each session's SSE stream registry.
+    stream_config: StreamConfig,
 }
 
 impl SessionStore {
@@ -517,13 +149,14 @@ impl SessionStore {
             timeout,
             init_timeout: DEFAULT_INIT_TIMEOUT,
             default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
+            stream_config: StreamConfig::default(),
         }
     }
 
     /// Create a new session store with a default 1-hour idle timeout.
     #[must_use]
     pub fn with_default_timeout() -> Self {
-        Self::new(DEFAULT_SESSION_TIMEOUT)
+        Self::new(Duration::from_secs(3600))
     }
 
     /// Set the timeout after which a session that never completed
@@ -532,6 +165,38 @@ impl SessionStore {
     pub const fn with_init_timeout(mut self, init_timeout: Duration) -> Self {
         self.init_timeout = init_timeout;
         self
+    }
+
+    /// Set the stream configuration applied to each new session's SSE
+    /// stream registry.
+    #[must_use]
+    pub fn with_stream_config(mut self, config: StreamConfig) -> Self {
+        self.stream_config = config;
+        self
+    }
+
+    /// The SSE stream registry for a session. `None` if the session is
+    /// unknown.
+    #[must_use]
+    pub fn streams(&self, id: &str) -> Option<Arc<StreamRegistry>> {
+        self.sessions.get(id).map(|s| Arc::clone(&s.streams))
+    }
+
+    /// Store `message` on the session's designated stream and queue it for
+    /// delivery, returning the allocated event id. `None` if the session is
+    /// unknown or has no live stream.
+    #[must_use]
+    pub fn send_event(&self, id: &str, event_type: &str, message: String) -> Option<String> {
+        self.sessions.get(id)?.streams.send(event_type, message)
+    }
+
+    /// The outbound-request registry for a session (server-initiated request
+    /// correlation). `None` if the session is unknown.
+    #[must_use]
+    pub fn outbound(&self, id: &str) -> Option<Arc<SessionOutbound>> {
+        self.sessions
+            .get(id)
+            .map(|s| Arc::clone(s.outbound_owner.outbound()))
     }
 
     /// Create a new session and return its ID.
@@ -555,6 +220,7 @@ impl SessionStore {
         session.tasks = Arc::new(
             mcpkit_server::capability::tasks::TaskManager::with_default_ttl(self.default_task_ttl),
         );
+        session.streams = Arc::new(StreamRegistry::new(self.stream_config.clone()));
         self.sessions.insert(id.clone(), session);
         id
     }
@@ -660,6 +326,43 @@ mod tests {
         assert_eq!(session.id, "test-123");
         assert!(!session.initialized);
         assert!(session.client_capabilities.is_none());
+        assert!(session.user.is_none());
+    }
+
+    #[test]
+    fn user_bound_session_enforces_identity() {
+        let store = SessionStore::new(Duration::from_secs(60));
+        let alice = VerifiedUser::new("alice").issuer("https://idp");
+        let bob = VerifiedUser::new("bob").issuer("https://idp");
+
+        let id = store.create_for_user(Some(alice.clone()));
+
+        // Same user: ok.
+        assert_eq!(store.touch_verified(&id, Some(&alice)), Ok(true));
+        assert!(store.get_verified(&id, Some(&alice)).unwrap().is_some());
+        // Different user: mismatch.
+        assert_eq!(
+            store.touch_verified(&id, Some(&bob)),
+            Err(SessionBindingError::IdentityMismatch)
+        );
+        // Missing identity on a bound session: rejected.
+        assert_eq!(
+            store.get_verified(&id, None).unwrap_err(),
+            SessionBindingError::IdentityRequired
+        );
+
+        // Anonymous session: anonymous ok, but a verified identity is rejected
+        // (no silent upgrade).
+        let anon = store.create();
+        assert_eq!(store.touch_verified(&anon, None), Ok(true));
+        assert_eq!(
+            store.touch_verified(&anon, Some(&alice)),
+            Err(SessionBindingError::UnexpectedIdentity)
+        );
+
+        // Unknown session id: not found, not an error.
+        assert_eq!(store.touch_verified("nope", Some(&alice)), Ok(false));
+        assert!(store.get_verified("nope", Some(&alice)).unwrap().is_none());
     }
 
     #[test]
@@ -667,6 +370,7 @@ mod tests {
         let mut session = Session::new("test".to_string());
         assert!(!session.is_expired(Duration::from_secs(60)));
 
+        // Simulate old session by setting last_active in the past
         session.last_active = Instant::now()
             .checked_sub(Duration::from_secs(120))
             .ok_or("Failed to subtract duration")?;
@@ -733,137 +437,58 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_session_manager() {
-        let manager = SessionManager::new();
-        let (id, mut rx) = manager.create_session();
+    async fn session_stream_send_and_receive() -> Result<(), Box<dyn std::error::Error>> {
+        let store = SessionStore::with_default_timeout();
+        let id = store.create();
+        let registry = store.streams(&id).ok_or("session missing")?;
+        let (mut handle, prime) = registry.open("connected", id.clone());
+        assert_eq!(prime.event_type, "connected");
 
-        assert!(manager.send_to_session(&id, "test message".to_string()));
-
-        let msg = rx.recv().await.expect("Should receive message");
-        assert_eq!(msg, "test message");
-
-        manager.remove_session(&id);
-        assert!(!manager.send_to_session(&id, "another".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_event_store_creation() {
-        let store = EventStore::with_defaults();
-        assert!(store.is_empty().await);
-        assert_eq!(store.len().await, 0);
-    }
-
-    #[tokio::test]
-    async fn test_event_store_store_and_retrieve() {
-        let store = EventStore::with_defaults();
-
-        store.store_async("evt-1", "message", "data1").await;
-        store.store_async("evt-2", "message", "data2").await;
-        store.store_async("evt-3", "message", "data3").await;
-
-        assert_eq!(store.len().await, 3);
-
-        let all_events = store.get_all_events().await;
-        assert_eq!(all_events.len(), 3);
-        assert_eq!(all_events[0].id, "evt-1");
-        assert_eq!(all_events[1].id, "evt-2");
-        assert_eq!(all_events[2].id, "evt-3");
-    }
-
-    #[tokio::test]
-    async fn test_event_store_get_events_after() {
-        let store = EventStore::with_defaults();
-
-        store.store_async("evt-1", "message", "data1").await;
-        store.store_async("evt-2", "message", "data2").await;
-        store.store_async("evt-3", "message", "data3").await;
-
-        let events = store.get_events_after("evt-1").await;
-        assert_eq!(events.len(), 2);
-        assert_eq!(events[0].id, "evt-2");
-        assert_eq!(events[1].id, "evt-3");
-
-        let events = store.get_events_after("evt-3").await;
-        assert_eq!(events.len(), 0);
-
-        let events = store.get_events_after("unknown").await;
-        assert_eq!(events.len(), 3);
-    }
-
-    #[tokio::test]
-    async fn test_session_manager_with_event_store() -> Result<(), Box<dyn std::error::Error>> {
-        let manager = SessionManager::new();
-        let (id, _rx) = manager.create_session();
-
-        let store = manager.get_event_store(&id);
-        assert!(store.is_some());
-
-        let store = store.ok_or("Event store not found")?;
-        assert!(store.is_empty().await);
-        Ok(())
-    }
-
-    #[tokio::test]
-    async fn test_session_manager_send_with_storage() -> Result<(), Box<dyn std::error::Error>> {
-        let manager = SessionManager::new();
-        let (id, mut rx) = manager.create_session();
-
-        let event_id =
-            manager.send_to_session_with_storage(&id, "message", "test data".to_string());
+        // Send an event (stored + queued on the designated stream).
+        let event_id = store.send_event(&id, "message", "test message".to_string());
         assert!(event_id.is_some());
 
-        let msg = rx.recv().await?;
-        assert_eq!(msg, "test data");
+        let got = handle.recv().await.ok_or("stream closed")?;
+        assert_eq!(got.data, "test message");
+        assert_eq!(Some(got.id), event_id);
 
-        let store = manager
-            .get_event_store(&id)
-            .ok_or("Event store not found")?;
-        assert_eq!(store.len().await, 1);
-
-        let events = store.get_all_events().await;
-        assert_eq!(events[0].data, "test data");
-        assert_eq!(events[0].event_type, "message");
+        // Unknown session: no registry, no send.
+        assert!(store.streams("nope").is_none());
+        assert!(
+            store
+                .send_event("nope", "message", "x".to_string())
+                .is_none()
+        );
         Ok(())
     }
 
     #[tokio::test]
-    async fn test_session_manager_replay() -> Result<(), Box<dyn std::error::Error>> {
-        let manager = SessionManager::new();
-        let (id, _rx) = manager.create_session();
+    async fn session_without_live_stream_drops_sends() {
+        // The event is not deliverable (send_event -> None) when no GET
+        // stream was ever opened; nothing panics and nothing leaks.
+        let store = SessionStore::with_default_timeout();
+        let id = store.create();
+        assert!(store.send_event(&id, "message", "x".to_string()).is_none());
+    }
 
-        let _ = manager.send_to_session_with_storage(&id, "message", "msg1".to_string());
-        let evt2 = manager.send_to_session_with_storage(&id, "message", "msg2".to_string());
-        let _ = manager.send_to_session_with_storage(&id, "message", "msg3".to_string());
+    #[tokio::test]
+    async fn session_replay_after_stream_death() -> Result<(), Box<dyn std::error::Error>> {
+        let store = SessionStore::with_default_timeout();
+        let id = store.create();
+        let registry = store.streams(&id).ok_or("session missing")?;
+        let (handle, _prime) = registry.open("connected", id.clone());
 
-        let events = manager
-            .get_events_for_replay(&id, &evt2.ok_or("Failed to get event ID")?)
-            .await
-            .ok_or("Failed to get events for replay")?;
+        let evt1 = store
+            .send_event(&id, "message", "msg1".to_string())
+            .ok_or("send failed")?;
+        let _ = store.send_event(&id, "message", "msg2".to_string());
+        drop(handle); // stream dies (client disconnect)
 
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].data, "msg3");
+        // Resume with Last-Event-ID = evt1: replay only what followed, on the
+        // same stream identity.
+        let (_h2, replay) = registry.resume(&evt1).ok_or("not resumable")?;
+        assert_eq!(replay.len(), 1);
+        assert_eq!(replay[0].data, "msg2");
         Ok(())
-    }
-
-    #[test]
-    fn test_event_store_config() {
-        let config = EventStoreConfig::default();
-        assert_eq!(config.max_events, 1000);
-        assert_eq!(config.max_age, Duration::from_secs(300));
-
-        let config = EventStoreConfig::new(500, Duration::from_secs(120))
-            .with_max_events(600)
-            .with_max_age(Duration::from_secs(180));
-
-        assert_eq!(config.max_events, 600);
-        assert_eq!(config.max_age, Duration::from_secs(180));
-    }
-
-    #[test]
-    fn test_stored_event() {
-        let event = StoredEvent::new("evt-123".to_string(), "message", "test data");
-        assert_eq!(event.id, "evt-123");
-        assert_eq!(event.event_type, "message");
-        assert_eq!(event.data, "test data");
     }
 }

--- a/crates/mcpkit-actix/src/state.rs
+++ b/crates/mcpkit-actix/src/state.rs
@@ -1,6 +1,6 @@
 //! Shared state for MCP Actix handlers.
 
-use crate::session::{SessionManager, SessionStore};
+use crate::session::SessionStore;
 use mcpkit_core::auth::ProtectedResourceMetadata;
 use mcpkit_core::capability::{ServerCapabilities, ServerInfo};
 use mcpkit_server::ServerHandler;
@@ -31,13 +31,16 @@ pub struct McpState<H> {
     pub handler: Arc<H>,
     /// Session store for tracking HTTP sessions.
     pub sessions: Arc<SessionStore>,
-    /// Session manager for SSE streaming connections.
-    pub sse_sessions: Arc<SessionManager>,
     /// Server info for the initialize response.
     pub server_info: ServerInfo,
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
+    /// Timeouts for server-initiated (peer) requests, by method class.
+    pub peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts,
+    /// Reconnect grace for peer requests. Fixed by design; overridable only
+    /// for tests via `McpRouter::with_reconnect_grace`.
+    pub(crate) reconnect_grace: std::time::Duration,
     /// Page size for `*/list` results; `None` disables pagination.
     pub list_page_size: Option<usize>,
     /// Optional completion handler for `completion/complete`.
@@ -66,23 +69,25 @@ where
         Self {
             handler: Arc::new(handler),
             sessions: Arc::new(SessionStore::with_default_timeout()),
-            sse_sessions: Arc::new(SessionManager::new()),
             server_info,
             origin_validator: Arc::new(OriginValidator::default()),
+            peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts::default(),
+            reconnect_grace: mcpkit_server::adapter_peer::RECONNECT_GRACE,
             list_page_size: None,
             completion: None,
         }
     }
 
     /// Create new MCP state with custom session configuration.
-    pub fn with_sessions(handler: H, sessions: SessionStore, sse_sessions: SessionManager) -> Self {
+    pub fn with_sessions(handler: H, sessions: SessionStore) -> Self {
         let server_info = handler.server_info();
         Self {
             handler: Arc::new(handler),
             server_info,
             sessions: Arc::new(sessions),
-            sse_sessions: Arc::new(sse_sessions),
             origin_validator: Arc::new(OriginValidator::default()),
+            peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts::default(),
+            reconnect_grace: mcpkit_server::adapter_peer::RECONNECT_GRACE,
             list_page_size: None,
             completion: None,
         }
@@ -94,9 +99,10 @@ impl<H> Clone for McpState<H> {
         Self {
             handler: Arc::clone(&self.handler),
             sessions: Arc::clone(&self.sessions),
-            sse_sessions: Arc::clone(&self.sse_sessions),
             server_info: self.server_info.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
+            peer_timeouts: self.peer_timeouts,
+            reconnect_grace: self.reconnect_grace,
             list_page_size: self.list_page_size,
             completion: self.completion.clone(),
         }

--- a/crates/mcpkit-actix/tests/peer_e2e.rs
+++ b/crates/mcpkit-actix/tests/peer_e2e.rs
@@ -1,0 +1,430 @@
+//! #153 PR 5 (actix port): SSE binding rules + server-initiated requests
+//! end-to-end — the same matrix as the axum `sse_binding`/`peer_e2e` suites.
+
+use actix_web::HttpMessage;
+use actix_web::test::TestRequest;
+use actix_web::web;
+use mcpkit_actix::{McpRouter, McpState};
+use mcpkit_core::auth::VerifiedUser;
+use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    ElicitRequest, ElicitationSchema, GetPromptResult, Prompt, Resource, ResourceContents, Root,
+    Tool, ToolOutput,
+};
+use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Clone, Default)]
+struct Observed {
+    initialized: Arc<AtomicBool>,
+    roots: Arc<Mutex<Option<Result<Vec<Root>, String>>>>,
+}
+
+#[derive(Clone)]
+struct H(Observed);
+
+impl ServerHandler for H {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("t", "1.0.0")
+    }
+    async fn on_initialized(&self, _ctx: &Context<'_>) {
+        self.0.initialized.store(true, Ordering::SeqCst);
+    }
+    async fn on_roots_list_changed(&self, ctx: &Context<'_>) {
+        let result = ctx.list_roots().await.map_err(|e| e.to_string());
+        *self.0.roots.lock().unwrap() = Some(result);
+    }
+}
+impl ToolHandler for H {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![Tool::new("ask")])
+    }
+    async fn call_tool(
+        &self,
+        name: &str,
+        _args: serde_json::Map<String, serde_json::Value>,
+        ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        match name {
+            "ask" => {
+                let schema = serde_json::from_value::<ElicitationSchema>(
+                    serde_json::json!({ "type": "object", "properties": {} }),
+                )
+                .expect("schema");
+                match ctx.elicit(ElicitRequest::new("pick a color", schema)).await {
+                    Ok(result) => Ok(ToolOutput::text(format!(
+                        "elicited: {}",
+                        serde_json::to_value(&result)
+                            .unwrap_or_default()
+                            .get("content")
+                            .and_then(|c| c.get("answer"))
+                            .and_then(|a| a.as_str())
+                            .unwrap_or("<none>")
+                    ))),
+                    Err(e) => Ok(ToolOutput::text(format!("elicit failed: {e}"))),
+                }
+            }
+            other => Err(McpError::method_not_found(other)),
+        }
+    }
+}
+impl ResourceHandler for H {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for H {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Err(McpError::method_not_found(name))
+    }
+}
+
+fn test_state() -> (McpState<H>, Observed) {
+    let observed = Observed::default();
+    let state = McpRouter::new(H(observed.clone()))
+        .with_reconnect_grace(Duration::from_millis(100))
+        .state();
+    (state, observed)
+}
+
+async fn post(
+    state: &McpState<H>,
+    session: Option<&str>,
+    body: serde_json::Value,
+) -> (actix_web::http::StatusCode, serde_json::Value) {
+    let mut req = TestRequest::default();
+    if let Some(s) = session {
+        req = req.insert_header(("mcp-session-id", s));
+    }
+    let req = req.to_http_request();
+    let resp =
+        match mcpkit_actix::handle_mcp_post(req, web::Data::new(state.clone()), body.to_string())
+            .await
+        {
+            Ok(resp) => resp,
+            Err(e) => actix_web::ResponseError::error_response(&e),
+        };
+    let status = resp.status();
+    let bytes = actix_web::body::to_bytes(resp.into_body())
+        .await
+        .expect("body");
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+async fn init(state: &McpState<H>) -> String {
+    let req = TestRequest::default().to_http_request();
+    let resp = mcpkit_actix::handle_mcp_post(
+        req,
+        web::Data::new(state.clone()),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": { "roots": {}, "elicitation": {} }
+            }
+        })
+        .to_string(),
+    )
+    .await
+    .expect("handler result");
+    resp.headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("session id")
+}
+
+async fn sse_status(state: &McpState<H>, session: Option<&str>, user: Option<VerifiedUser>) -> u16 {
+    let mut req = TestRequest::default();
+    if let Some(s) = session {
+        req = req.insert_header(("mcp-session-id", s));
+    }
+    let req = req.to_http_request();
+    if let Some(u) = user {
+        req.extensions_mut().insert(u);
+    }
+    mcpkit_actix::handle_sse(req, web::Data::new(state.clone()))
+        .await
+        .status()
+        .as_u16()
+}
+
+async fn next_stream_request(
+    handle: &mut mcpkit_server::streams::StreamHandle,
+) -> serde_json::Value {
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), handle.recv())
+            .await
+            .expect("stream event within 5s")
+            .expect("stream open");
+        if event.event_type == "message" {
+            return serde_json::from_str(&event.data).expect("json-rpc message");
+        }
+    }
+}
+
+// ---- SSE binding rules (#172/#173 for actix) -------------------------------
+
+#[actix_rt::test]
+async fn sse_without_session_id_is_400() {
+    let (state, _) = test_state();
+    assert_eq!(sse_status(&state, None, None).await, 400);
+}
+
+#[actix_rt::test]
+async fn sse_with_unknown_session_id_is_404_and_never_adopts_it() {
+    let (state, _) = test_state();
+    assert_eq!(
+        sse_status(&state, Some("attacker-chosen-id"), None).await,
+        404
+    );
+    assert!(state.sessions.get("attacker-chosen-id").is_none());
+}
+
+#[actix_rt::test]
+async fn sse_with_other_users_session_is_403() {
+    let (state, _) = test_state();
+    let alice = VerifiedUser::new("alice").issuer("https://idp");
+    let bob = VerifiedUser::new("bob").issuer("https://idp");
+    let sid = state.sessions.create_for_user(Some(alice));
+
+    assert_eq!(sse_status(&state, Some(&sid), Some(bob)).await, 403);
+    assert_eq!(sse_status(&state, Some(&sid), None).await, 403);
+}
+
+#[actix_rt::test]
+async fn sse_with_own_session_streams() {
+    let (state, _) = test_state();
+    let sid = state.sessions.create();
+    assert_eq!(sse_status(&state, Some(&sid), None).await, 200);
+}
+
+#[actix_rt::test]
+async fn get_on_mcp_endpoint_serves_sse() {
+    use actix_web::{App, test};
+    let router = McpRouter::new(H(Observed::default()));
+    let state = router.state();
+    let app = test::init_service(App::new().configure(router.configure_app())).await;
+
+    let sid = init(&state).await;
+    let req = test::TestRequest::get()
+        .uri("/mcp")
+        .insert_header(("mcp-session-id", sid.as_str()))
+        .to_request();
+    let resp = test::call_service(&app, req).await;
+    assert_eq!(resp.status(), actix_web::http::StatusCode::OK);
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|ct| ct.starts_with("text/event-stream")),
+        "GET on the MCP endpoint must open an SSE stream"
+    );
+}
+
+// ---- server-initiated requests (the #153 feature) --------------------------
+
+#[actix_rt::test]
+async fn tool_elicitation_round_trips_over_the_stream() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let call = {
+        let state = state.clone();
+        let sid = sid.clone();
+        tokio::task::spawn_local(async move {
+            post(
+                &state,
+                Some(&sid),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": { "name": "ask", "arguments": {} }
+                }),
+            )
+            .await
+            .1
+        })
+    };
+
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+    let request_id = request["id"].clone();
+
+    let (status, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "action": "accept", "content": { "answer": "blue" } }
+        }),
+    )
+    .await;
+    assert_eq!(status, actix_web::http::StatusCode::ACCEPTED);
+
+    let result = call.await.expect("join");
+    let text = result["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert_eq!(text, "elicited: blue", "tool result: {result}");
+}
+
+#[actix_rt::test]
+async fn roots_hook_round_trips_over_the_stream() {
+    let (state, observed) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/roots/list_changed" }),
+    )
+    .await;
+
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "roots/list");
+    let request_id = request["id"].clone();
+
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "roots": [{ "uri": "file:///w", "name": "w" }] }
+        }),
+    )
+    .await;
+
+    for _ in 0..100 {
+        if observed.roots.lock().unwrap().is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let roots = observed
+        .roots
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("hook ran")
+        .expect("list_roots succeeded");
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].uri, "file:///w");
+}
+
+#[actix_rt::test]
+async fn on_initialized_hook_fires() {
+    let (state, observed) = test_state();
+    let sid = init(&state).await;
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+    )
+    .await;
+    for _ in 0..100 {
+        if observed.initialized.load(Ordering::SeqCst) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("on_initialized hook never fired");
+}
+
+#[actix_rt::test]
+async fn elicit_without_stream_fails_fast() {
+    let (state, _) = test_state(); // 100ms grace
+    let sid = init(&state).await;
+
+    let started = std::time::Instant::now();
+    let (_, resp) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "ask", "arguments": {} }
+        }),
+    )
+    .await;
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.starts_with("elicit failed:"), "got: {resp}");
+    assert!(started.elapsed() < Duration::from_secs(30));
+}
+
+#[actix_rt::test]
+async fn delete_fails_pending_and_forgets_the_session() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let call = {
+        let state = state.clone();
+        let sid = sid.clone();
+        tokio::task::spawn_local(async move {
+            post(
+                &state,
+                Some(&sid),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": { "name": "ask", "arguments": {} }
+                }),
+            )
+            .await
+            .1
+        })
+    };
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+
+    let req = TestRequest::default()
+        .insert_header(("mcp-session-id", sid.as_str()))
+        .to_http_request();
+    let resp = mcpkit_actix::handle_mcp_delete(req, web::Data::new(state.clone())).await;
+    assert_eq!(resp.status(), actix_web::http::StatusCode::NO_CONTENT);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), call)
+        .await
+        .expect("pending request must fail on DELETE, not run out its timeout")
+        .expect("join");
+    let text = result["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.starts_with("elicit failed:"), "got: {result}");
+
+    let (status, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "id": 9, "method": "ping" }),
+    )
+    .await;
+    assert_eq!(status, actix_web::http::StatusCode::NOT_FOUND);
+}

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -38,59 +38,6 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-/// Delivers peer messages onto the session's SSE stream registry.
-struct SessionStreamSink {
-    registry: Arc<mcpkit_server::streams::StreamRegistry>,
-}
-
-impl mcpkit_server::adapter_peer::SessionSink for SessionStreamSink {
-    fn send_notification(
-        &self,
-        message: Message,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<(), mcpkit_server::adapter_peer::SinkError>>
-                + Send
-                + '_,
-        >,
-    > {
-        Box::pin(async move {
-            let json = serde_json::to_string(&message).map_err(|e| {
-                mcpkit_server::adapter_peer::SinkError::Serialization(e.to_string())
-            })?;
-            // Best-effort: with no live stream the notification is dropped
-            // (runtime parity — a client without a stream misses it).
-            let _ = self.registry.send("message", json);
-            Ok(())
-        })
-    }
-
-    fn send_request(
-        &self,
-        message: Message,
-    ) -> std::pin::Pin<
-        Box<
-            dyn std::future::Future<Output = Result<(), mcpkit_server::adapter_peer::SinkError>>
-                + Send
-                + '_,
-        >,
-    > {
-        Box::pin(async move {
-            let json = serde_json::to_string(&message).map_err(|e| {
-                mcpkit_server::adapter_peer::SinkError::Serialization(e.to_string())
-            })?;
-            self.registry
-                .send("message", json)
-                .map(|_| ())
-                .ok_or(mcpkit_server::adapter_peer::SinkError::NoClientStream)
-        })
-    }
-
-    fn has_live_stream(&self) -> bool {
-        self.registry.has_live_stream()
-    }
-}
-
 /// Build the request-capable peer for a session (#153 PR 4).
 ///
 /// Takes the session's parts rather than a `Session` snapshot so callers can
@@ -107,7 +54,9 @@ where
     H: HasServerInfo + Send + Sync + 'static,
 {
     mcpkit_server::adapter_peer::SessionPeer::new(
-        Arc::new(SessionStreamSink { registry: streams }),
+        Arc::new(mcpkit_server::adapter_peer::StreamRegistrySink::new(
+            streams,
+        )),
         outbound,
         state.peer_timeouts,
     )

--- a/crates/mcpkit-server/src/adapter_peer.rs
+++ b/crates/mcpkit-server/src/adapter_peer.rs
@@ -217,6 +217,58 @@ pub trait SessionSink: Send + Sync {
     fn has_live_stream(&self) -> bool;
 }
 
+/// The standard adapter sink: delivers peer messages onto a session's
+/// [`StreamRegistry`](crate::streams::StreamRegistry). Framework-free —
+/// every HTTP adapter uses this same implementation.
+#[cfg(feature = "tokio")]
+pub struct StreamRegistrySink {
+    registry: Arc<crate::streams::StreamRegistry>,
+}
+
+#[cfg(feature = "tokio")]
+impl StreamRegistrySink {
+    /// Create a sink over a session's stream registry.
+    #[must_use]
+    pub fn new(registry: Arc<crate::streams::StreamRegistry>) -> Self {
+        Self { registry }
+    }
+}
+
+#[cfg(feature = "tokio")]
+impl SessionSink for StreamRegistrySink {
+    fn send_notification(
+        &self,
+        message: Message,
+    ) -> Pin<Box<dyn Future<Output = Result<(), SinkError>> + Send + '_>> {
+        Box::pin(async move {
+            let json = serde_json::to_string(&message)
+                .map_err(|e| SinkError::Serialization(e.to_string()))?;
+            // Best-effort: with no live stream the notification is dropped
+            // (runtime parity — a client without a stream misses it).
+            let _ = self.registry.send("message", json);
+            Ok(())
+        })
+    }
+
+    fn send_request(
+        &self,
+        message: Message,
+    ) -> Pin<Box<dyn Future<Output = Result<(), SinkError>> + Send + '_>> {
+        Box::pin(async move {
+            let json = serde_json::to_string(&message)
+                .map_err(|e| SinkError::Serialization(e.to_string()))?;
+            self.registry
+                .send("message", json)
+                .map(|_| ())
+                .ok_or(SinkError::NoClientStream)
+        })
+    }
+
+    fn has_live_stream(&self) -> bool {
+        self.registry.has_live_stream()
+    }
+}
+
 // ============================================================================
 // Peer
 // ============================================================================


### PR DESCRIPTION
PR 5a of the #153 design v3 — first of the three adapter ports (actix chosen first as structurally closest to axum). Leave #153, #172, #173 open — warp and rocket remain.

## What

The actix adapter reaches the axum baseline in one PR (substrate + peer):

- **Unified session** — `session.rs` is axum's ported file transplanted verbatim (they were parallel copies pre-port; the 214-line drift was doc comments and two unused consts, preserved). `SessionManager`/`McpState.sse_sessions` gone; SSE binding enforced against the registry that holds the user binding: 400 / 404-never-adopts / 403, same tests as axum.
- **Single MCP endpoint** — GET (SSE) and DELETE join POST on `post_path`; `/mcp/sse` stays as a deprecated alias.
- **Per-stream delivery** — actix previously emitted SSE frames with **no `id:` fields at all** (round-1 finding C4: "actix emits raw frames with no id field"), so `Last-Event-ID` replay was impossible. Now on the shared `StreamRegistry`: `{stream_id}-{seq}` ids, same-stream replay, `retry: 2000`, overflow-kill.
- **The peer** — `ctx.elicit()`/`ctx.list_roots()`/sampling work over actix; response POSTs correlate; notification hooks dispatch off the request path; DELETE fails pending requests immediately. The snapshot-drop discipline from the axum DELETE bug is applied from the start.
- **Shared sink extracted** — `StreamRegistrySink` moves into `mcpkit_server::adapter_peer` (it was framework-free all along); axum is refactored onto it, so warp/rocket will not copy it either. One sink, four adapters.

**Breaking (actix):** mirrors the axum migration — `SessionManager`, `EventStore`, `EventStoreConfig`, `McpState.sse_sessions`, `with_sessions` arity.

## Tests

The full 10-test matrix ported from axum's `sse_binding` + `peer_e2e` suites, adapted to actix mechanics (`spawn_local` for actix's `!Send` request futures; `ResponseError` mapping for its `Result`-shaped handler). All pass, plus the transplanted session unit tests and the existing integration suite. Full local gate green: fmt, clippy `-D warnings` (1.97), rustdoc, 77 suites.

Refs #153.