### PR TITLE
feat(warp)!: port to the unified session + stream registry + peer (#153 PR 5b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The warp adapter reaches the axum baseline** (#153 PR 5, second of the
+  three ports): unified session registry (SSE binding enforced against the
+  registry holding the user binding — 400 missing id / 404 unknown-and-never-
+  adopted / 403 mismatched user; warp previously never checked the session id
+  on GET at all), GET and DELETE served on the MCP endpoint (old `/mcp/sse`
+  path kept as deprecated alias), per-stream delivery with `{stream_id}-{seq}`
+  event ids, working `Last-Event-ID` replay and `retry: 2000` via the shared
+  `mcpkit_server::streams` registry (warp previously fanned a per-session
+  `broadcast` channel out to every connected stream with no event ids), and
+  the session peer: `ctx.elicit()`/`ctx.list_roots()`/sampling work over
+  warp, response POSTs correlate, notification hooks dispatch, and DELETE
+  fails pending requests immediately. 202s now carry no body per spec
+  (previously `{}`). **Breaking (warp):** the broadcast plumbing is removed —
+  `McpState.sse_sessions` and `SessionStore::get_receiver` are gone, and
+  `SessionStore`'s inherent `create_session` (which returned the id plus a
+  broadcast receiver) is replaced by the id-only `create`/`create_for_user`
+  ([#153](https://github.com/praxiomlabs/mcpkit/issues/153)).
+
 - **The actix adapter reaches the axum baseline** (#153 PR 5, first of the
   three ports): unified session registry (SSE binding enforced against the
   registry holding the user binding — 400 missing id / 404 unknown-and-never-

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,7 +2864,6 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.17",
  "tokio",
- "tokio-stream",
  "tokio-test",
  "tracing",
  "uuid",
@@ -5060,7 +5059,6 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
- "tokio-util",
 ]
 
 [[package]]

--- a/crates/mcpkit-warp/Cargo.toml
+++ b/crates/mcpkit-warp/Cargo.toml
@@ -21,7 +21,6 @@ warp = "0.3"
 
 # Async runtime
 tokio = { workspace = true, features = ["sync", "rt"] }
-tokio-stream = { version = "0.1", features = ["sync"] }
 bytes = { workspace = true }
 
 # Serialization

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -16,12 +16,67 @@ use mcpkit_server::{
 };
 use std::convert::Infallible;
 use std::sync::Arc;
-use tokio_stream::wrappers::BroadcastStream;
 use tracing::{debug, info, warn};
 use warp::Filter;
 use warp::Reply as _;
 use warp::http::StatusCode;
 use warp::sse::Event;
+
+/// Build the request-capable peer for a session (#153).
+fn session_peer<H>(
+    state: &McpState<H>,
+    streams: Arc<mcpkit_server::streams::StreamRegistry>,
+    outbound: Arc<mcpkit_server::adapter_peer::SessionOutbound>,
+) -> mcpkit_server::adapter_peer::SessionPeer
+where
+    H: HasServerInfo + Send + Sync + 'static,
+{
+    mcpkit_server::adapter_peer::SessionPeer::new(
+        Arc::new(mcpkit_server::adapter_peer::StreamRegistrySink::new(
+            streams,
+        )),
+        outbound,
+        state.peer_timeouts,
+    )
+    .with_reconnect_grace(state.reconnect_grace)
+}
+
+/// Handle MCP DELETE requests: explicit session termination.
+///
+/// Per spec (§Session Management item 5). Removing the session drops its
+/// `OutboundOwner`, so every pending server-initiated request fails
+/// immediately; subsequent requests with the id get 404.
+pub fn handle_mcp_delete<H>(
+    state: Arc<McpState<H>>,
+    session_id: Option<String>,
+    origin: Option<String>,
+    user: Option<VerifiedUser>,
+) -> warp::reply::Response
+where
+    H: HasServerInfo + Send + Sync + 'static,
+{
+    if !state.origin_validator.is_allowed(origin.as_deref()) {
+        return warp::reply::with_status("origin not allowed", StatusCode::FORBIDDEN)
+            .into_response();
+    }
+    let Some(id) = session_id else {
+        return warp::reply::with_status("missing mcp-session-id", StatusCode::BAD_REQUEST)
+            .into_response();
+    };
+    match state.sessions.touch_verified(&id, user.as_ref()) {
+        Ok(true) => {}
+        Ok(false) => {
+            return warp::reply::with_status("unknown session id", StatusCode::NOT_FOUND)
+                .into_response();
+        }
+        Err(e) => {
+            return warp::reply::with_status(e.to_string(), StatusCode::FORBIDDEN).into_response();
+        }
+    }
+    let _ = state.sessions.remove(&id);
+    info!(session_id = %id, "Session terminated by client DELETE");
+    warp::reply::with_status(warp::reply::reply(), StatusCode::NO_CONTENT).into_response()
+}
 
 /// Whether this message is an `initialize` request — the only message allowed
 /// to omit `mcp-session-id` (the server assigns the id in its response).
@@ -194,12 +249,28 @@ where
             // This session's task store (per-session isolation for `tasks/*`).
             let task_store = state.sessions.tasks(&session_id);
 
+            // Route with a request-capable peer (#153): handlers can call
+            // ctx.elicit()/ctx.list_roots()/sampling; the request rides the
+            // session's SSE stream and the client answers via a response POST
+            // correlated below. The store hands out plain Arcs (never the
+            // OutboundOwner), so holding these across the await cannot keep
+            // DELETE/reap from failing pending requests.
+            let peer: Box<dyn mcpkit_server::Peer> = match (
+                state.sessions.streams(&session_id),
+                state.sessions.outbound(&session_id),
+            ) {
+                (Some(streams), Some(outbound)) => {
+                    Box::new(session_peer(&state, streams, outbound))
+                }
+                _ => Box::new(NoOpPeer),
+            };
             let response = create_response_for_request(
                 &state,
                 &request,
                 protocol_version,
                 &client_caps,
                 task_store.as_ref(),
+                peer.as_ref(),
             )
             .await;
 
@@ -231,32 +302,69 @@ where
                 session_id = %session_id,
                 "Received notification"
             );
+            // Dispatch to the ServerHandler hooks off the request path
+            // (#153): a hook may call ctx.list_roots(), whose response
+            // arrives via a separate POST — the 202 must not wait for that
+            // round-trip.
+            if let Some(hooks) = state.sessions.hooks(&session_id) {
+                let state2 = Arc::clone(&state);
+                let sid = session_id.clone();
+                let method = notification.method.to_string();
+                if let Ok(mut hooks) = hooks.lock() {
+                    hooks.spawn(async move {
+                        let (Some(streams), Some(outbound)) = (
+                            state2.sessions.streams(&sid),
+                            state2.sessions.outbound(&sid),
+                        ) else {
+                            return;
+                        };
+                        let peer = session_peer(&state2, streams, outbound);
+                        let (protocol_version, client_caps) =
+                            state2.sessions.negotiated(&sid).map_or_else(
+                                || (ProtocolVersion::LATEST, ClientCapabilities::default()),
+                                |(v, c)| (v, c.unwrap_or_default()),
+                            );
+                        let server_caps = state2.effective_capabilities();
+                        let ctx = Context::for_notification(
+                            &client_caps,
+                            &server_caps,
+                            protocol_version,
+                            &peer,
+                        );
+                        mcpkit_server::dispatch_notification_hooks(
+                            state2.handler.as_ref(),
+                            &method,
+                            &ctx,
+                        )
+                        .await;
+                        debug!(method = %method, "notification hook completed");
+                    });
+                }
+            }
             Ok(reply_with_session(
-                warp::reply::with_status(
-                    warp::reply::json(&serde_json::json!({})),
-                    StatusCode::ACCEPTED,
-                ),
+                warp::reply::with_status(warp::reply::reply(), StatusCode::ACCEPTED),
                 &session_id,
             ))
         }
         // Spec (Streamable HTTP): a client delivers responses to
         // server-initiated requests by POSTing them; "if the server accepts
         // the input, the server MUST return HTTP status code 202 Accepted
-        // with no body". Correlation with a pending server-initiated request
-        // arrives with the session peer (#153); until then this is
-        // log-and-drop, matching the runtime's `route_response` for ids that
-        // match no pending request.
+        // with no body". Correlated against the session's pending
+        // server-initiated requests (#153); an unmatched id is logged and
+        // dropped (runtime parity).
         Message::Response(response) => {
-            debug!(
-                id = %response.id,
-                session_id = %session_id,
-                "Received client response (no pending server-initiated request; dropped)"
-            );
+            let resolved = state
+                .sessions
+                .outbound(&session_id)
+                .is_some_and(|outbound| outbound.resolve(response));
+            if !resolved {
+                debug!(
+                    session_id = %session_id,
+                    "client response matched no pending server-initiated request; dropped"
+                );
+            }
             Ok(reply_with_session(
-                warp::reply::with_status(
-                    warp::reply::json(&serde_json::json!({})),
-                    StatusCode::ACCEPTED,
-                ),
+                warp::reply::with_status(warp::reply::reply(), StatusCode::ACCEPTED),
                 &session_id,
             ))
         }
@@ -291,6 +399,7 @@ async fn create_response_for_request<H>(
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
     task_store: Option<&Arc<TaskManager>>,
+    peer: &dyn mcpkit_server::Peer,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -304,14 +413,13 @@ where
     // Create a context for the request
     let req_id = request.id.clone();
     let server_caps = state.effective_capabilities();
-    let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
         None,
         client_caps,
         &server_caps,
         protocol_version,
-        &peer,
+        peer,
     );
 
     match method {
@@ -441,6 +549,7 @@ pub fn handle_sse<H>(
     session_id: Option<String>,
     origin: Option<String>,
     user: Option<VerifiedUser>,
+    last_event_id: Option<String>,
 ) -> warp::reply::Response
 where
     H: HasServerInfo + Send + Sync + 'static,
@@ -457,48 +566,78 @@ where
             .into_response();
     }
 
-    // Enforce the session's user binding before subscribing a reconnecting
-    // client to its event stream.
-    if let Some(id) = &session_id {
-        if let Err(e) = state.sessions.touch_verified(id, user.as_ref()) {
+    // #153: streams attach to the POST-created session. 400 without a
+    // session id; 404 for unknown ids (never adopt a client-presented id);
+    // 403 for a mismatched user — enforced against the same registry that
+    // holds the binding.
+    let Some(id) = session_id else {
+        warn!("Rejected SSE: missing mcp-session-id");
+        return warp::reply::with_status(
+            "missing mcp-session-id (obtain one via initialize)",
+            StatusCode::BAD_REQUEST,
+        )
+        .into_response();
+    };
+    match state.sessions.touch_verified(&id, user.as_ref()) {
+        Ok(true) => {}
+        Ok(false) => {
+            warn!(session_id = %id, "Rejected SSE: unknown session id");
+            return warp::reply::with_status("unknown session id", StatusCode::NOT_FOUND)
+                .into_response();
+        }
+        Err(e) => {
             warn!(session_id = %id, error = %e, "Rejected SSE: session binding violation");
             return warp::reply::with_status(e.to_string(), StatusCode::FORBIDDEN).into_response();
         }
     }
 
-    let (session_id, rx) = if let Some(id) = session_id {
-        if let Some(rx) = state.sse_sessions.get_receiver(&id) {
-            info!(session_id = %id, "Reconnected to SSE session");
-            (id, rx)
+    let registry = state.sessions.streams(&id).expect("session verified above");
+    let (handle, replay_events) = if let Some(last_id) = &last_event_id {
+        info!(session_id = %id, last_event_id = %last_id, "Reconnecting with Last-Event-ID");
+        if let Some((handle, replay)) = registry.resume(last_id) {
+            (handle, replay)
         } else {
-            let (new_id, rx) = state.sse_sessions.create_session();
-            info!(session_id = %new_id, "Created new SSE session (requested not found)");
-            (new_id, rx)
+            // Unknown or expired cursor: open a fresh stream rather than
+            // replaying another stream's events (spec MUST NOT).
+            let (handle, prime) = registry.open("connected", id);
+            (handle, vec![prime])
         }
     } else {
-        let (id, rx) = state.sse_sessions.create_session();
-        info!(session_id = %id, "Created new SSE session");
-        (id, rx)
+        let (handle, prime) = registry.open("connected", id);
+        (handle, vec![prime])
     };
 
-    // Create a stream of SSE events
-    let stream = BroadcastStream::new(rx).filter_map(move |result| {
-        let session = session_id.clone();
-        async move {
-            match result {
-                Ok(msg) => {
-                    let event_id = format!("evt-{}", uuid::Uuid::new_v4());
-                    Some(Ok::<_, Infallible>(
-                        Event::default().id(&event_id).event("message").data(msg),
-                    ))
+    // Replayed/prime events first, then live delivery; the first event
+    // carries the retry hint (spec: clients MUST respect `retry`).
+    let mut first = true;
+    let replay_stream = futures::stream::iter(
+        replay_events
+            .into_iter()
+            .map(|stored| {
+                let mut event = Event::default()
+                    .id(stored.id)
+                    .event(stored.event_type)
+                    .data(stored.data);
+                if first {
+                    event = event.retry(std::time::Duration::from_secs(2));
+                    first = false;
                 }
-                Err(e) => {
-                    warn!(error = %e, session_id = %session, "SSE broadcast error");
-                    None
-                }
-            }
+                Ok::<_, Infallible>(event)
+            })
+            .collect::<Vec<_>>(),
+    );
+    let live = futures::stream::unfold((handle, first), |(mut handle, first)| async move {
+        let stored = handle.recv().await?;
+        let mut event = Event::default()
+            .id(stored.id)
+            .event(stored.event_type)
+            .data(stored.data);
+        if first {
+            event = event.retry(std::time::Duration::from_secs(2));
         }
+        Some((Ok::<_, Infallible>(event), (handle, false)))
     });
+    let stream = replay_stream.chain(live);
 
     warp::sse::reply(warp::sse::keep_alive().stream(stream)).into_response()
 }

--- a/crates/mcpkit-warp/src/lib.rs
+++ b/crates/mcpkit-warp/src/lib.rs
@@ -44,7 +44,8 @@ mod session;
 mod state;
 
 pub use error::WarpError;
-pub use handler::{handle_mcp_post, handle_sse};
+pub use handler::{handle_mcp_delete, handle_mcp_post, handle_sse};
+pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 pub use router::McpRouter;
 pub use session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};
 pub use state::McpState;
@@ -52,10 +53,11 @@ pub use state::McpState;
 /// Prelude module for convenient imports.
 pub mod prelude {
     pub use crate::error::WarpError;
-    pub use crate::handler::{handle_mcp_post, handle_sse};
+    pub use crate::handler::{handle_mcp_delete, handle_mcp_post, handle_sse};
     pub use crate::router::McpRouter;
     pub use crate::session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};
     pub use crate::state::McpState;
+    pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 }
 
 /// Protocol versions supported by this extension.

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -129,6 +129,38 @@ where
         self
     }
 
+    /// Set the timeouts for server-initiated (peer) requests.
+    #[must_use]
+    pub fn with_peer_timeouts(
+        mut self,
+        timeouts: mcpkit_server::adapter_peer::PeerTimeouts,
+    ) -> Self {
+        // The builder owns the only reference to the state at this point.
+        if let Some(state) = Arc::get_mut(&mut self.state) {
+            state.peer_timeouts = timeouts;
+        }
+        self
+    }
+
+    /// Override the peer reconnect grace. Test hook — the grace is a fixed
+    /// constant by design.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_reconnect_grace(mut self, grace: std::time::Duration) -> Self {
+        // The builder owns the only reference to the state at this point.
+        if let Some(state) = Arc::get_mut(&mut self.state) {
+            state.reconnect_grace = grace;
+        }
+        self
+    }
+
+    /// The router's shared state. Test hook.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn state(&self) -> Arc<McpState<H>> {
+        Arc::clone(&self.state)
+    }
+
     fn set_origin_validator(&mut self, validator: OriginValidator) {
         // The builder owns the only reference to the state at this point, so
         // `get_mut` succeeds.
@@ -170,7 +202,40 @@ where
                 },
             );
 
-        // GET /mcp/sse - Server-Sent Events
+        // GET /mcp - the MCP endpoint serves SSE (#172); /mcp/sse stays as
+        // a deprecated alias.
+        let get_state = state.clone();
+        let mcp_get = warp::path("mcp")
+            .and(warp::path::end())
+            .and(warp::get())
+            .and(with_state(get_state))
+            .and(with_session_id())
+            .and(with_origin())
+            .and(warp::header::optional::<String>("last-event-id"))
+            .map(
+                |state: Arc<McpState<H>>,
+                 session_id: Option<String>,
+                 origin: Option<String>,
+                 last_event_id: Option<String>| {
+                    handle_sse(state, session_id, origin, None, last_event_id)
+                },
+            );
+
+        // DELETE /mcp - explicit session termination (#153).
+        let delete_state = state.clone();
+        let mcp_delete = warp::path("mcp")
+            .and(warp::path::end())
+            .and(warp::delete())
+            .and(with_state(delete_state))
+            .and(with_session_id())
+            .and(with_origin())
+            .map(
+                |state: Arc<McpState<H>>, session_id: Option<String>, origin: Option<String>| {
+                    crate::handler::handle_mcp_delete(state, session_id, origin, None)
+                },
+            );
+
+        // GET /mcp/sse - deprecated alias.
         let sse_state = state;
         let mcp_sse = warp::path("mcp")
             .and(warp::path("sse"))
@@ -178,17 +243,21 @@ where
             .and(with_state(sse_state))
             .and(with_session_id())
             .and(with_origin())
+            .and(warp::header::optional::<String>("last-event-id"))
             .map(
-                |state: Arc<McpState<H>>, session_id: Option<String>, origin: Option<String>| {
-                    handle_sse(state, session_id, origin, None)
+                |state: Arc<McpState<H>>,
+                 session_id: Option<String>,
+                 origin: Option<String>,
+                 last_event_id: Option<String>| {
+                    handle_sse(state, session_id, origin, None, last_event_id)
                 },
             );
 
         // Combine routes with CORS
-        mcp_post.or(mcp_sse).with(
+        mcp_post.or(mcp_get).or(mcp_delete).or(mcp_sse).with(
             warp::cors()
                 .allow_any_origin()
-                .allow_methods(vec!["GET", "POST", "OPTIONS"])
+                .allow_methods(vec!["GET", "POST", "DELETE", "OPTIONS"])
                 .allow_headers(vec![
                     "content-type",
                     "mcp-protocol-version",
@@ -229,7 +298,39 @@ where
                 },
             );
 
-        // GET /mcp/sse - Server-Sent Events
+        // GET /mcp - the MCP endpoint serves SSE (#172); /mcp/sse alias.
+        let get_state = state.clone();
+        let mcp_get = warp::path("mcp")
+            .and(warp::path::end())
+            .and(warp::get())
+            .and(with_state(get_state))
+            .and(with_session_id())
+            .and(with_origin())
+            .and(warp::header::optional::<String>("last-event-id"))
+            .map(
+                |state: Arc<McpState<H>>,
+                 session_id: Option<String>,
+                 origin: Option<String>,
+                 last_event_id: Option<String>| {
+                    handle_sse(state, session_id, origin, None, last_event_id)
+                },
+            );
+
+        // DELETE /mcp - explicit session termination (#153).
+        let delete_state = state.clone();
+        let mcp_delete = warp::path("mcp")
+            .and(warp::path::end())
+            .and(warp::delete())
+            .and(with_state(delete_state))
+            .and(with_session_id())
+            .and(with_origin())
+            .map(
+                |state: Arc<McpState<H>>, session_id: Option<String>, origin: Option<String>| {
+                    crate::handler::handle_mcp_delete(state, session_id, origin, None)
+                },
+            );
+
+        // GET /mcp/sse - deprecated alias.
         let sse_state = state;
         let mcp_sse = warp::path("mcp")
             .and(warp::path("sse"))
@@ -237,13 +338,17 @@ where
             .and(with_state(sse_state))
             .and(with_session_id())
             .and(with_origin())
+            .and(warp::header::optional::<String>("last-event-id"))
             .map(
-                |state: Arc<McpState<H>>, session_id: Option<String>, origin: Option<String>| {
-                    handle_sse(state, session_id, origin, None)
+                |state: Arc<McpState<H>>,
+                 session_id: Option<String>,
+                 origin: Option<String>,
+                 last_event_id: Option<String>| {
+                    handle_sse(state, session_id, origin, None, last_event_id)
                 },
             );
 
-        mcp_post.or(mcp_sse)
+        mcp_post.or(mcp_get).or(mcp_delete).or(mcp_sse)
     }
 
     /// Serve the MCP server on the given address.

--- a/crates/mcpkit-warp/src/session.rs
+++ b/crates/mcpkit-warp/src/session.rs
@@ -4,9 +4,10 @@ use dashmap::DashMap;
 use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
+use mcpkit_server::adapter_peer::{OutboundOwner, SessionOutbound};
+use mcpkit_server::streams::{StreamConfig, StreamRegistry};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::broadcast;
 use uuid::Uuid;
 
 /// Default idle timeout after which an inactive session is reaped.
@@ -16,8 +17,9 @@ pub const DEFAULT_SESSION_TIMEOUT: Duration = Duration::from_secs(3600);
 #[derive(Clone)]
 pub struct SessionStore {
     sessions: Arc<DashMap<String, SessionState>>,
-    sse_channels: Arc<DashMap<String, broadcast::Sender<String>>>,
     idle_timeout: Duration,
+    /// Stream configuration applied to each session's SSE stream registry.
+    stream_config: StreamConfig,
     /// Default task retention (ms) applied to each session's task store; `None`
     /// means unlimited. Configure via `McpRouter::with_task_ttl`.
     pub(crate) default_task_ttl: Option<u64>,
@@ -34,6 +36,14 @@ struct SessionState {
     /// This session's task store for task-augmented `tools/call` (per-session
     /// isolation for `tasks/*`).
     tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
+    /// This session's SSE stream registry (#153): per-stream channels,
+    /// single-stream delivery, `{stream_id}-{seq}` ids, same-stream replay.
+    streams: Arc<StreamRegistry>,
+    /// Owner of the outbound-request registry; dropped with the session so
+    /// pending server-initiated requests fail immediately on reap/DELETE.
+    outbound_owner: Arc<OutboundOwner>,
+    /// In-flight notification-hook tasks (aborted on session teardown).
+    hooks: Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>,
 }
 
 impl Default for SessionStore {
@@ -48,8 +58,8 @@ impl SessionStore {
     pub fn new() -> Self {
         Self {
             sessions: Arc::new(DashMap::new()),
-            sse_channels: Arc::new(DashMap::new()),
             idle_timeout: DEFAULT_SESSION_TIMEOUT,
+            stream_config: StreamConfig::default(),
             default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
         }
     }
@@ -92,6 +102,9 @@ impl SessionStore {
                         self.default_task_ttl,
                     ),
                 ),
+                streams: Arc::new(StreamRegistry::new(self.stream_config.clone())),
+                outbound_owner: Arc::new(OutboundOwner::new()),
+                hooks: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
             },
         );
         id
@@ -160,19 +173,38 @@ impl SessionStore {
         self.sessions.contains_key(id)
     }
 
-    /// Get or create an SSE channel for a session.
+    /// Set the stream configuration applied to each new session.
     #[must_use]
-    pub fn create_session(&self) -> (String, broadcast::Receiver<String>) {
-        let id = self.create();
-        let (tx, rx) = broadcast::channel(100);
-        self.sse_channels.insert(id.clone(), tx);
-        (id, rx)
+    pub fn with_stream_config(mut self, config: StreamConfig) -> Self {
+        self.stream_config = config;
+        self
     }
 
-    /// Get a receiver for an existing SSE session.
+    /// The SSE stream registry for a session. `None` if unknown.
     #[must_use]
-    pub fn get_receiver(&self, id: &str) -> Option<broadcast::Receiver<String>> {
-        self.sse_channels.get(id).map(|tx| tx.subscribe())
+    pub fn streams(&self, id: &str) -> Option<Arc<StreamRegistry>> {
+        self.sessions.get(id).map(|s| Arc::clone(&s.streams))
+    }
+
+    /// The outbound-request registry for a session. `None` if unknown.
+    #[must_use]
+    pub fn outbound(&self, id: &str) -> Option<Arc<SessionOutbound>> {
+        self.sessions
+            .get(id)
+            .map(|s| Arc::clone(s.outbound_owner.outbound()))
+    }
+
+    /// The notification-hook task set for a session. `None` if unknown.
+    #[must_use]
+    pub fn hooks(&self, id: &str) -> Option<Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>> {
+        self.sessions.get(id).map(|s| Arc::clone(&s.hooks))
+    }
+
+    /// Terminate and remove a session (DELETE). Dropping it drops the
+    /// `OutboundOwner`, failing all pending server-initiated requests.
+    #[must_use]
+    pub fn remove(&self, id: &str) -> bool {
+        self.sessions.remove(id).is_some()
     }
 
     /// Remove sessions older than the given duration.
@@ -287,33 +319,28 @@ mod tests {
         assert!(store.exists(&id));
     }
 
-    #[tokio::test]
-    async fn test_session_store_sse_channel() {
+    #[test]
+    fn test_session_store_peer_accessors() {
         let store = SessionStore::new();
-        let (id, mut rx) = store.create_session();
+        let id = store.create();
 
-        // Get the sender and send
-        let tx = store.sse_channels.get(&id).unwrap();
-        tx.send("test message".to_string()).unwrap();
-        drop(tx);
+        assert!(store.streams(&id).is_some());
+        assert!(store.outbound(&id).is_some());
+        assert!(store.hooks(&id).is_some());
 
-        // Receive the message
-        let msg = rx.recv().await.unwrap();
-        assert_eq!(msg, "test message");
+        assert!(store.streams("non-existent").is_none());
+        assert!(store.outbound("non-existent").is_none());
+        assert!(store.hooks("non-existent").is_none());
     }
 
     #[test]
-    fn test_session_store_get_receiver() {
+    fn test_session_store_remove() {
         let store = SessionStore::new();
-        let (id, _rx) = store.create_session();
+        let id = store.create();
 
-        // Should be able to get another receiver
-        let rx2 = store.get_receiver(&id);
-        assert!(rx2.is_some());
-
-        // Non-existent session should return None
-        let rx3 = store.get_receiver("non-existent");
-        assert!(rx3.is_none());
+        assert!(store.remove(&id));
+        assert!(!store.exists(&id));
+        assert!(!store.remove(&id));
     }
 
     #[test]

--- a/crates/mcpkit-warp/src/state.rs
+++ b/crates/mcpkit-warp/src/state.rs
@@ -26,8 +26,6 @@ pub struct McpState<H> {
     pub server_info: ServerInfo,
     /// Session manager for tracking client sessions.
     pub sessions: SessionStore,
-    /// SSE session manager for Server-Sent Events.
-    pub sse_sessions: SessionStore,
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
@@ -35,6 +33,11 @@ pub struct McpState<H> {
     pub list_page_size: Option<usize>,
     /// Optional completion handler for `completion/complete`.
     pub completion: Option<Arc<dyn mcpkit_server::dispatch::DynCompletionHandler>>,
+    /// Timeouts applied to server-initiated requests (#153).
+    pub peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts,
+    /// Grace period a server-initiated send waits for a live stream; tunable
+    /// for tests via `McpRouter::with_reconnect_grace`.
+    pub(crate) reconnect_grace: std::time::Duration,
 }
 
 impl<H> McpState<H>
@@ -48,10 +51,11 @@ where
             handler: Arc::new(handler),
             server_info,
             sessions: SessionStore::new(),
-            sse_sessions: SessionStore::new(),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
             completion: None,
+            peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts::default(),
+            reconnect_grace: mcpkit_server::adapter_peer::RECONNECT_GRACE,
         }
     }
 
@@ -71,10 +75,11 @@ impl<H> Clone for McpState<H> {
             handler: Arc::clone(&self.handler),
             server_info: self.server_info.clone(),
             sessions: self.sessions.clone(),
-            sse_sessions: self.sse_sessions.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
             list_page_size: self.list_page_size,
             completion: self.completion.clone(),
+            peer_timeouts: self.peer_timeouts,
+            reconnect_grace: self.reconnect_grace,
         }
     }
 }
@@ -227,12 +232,9 @@ mod tests {
     fn test_mcp_state_sessions() {
         let state = McpState::new(TestHandler);
 
-        // Create sessions in both stores
-        let id1 = state.sessions.create();
-        let id2 = state.sse_sessions.create();
+        let id = state.sessions.create();
 
-        assert!(state.sessions.exists(&id1));
-        assert!(state.sse_sessions.exists(&id2));
+        assert!(state.sessions.exists(&id));
     }
 
     #[test]

--- a/crates/mcpkit-warp/tests/peer_e2e.rs
+++ b/crates/mcpkit-warp/tests/peer_e2e.rs
@@ -1,0 +1,423 @@
+//! #153 PR 5 (warp port): SSE binding rules + server-initiated requests
+//! end-to-end — the same matrix as the axum `sse_binding`/`peer_e2e` suites.
+
+use mcpkit_core::auth::VerifiedUser;
+use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    ElicitRequest, ElicitationSchema, GetPromptResult, Prompt, Resource, ResourceContents, Root,
+    Tool, ToolOutput,
+};
+use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use mcpkit_warp::{McpRouter, McpState};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Clone, Default)]
+struct Observed {
+    initialized: Arc<AtomicBool>,
+    roots: Arc<Mutex<Option<Result<Vec<Root>, String>>>>,
+}
+
+#[derive(Clone)]
+struct H(Observed);
+
+impl ServerHandler for H {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("t", "1.0.0")
+    }
+    async fn on_initialized(&self, _ctx: &Context<'_>) {
+        self.0.initialized.store(true, Ordering::SeqCst);
+    }
+    async fn on_roots_list_changed(&self, ctx: &Context<'_>) {
+        let result = ctx.list_roots().await.map_err(|e| e.to_string());
+        *self.0.roots.lock().unwrap() = Some(result);
+    }
+}
+impl ToolHandler for H {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![Tool::new("ask")])
+    }
+    async fn call_tool(
+        &self,
+        name: &str,
+        _args: serde_json::Map<String, serde_json::Value>,
+        ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        match name {
+            "ask" => {
+                let schema = serde_json::from_value::<ElicitationSchema>(
+                    serde_json::json!({ "type": "object", "properties": {} }),
+                )
+                .expect("schema");
+                match ctx.elicit(ElicitRequest::new("pick a color", schema)).await {
+                    Ok(result) => Ok(ToolOutput::text(format!(
+                        "elicited: {}",
+                        serde_json::to_value(&result)
+                            .unwrap_or_default()
+                            .get("content")
+                            .and_then(|c| c.get("answer"))
+                            .and_then(|a| a.as_str())
+                            .unwrap_or("<none>")
+                    ))),
+                    Err(e) => Ok(ToolOutput::text(format!("elicit failed: {e}"))),
+                }
+            }
+            other => Err(McpError::method_not_found(other)),
+        }
+    }
+}
+impl ResourceHandler for H {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for H {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Err(McpError::method_not_found(name))
+    }
+}
+
+fn test_state() -> (Arc<McpState<H>>, Observed) {
+    let observed = Observed::default();
+    let state = McpRouter::new(H(observed.clone()))
+        .with_reconnect_grace(Duration::from_millis(100))
+        .state();
+    (state, observed)
+}
+
+async fn post(
+    state: &Arc<McpState<H>>,
+    session: Option<&str>,
+    body: serde_json::Value,
+) -> (u16, serde_json::Value) {
+    let resp = mcpkit_warp::handle_mcp_post(
+        Arc::clone(state),
+        None,
+        session.map(String::from),
+        None,
+        None,
+        body.to_string(),
+    )
+    .await
+    .expect("infallible");
+    let status = resp.status().as_u16();
+    let bytes = warp::hyper::body::to_bytes(resp.into_body())
+        .await
+        .expect("body");
+    let json = if bytes.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_slice(&bytes).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+async fn init(state: &Arc<McpState<H>>) -> String {
+    let resp = mcpkit_warp::handle_mcp_post(
+        Arc::clone(state),
+        None,
+        None,
+        None,
+        None,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": {
+                "protocolVersion": "2025-11-25",
+                "capabilities": { "roots": {}, "elicitation": {} }
+            }
+        })
+        .to_string(),
+    )
+    .await
+    .expect("infallible");
+    resp.headers()
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(String::from)
+        .expect("session id")
+}
+
+fn sse_status(state: &Arc<McpState<H>>, session: Option<&str>, user: Option<VerifiedUser>) -> u16 {
+    mcpkit_warp::handle_sse(
+        Arc::clone(state),
+        session.map(String::from),
+        None,
+        user,
+        None,
+    )
+    .status()
+    .as_u16()
+}
+
+async fn next_stream_request(
+    handle: &mut mcpkit_server::streams::StreamHandle,
+) -> serde_json::Value {
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), handle.recv())
+            .await
+            .expect("stream event within 5s")
+            .expect("stream open");
+        if event.event_type == "message" {
+            return serde_json::from_str(&event.data).expect("json-rpc message");
+        }
+    }
+}
+
+// ---- SSE binding rules (#172/#173 for warp) --------------------------------
+
+#[tokio::test]
+async fn sse_without_session_id_is_400() {
+    let (state, _) = test_state();
+    assert_eq!(sse_status(&state, None, None), 400);
+}
+
+#[tokio::test]
+async fn sse_with_unknown_session_id_is_404_and_never_adopts_it() {
+    let (state, _) = test_state();
+    assert_eq!(sse_status(&state, Some("attacker-chosen-id"), None), 404);
+    assert!(!state.sessions.exists("attacker-chosen-id"));
+}
+
+#[tokio::test]
+async fn sse_with_other_users_session_is_403() {
+    let (state, _) = test_state();
+    let alice = VerifiedUser::new("alice").issuer("https://idp");
+    let bob = VerifiedUser::new("bob").issuer("https://idp");
+    let sid = state.sessions.create_for_user(Some(alice));
+
+    assert_eq!(sse_status(&state, Some(&sid), Some(bob)), 403);
+    assert_eq!(sse_status(&state, Some(&sid), None), 403);
+}
+
+#[tokio::test]
+async fn sse_with_own_session_streams() {
+    let (state, _) = test_state();
+    let sid = state.sessions.create();
+    assert_eq!(sse_status(&state, Some(&sid), None), 200);
+}
+
+#[tokio::test]
+async fn get_on_mcp_endpoint_serves_sse() {
+    use warp::Reply;
+    let router = McpRouter::new(H(Observed::default()));
+    let state = router.state();
+    let filter = router.into_filter();
+
+    let sid = init(&state).await;
+    // `.filter()` rather than `.reply()`: reply() drains the full response
+    // body, and an SSE stream never ends.
+    let reply = warp::test::request()
+        .method("GET")
+        .path("/mcp")
+        .header("mcp-session-id", sid.as_str())
+        .filter(&filter)
+        .await
+        .expect("GET /mcp must match a route");
+    let resp = reply.into_response();
+    assert_eq!(resp.status(), 200);
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|ct| ct.starts_with("text/event-stream")),
+        "GET on the MCP endpoint must open an SSE stream"
+    );
+}
+
+// ---- server-initiated requests (the #153 feature) --------------------------
+
+#[tokio::test]
+async fn tool_elicitation_round_trips_over_the_stream() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let call = {
+        let state = Arc::clone(&state);
+        let sid = sid.clone();
+        tokio::spawn(async move {
+            post(
+                &state,
+                Some(&sid),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": { "name": "ask", "arguments": {} }
+                }),
+            )
+            .await
+            .1
+        })
+    };
+
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+    let request_id = request["id"].clone();
+
+    let (status, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "action": "accept", "content": { "answer": "blue" } }
+        }),
+    )
+    .await;
+    assert_eq!(status, 202);
+
+    let result = call.await.expect("join");
+    let text = result["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert_eq!(text, "elicited: blue", "tool result: {result}");
+}
+
+#[tokio::test]
+async fn roots_hook_round_trips_over_the_stream() {
+    let (state, observed) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/roots/list_changed" }),
+    )
+    .await;
+
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "roots/list");
+    let request_id = request["id"].clone();
+
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "roots": [{ "uri": "file:///w", "name": "w" }] }
+        }),
+    )
+    .await;
+
+    for _ in 0..100 {
+        if observed.roots.lock().unwrap().is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let roots = observed
+        .roots
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("hook ran")
+        .expect("list_roots succeeded");
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].uri, "file:///w");
+}
+
+#[tokio::test]
+async fn on_initialized_hook_fires() {
+    let (state, observed) = test_state();
+    let sid = init(&state).await;
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+    )
+    .await;
+    for _ in 0..100 {
+        if observed.initialized.load(Ordering::SeqCst) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("on_initialized hook never fired");
+}
+
+#[tokio::test]
+async fn elicit_without_stream_fails_fast() {
+    let (state, _) = test_state(); // 100ms grace
+    let sid = init(&state).await;
+
+    let started = std::time::Instant::now();
+    let (_, resp) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "ask", "arguments": {} }
+        }),
+    )
+    .await;
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.starts_with("elicit failed:"), "got: {resp}");
+    assert!(started.elapsed() < Duration::from_secs(30));
+}
+
+#[tokio::test]
+async fn delete_fails_pending_and_forgets_the_session() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let call = {
+        let state = Arc::clone(&state);
+        let sid = sid.clone();
+        tokio::spawn(async move {
+            post(
+                &state,
+                Some(&sid),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": { "name": "ask", "arguments": {} }
+                }),
+            )
+            .await
+            .1
+        })
+    };
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+
+    let resp = mcpkit_warp::handle_mcp_delete(Arc::clone(&state), Some(sid.clone()), None, None);
+    assert_eq!(resp.status(), 204);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), call)
+        .await
+        .expect("pending request must fail on DELETE, not run out its timeout")
+        .expect("join");
+    let text = result["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.starts_with("elicit failed:"), "got: {result}");
+
+    let (status, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "id": 9, "method": "ping" }),
+    )
+    .await;
+    assert_eq!(status, 404);
+}


### PR DESCRIPTION
PR 5b of the #153 design v3 — second of the three adapter ports (actix landed as #181). Leave #153, #172, #173 open — rocket remains.

## What

The warp adapter reaches the axum baseline in one PR (substrate + peer):

- **Unified session** — `SessionStore` adapted in place (warp's copy had already converged on the axum shape through PRs 0b/1); the per-session broadcast channel (`sse_channels`) is replaced by the shared `StreamRegistry` + `OutboundOwner` + hook `JoinSet`. SSE binding enforced against the registry holding the user binding: 400 missing id / 404 unknown-and-never-adopted / 403 mismatched user. **Warp previously performed no session-id check on GET at all** — any GET opened a broadcast stream.
- **Single MCP endpoint** — GET (SSE) and DELETE join POST on `/mcp` in both `into_filter` and `into_filter_without_cors`; `/mcp/sse` stays as a deprecated alias; CORS allows DELETE.
- **Per-stream delivery** — warp previously fanned every message out to all connected streams via one `broadcast` channel with **no `id:` fields**, so replay was impossible and the MUST-NOT-broadcast rule was violated. Now on the shared registry: `{stream_id}-{seq}` ids, same-stream `Last-Event-ID` replay, `retry: 2000`, overflow-kill.
- **The peer** — `ctx.elicit()`/`ctx.list_roots()`/sampling work over warp; response POSTs correlate against the session's pending server-initiated requests; notification hooks dispatch off the request path; DELETE fails pending requests immediately. Warp's store hands out plain `Arc`s (never the `OutboundOwner`), so the axum snapshot-drop hazard can't arise here by construction.
- **Spec fix in passing** — 202 responses (notification/response POSTs) now carry no body per spec (previously `{}`).

**Breaking (warp):** the broadcast plumbing is removed — `McpState.sse_sessions`, `SessionStore::get_receiver`, and the inherent `create_session` (id + broadcast receiver) are gone; sessions are created id-only via `create`/`create_for_user`. `tokio-stream` dropped as a dependency.

## Tests

The full 10-test matrix ported from the axum/actix suites, adapted to warp mechanics (handlers are plain fns taking explicit args, so the suite calls them directly; the GET-routing test uses `warp::test::request().filter()` rather than `.reply()`, which drains the full body — an SSE stream never ends, so `.reply()` deadlocks). All pass, plus the adapted session unit tests and the existing integration suite. Full local gate green: fmt, clippy `-D warnings` (1.97), rustdoc, workspace tests.

Refs #153.