### PR TITLE
feat(rocket)!: port to the unified session + stream registry + peer (#153 PR 5c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **The rocket adapter reaches the axum baseline** (#153 PR 5, last of the
+  three ports — every adapter now has the full session/stream/peer substrate):
+  unified session registry (SSE binding: 400 missing id / 404
+  unknown-and-never-adopted / 403 disallowed origin or mismatched user;
+  rocket previously **created a fresh session for any GET with a missing or
+  unknown id**, adopting streams for sessions that never initialized), GET
+  and DELETE served on the MCP endpoint via new `mcp_get`/`mcp_delete`
+  routes in `create_mcp_routes!` (`/mcp/sse` kept as a deprecated alias;
+  CORS allows DELETE), per-stream delivery with `{stream_id}-{seq}` event
+  ids, working `Last-Event-ID` replay and `retry: 2000` via the shared
+  `mcpkit_server::streams` registry (rocket previously broadcast every
+  message to all connected streams with random per-emit `evt-{uuid}` ids),
+  and the session peer: `ctx.elicit()`/`ctx.list_roots()`/sampling work over
+  rocket, response POSTs correlate, notification hooks dispatch, and DELETE
+  fails pending requests immediately. **Breaking (rocket):** the broadcast
+  plumbing is removed — `McpState.sse_sessions`, `SessionStore::{get_receiver,
+  send}`, and the inherent `create_session` (id + broadcast receiver) are
+  gone (sessions are created id-only via `create`/`create_for_user`), and
+  `handle_sse` now takes the session id, origin, user, and `Last-Event-ID`
+  and returns `Result<EventStream![], Status>`
+  ([#153](https://github.com/praxiomlabs/mcpkit/issues/153)).
+
 - **The warp adapter reaches the axum baseline** (#153 PR 5, second of the
   three ports): unified session registry (SSE binding enforced against the
   registry holding the user binding — 400 missing id / 404 unknown-and-never-

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -21,6 +21,55 @@ use std::io::Cursor;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
+/// Build the request-capable peer for a session (#153).
+fn session_peer<H>(
+    state: &McpState<H>,
+    streams: Arc<mcpkit_server::streams::StreamRegistry>,
+    outbound: Arc<mcpkit_server::adapter_peer::SessionOutbound>,
+) -> mcpkit_server::adapter_peer::SessionPeer
+where
+    H: HasServerInfo + Send + Sync + 'static,
+{
+    mcpkit_server::adapter_peer::SessionPeer::new(
+        Arc::new(mcpkit_server::adapter_peer::StreamRegistrySink::new(
+            streams,
+        )),
+        outbound,
+        state.peer_timeouts,
+    )
+    .with_reconnect_grace(state.reconnect_grace)
+}
+
+/// Handle MCP DELETE requests: explicit session termination.
+///
+/// Per spec (§Session Management item 5). Removing the session drops its
+/// `OutboundOwner`, so every pending server-initiated request fails
+/// immediately; subsequent requests with the id get 404.
+pub fn handle_mcp_delete<H>(
+    state: &McpState<H>,
+    session_id: Option<String>,
+    origin: Option<&str>,
+    user: Option<VerifiedUser>,
+) -> Status
+where
+    H: HasServerInfo + Send + Sync + 'static,
+{
+    if !state.origin_validator.is_allowed(origin) {
+        return Status::Forbidden;
+    }
+    let Some(id) = session_id else {
+        return Status::BadRequest;
+    };
+    match state.sessions.touch_verified(&id, user.as_ref()) {
+        Ok(true) => {}
+        Ok(false) => return Status::NotFound,
+        Err(_) => return Status::Forbidden,
+    }
+    let _ = state.sessions.remove(&id);
+    info!(session_id = %id, "Session terminated by client DELETE");
+    Status::NoContent
+}
+
 /// Whether this message is an `initialize` request — the only message allowed
 /// to omit `mcp-session-id` (the server assigns the id in its response).
 fn is_initialize(msg: &Message) -> bool {
@@ -307,12 +356,26 @@ where
             // This session's task store (per-session isolation for `tasks/*`).
             let task_store = state.sessions.tasks(&session_id);
 
+            // Route with a request-capable peer (#153): handlers can call
+            // ctx.elicit()/ctx.list_roots()/sampling; the request rides the
+            // session's SSE stream and the client answers via a response POST
+            // correlated below. The store hands out plain Arcs (never the
+            // OutboundOwner), so holding these across the await cannot keep
+            // DELETE/reap from failing pending requests.
+            let peer: Box<dyn mcpkit_server::Peer> = match (
+                state.sessions.streams(&session_id),
+                state.sessions.outbound(&session_id),
+            ) {
+                (Some(streams), Some(outbound)) => Box::new(session_peer(state, streams, outbound)),
+                _ => Box::new(NoOpPeer),
+            };
             let response = create_response_for_request(
                 state,
                 &request,
                 protocol_version,
                 &client_caps,
                 task_store.as_ref(),
+                peer.as_ref(),
             )
             .await;
 
@@ -330,21 +393,64 @@ where
                 session_id = %session_id,
                 "Received notification"
             );
+            // Dispatch to the ServerHandler hooks off the request path
+            // (#153): a hook may call ctx.list_roots(), whose response
+            // arrives via a separate POST — the 202 must not wait for that
+            // round-trip.
+            if let Some(hooks) = state.sessions.hooks(&session_id) {
+                let state2 = state.clone();
+                let sid = session_id.clone();
+                let method = notification.method.to_string();
+                if let Ok(mut hooks) = hooks.lock() {
+                    hooks.spawn(async move {
+                        let (Some(streams), Some(outbound)) = (
+                            state2.sessions.streams(&sid),
+                            state2.sessions.outbound(&sid),
+                        ) else {
+                            return;
+                        };
+                        let peer = session_peer(&state2, streams, outbound);
+                        let (protocol_version, client_caps) =
+                            state2.sessions.negotiated(&sid).map_or_else(
+                                || (ProtocolVersion::LATEST, ClientCapabilities::default()),
+                                |(v, c)| (v, c.unwrap_or_default()),
+                            );
+                        let server_caps = state2.effective_capabilities();
+                        let ctx = Context::for_notification(
+                            &client_caps,
+                            &server_caps,
+                            protocol_version,
+                            &peer,
+                        );
+                        mcpkit_server::dispatch_notification_hooks(
+                            state2.handler.as_ref(),
+                            &method,
+                            &ctx,
+                        )
+                        .await;
+                        debug!(method = %method, "notification hook completed");
+                    });
+                }
+            }
             McpResponse::accepted(session_id)
         }
         // Spec (Streamable HTTP): a client delivers responses to
         // server-initiated requests by POSTing them; "if the server accepts
         // the input, the server MUST return HTTP status code 202 Accepted
-        // with no body". Correlation with a pending server-initiated request
-        // arrives with the session peer (#153); until then this is
-        // log-and-drop, matching the runtime's `route_response` for ids that
-        // match no pending request.
+        // with no body". Correlated against the session's pending
+        // server-initiated requests (#153); an unmatched id is logged and
+        // dropped (runtime parity).
         Message::Response(response) => {
-            debug!(
-                id = %response.id,
-                session_id = %session_id,
-                "Received client response (no pending server-initiated request; dropped)"
-            );
+            let resolved = state
+                .sessions
+                .outbound(&session_id)
+                .is_some_and(|outbound| outbound.resolve(response));
+            if !resolved {
+                debug!(
+                    session_id = %session_id,
+                    "client response matched no pending server-initiated request; dropped"
+                );
+            }
             McpResponse::accepted(session_id)
         }
     }
@@ -378,6 +484,7 @@ async fn create_response_for_request<H>(
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
     task_store: Option<&Arc<TaskManager>>,
+    peer: &dyn mcpkit_server::Peer,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -391,14 +498,13 @@ where
     // Create a context for the request
     let req_id = request.id.clone();
     let server_caps = state.effective_capabilities();
-    let peer = NoOpPeer;
     let ctx = Context::new(
         &req_id,
         None,
         client_caps,
         &server_caps,
         protocol_version,
-        &peer,
+        peer,
     );
 
     match method {
@@ -520,49 +626,86 @@ where
     }
 }
 
-/// Handle SSE connections for server-to-client streaming.
+/// Handle SSE connections for server-to-client streaming (GET on the MCP
+/// endpoint, #153).
 ///
-/// This returns an `EventStream` for pushing notifications to clients.
-pub fn handle_sse<H>(state: &McpState<H>, session_id: Option<String>) -> EventStream![]
+/// Streams attach to the POST-created session: 400 without a session id;
+/// 404 for unknown ids (never adopt a client-presented id); 403 for a
+/// disallowed origin or mismatched user — enforced against the same
+/// registry that holds the binding. `Last-Event-ID` resumes the stream with
+/// same-stream replay; an unknown or expired cursor opens a fresh stream.
+pub fn handle_sse<H>(
+    state: &McpState<H>,
+    session_id: Option<String>,
+    origin: Option<&str>,
+    user: Option<VerifiedUser>,
+    last_event_id: Option<String>,
+) -> Result<EventStream![], Status>
 where
     H: HasServerInfo + Send + Sync + 'static,
 {
-    let (session_id, mut rx) = if let Some(id) = session_id {
-        if let Some(rx) = state.sse_sessions.get_receiver(&id) {
-            info!(session_id = %id, "Reconnected to SSE session");
-            (id, rx)
-        } else {
-            let (new_id, rx) = state.sse_sessions.create_session();
-            info!(session_id = %new_id, "Created new SSE session (requested not found)");
-            (new_id, rx)
-        }
-    } else {
-        let (id, rx) = state.sse_sessions.create_session();
-        info!(session_id = %id, "Created new SSE session");
-        (id, rx)
+    // Reject disallowed Origins (DNS-rebinding protection) before streaming.
+    if !state.origin_validator.is_allowed(origin) {
+        warn!(
+            origin = origin.unwrap_or("none"),
+            "Rejected SSE: origin not allowed"
+        );
+        return Err(Status::Forbidden);
+    }
+    let Some(id) = session_id else {
+        warn!("Rejected SSE: missing mcp-session-id");
+        return Err(Status::BadRequest);
     };
-
-    EventStream! {
-        // Send connected event with session ID
-        yield Event::data(session_id.clone()).event("connected").id("evt-connected");
-
-        // Stream new messages
-        loop {
-            match rx.recv().await {
-                Ok(msg) => {
-                    let event_id = format!("evt-{}", uuid::Uuid::new_v4());
-                    yield Event::data(msg).event("message").id(event_id);
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
-                    warn!(skipped = n, "SSE client lagged, skipped messages");
-                }
-                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                    debug!("SSE channel closed");
-                    break;
-                }
-            }
+    match state.sessions.touch_verified(&id, user.as_ref()) {
+        Ok(true) => {}
+        Ok(false) => {
+            warn!(session_id = %id, "Rejected SSE: unknown session id");
+            return Err(Status::NotFound);
+        }
+        Err(e) => {
+            warn!(session_id = %id, error = %e, "Rejected SSE: session binding violation");
+            return Err(Status::Forbidden);
         }
     }
+
+    let registry = state.sessions.streams(&id).expect("session verified above");
+    let (handle, replay_events) = if let Some(last_id) = &last_event_id {
+        info!(session_id = %id, last_event_id = %last_id, "Reconnecting with Last-Event-ID");
+        if let Some((handle, replay)) = registry.resume(last_id) {
+            (handle, replay)
+        } else {
+            // Unknown or expired cursor: open a fresh stream rather than
+            // replaying another stream's events (spec MUST NOT).
+            let (handle, prime) = registry.open("connected", id);
+            (handle, vec![prime])
+        }
+    } else {
+        let (handle, prime) = registry.open("connected", id);
+        (handle, vec![prime])
+    };
+
+    // Replayed/prime events first, then live delivery; the first event
+    // carries the retry hint (spec: clients MUST respect `retry`).
+    Ok(EventStream! {
+        let mut handle = handle;
+        let mut first = true;
+        for stored in replay_events {
+            let mut event = Event::data(stored.data).event(stored.event_type).id(stored.id);
+            if first {
+                event = event.with_retry(std::time::Duration::from_secs(2));
+                first = false;
+            }
+            yield event;
+        }
+        while let Some(stored) = handle.recv().await {
+            let mut event = Event::data(stored.data).event(stored.event_type).id(stored.id);
+            if first {
+                event = event.with_retry(std::time::Duration::from_secs(2));
+                first = false;
+            }
+            yield event;
+        }
+    })
 }
 
 #[cfg(test)]

--- a/crates/mcpkit-rocket/src/lib.rs
+++ b/crates/mcpkit-rocket/src/lib.rs
@@ -100,8 +100,9 @@ mod state;
 pub use error::RocketError;
 pub use handler::{
     LastEventIdHeader, McpResponse, OriginHeader, ProtocolVersionHeader, SessionIdHeader,
-    handle_mcp_post, handle_sse,
+    handle_mcp_delete, handle_mcp_post, handle_sse,
 };
+pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 pub use router::{Cors, McpRouter};
 pub use session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};
 pub use state::McpState;
@@ -115,10 +116,11 @@ pub use state::McpState;
 /// ```
 pub mod prelude {
     pub use crate::error::RocketError;
-    pub use crate::handler::{handle_mcp_post, handle_sse};
+    pub use crate::handler::{handle_mcp_delete, handle_mcp_post, handle_sse};
     pub use crate::router::McpRouter;
     pub use crate::session::{DEFAULT_SESSION_TIMEOUT, SessionManager, SessionStore};
     pub use crate::state::McpState;
+    pub use mcpkit_server::streams::{StoredEvent, StreamConfig, StreamRegistry};
 }
 
 /// Protocol versions supported by this extension.

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -139,6 +139,25 @@ where
         self.state
     }
 
+    /// Set the timeouts for server-initiated (peer) requests.
+    #[must_use]
+    pub fn with_peer_timeouts(
+        mut self,
+        timeouts: mcpkit_server::adapter_peer::PeerTimeouts,
+    ) -> Self {
+        self.state.peer_timeouts = timeouts;
+        self
+    }
+
+    /// Override the peer reconnect grace. Test hook — the grace is a fixed
+    /// constant by design.
+    #[doc(hidden)]
+    #[must_use]
+    pub fn with_reconnect_grace(mut self, grace: std::time::Duration) -> Self {
+        self.state.reconnect_grace = grace;
+        self
+    }
+
     /// Launch the MCP server.
     ///
     /// This is a convenience method that provides a stdio-like experience.
@@ -165,7 +184,7 @@ impl Fairing for Cors {
         response.set_header(Header::new("Access-Control-Allow-Origin", "*"));
         response.set_header(Header::new(
             "Access-Control-Allow-Methods",
-            "GET, POST, OPTIONS",
+            "GET, POST, DELETE, OPTIONS",
         ));
         response.set_header(Header::new(
             "Access-Control-Allow-Headers",
@@ -201,7 +220,7 @@ impl Fairing for Cors {
 ///
 ///     rocket::build()
 ///         .manage(state)
-///         .mount("/", routes![mcp_post, mcp_sse])
+///         .mount("/", routes![mcp_post, mcp_get, mcp_delete, mcp_sse])
 ///         .launch()
 ///         .await?;
 ///
@@ -231,37 +250,63 @@ macro_rules! create_mcp_routes {
             .await
         }
 
+        // GET on the MCP endpoint serves SSE (#153); the full
+        // 400/404/403 ladder lives in `handle_sse`.
+        #[rocket::get("/mcp")]
+        fn mcp_get(
+            state: &::rocket::State<$crate::McpState<$handler_type>>,
+            session: $crate::handler::SessionIdHeader,
+            origin: $crate::handler::OriginHeader,
+            user: $crate::handler::VerifiedUserGuard,
+            last_event_id: $crate::handler::LastEventIdHeader,
+        ) -> ::std::result::Result<
+            ::rocket::response::stream::EventStream![],
+            ::rocket::http::Status,
+        > {
+            $crate::handler::handle_sse(
+                state.inner(),
+                session.0,
+                origin.0.as_deref(),
+                user.0,
+                last_event_id.0,
+            )
+        }
+
+        // DELETE on the MCP endpoint terminates the session (#153).
+        #[rocket::delete("/mcp")]
+        fn mcp_delete(
+            state: &::rocket::State<$crate::McpState<$handler_type>>,
+            session: $crate::handler::SessionIdHeader,
+            origin: $crate::handler::OriginHeader,
+            user: $crate::handler::VerifiedUserGuard,
+        ) -> ::rocket::http::Status {
+            $crate::handler::handle_mcp_delete(
+                state.inner(),
+                session.0,
+                origin.0.as_deref(),
+                user.0,
+            )
+        }
+
+        /// Deprecated alias for GET on the MCP endpoint.
         #[rocket::get("/mcp/sse")]
         fn mcp_sse(
             state: &::rocket::State<$crate::McpState<$handler_type>>,
             session: $crate::handler::SessionIdHeader,
             origin: $crate::handler::OriginHeader,
             user: $crate::handler::VerifiedUserGuard,
+            last_event_id: $crate::handler::LastEventIdHeader,
         ) -> ::std::result::Result<
             ::rocket::response::stream::EventStream![],
             ::rocket::http::Status,
         > {
-            // Reject disallowed Origins (DNS-rebinding protection) before streaming.
-            if !state
-                .inner()
-                .origin_validator
-                .is_allowed(origin.0.as_deref())
-            {
-                return ::std::result::Result::Err(::rocket::http::Status::Forbidden);
-            }
-            // Enforce the session's user binding before subscribing a
-            // reconnecting client to its event stream.
-            if let ::std::option::Option::Some(id) = &session.0 {
-                if state
-                    .inner()
-                    .sessions
-                    .touch_verified(id, user.0.as_ref())
-                    .is_err()
-                {
-                    return ::std::result::Result::Err(::rocket::http::Status::Forbidden);
-                }
-            }
-            ::std::result::Result::Ok($crate::handler::handle_sse(state.inner(), session.0))
+            $crate::handler::handle_sse(
+                state.inner(),
+                session.0,
+                origin.0.as_deref(),
+                user.0,
+                last_event_id.0,
+            )
         }
     };
 }

--- a/crates/mcpkit-rocket/src/session.rs
+++ b/crates/mcpkit-rocket/src/session.rs
@@ -4,9 +4,10 @@ use dashmap::DashMap;
 use mcpkit_core::auth::{SessionBindingError, VerifiedUser, check_session_binding};
 use mcpkit_core::capability::ClientCapabilities;
 use mcpkit_core::protocol_version::ProtocolVersion;
+use mcpkit_server::adapter_peer::{OutboundOwner, SessionOutbound};
+use mcpkit_server::streams::{StreamConfig, StreamRegistry};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::sync::broadcast;
 use uuid::Uuid;
 
 /// Default idle timeout after which an inactive session is reaped.
@@ -16,16 +17,15 @@ pub const DEFAULT_SESSION_TIMEOUT: Duration = Duration::from_secs(3600);
 #[derive(Clone)]
 pub struct SessionStore {
     sessions: Arc<DashMap<String, SessionState>>,
-    sse_channels: Arc<DashMap<String, broadcast::Sender<String>>>,
     idle_timeout: Duration,
+    /// Stream configuration applied to each session's SSE stream registry.
+    stream_config: StreamConfig,
     /// Default task retention (ms) applied to each session's task store; `None`
     /// means unlimited. Configure via `McpRouter::with_task_ttl`.
     pub(crate) default_task_ttl: Option<u64>,
 }
 
 struct SessionState {
-    #[allow(dead_code)] // Reserved for future session metadata/debugging
-    created_at: Instant,
     last_seen: Instant,
     /// Protocol version negotiated during initialization.
     protocol_version: Option<ProtocolVersion>,
@@ -36,6 +36,14 @@ struct SessionState {
     /// This session's task store for task-augmented `tools/call` (per-session
     /// isolation for `tasks/*`).
     tasks: Arc<mcpkit_server::capability::tasks::TaskManager>,
+    /// This session's SSE stream registry (#153): per-stream channels,
+    /// single-stream delivery, `{stream_id}-{seq}` ids, same-stream replay.
+    streams: Arc<StreamRegistry>,
+    /// Owner of the outbound-request registry; dropped with the session so
+    /// pending server-initiated requests fail immediately on reap/DELETE.
+    outbound_owner: Arc<OutboundOwner>,
+    /// In-flight notification-hook tasks (aborted on session teardown).
+    hooks: Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>,
 }
 
 impl Default for SessionStore {
@@ -50,8 +58,8 @@ impl SessionStore {
     pub fn new() -> Self {
         Self {
             sessions: Arc::new(DashMap::new()),
-            sse_channels: Arc::new(DashMap::new()),
             idle_timeout: DEFAULT_SESSION_TIMEOUT,
+            stream_config: StreamConfig::default(),
             default_task_ttl: Some(mcpkit_server::capability::tasks::DEFAULT_TASK_TTL_MS),
         }
     }
@@ -85,7 +93,6 @@ impl SessionStore {
         self.sessions.insert(
             id.clone(),
             SessionState {
-                created_at: now,
                 last_seen: now,
                 protocol_version: None,
                 client_capabilities: None,
@@ -95,9 +102,19 @@ impl SessionStore {
                         self.default_task_ttl,
                     ),
                 ),
+                streams: Arc::new(StreamRegistry::new(self.stream_config.clone())),
+                outbound_owner: Arc::new(OutboundOwner::new()),
+                hooks: Arc::new(std::sync::Mutex::new(tokio::task::JoinSet::new())),
             },
         );
         id
+    }
+
+    /// Update the last seen time for a session.
+    pub fn touch(&self, id: &str) {
+        if let Some(mut session) = self.sessions.get_mut(id) {
+            session.last_seen = Instant::now();
+        }
     }
 
     /// Touch a session, enforcing its user binding against the identity
@@ -116,13 +133,6 @@ impl SessionStore {
         check_session_binding(session.user.as_ref(), presenting)?;
         session.last_seen = Instant::now();
         Ok(true)
-    }
-
-    /// Update the last seen time for a session.
-    pub fn touch(&self, id: &str) {
-        if let Some(mut session) = self.sessions.get_mut(id) {
-            session.last_seen = Instant::now();
-        }
     }
 
     /// Record the protocol version and client capabilities negotiated during
@@ -163,31 +173,38 @@ impl SessionStore {
         self.sessions.contains_key(id)
     }
 
-    /// Get or create an SSE channel for a session.
+    /// Set the stream configuration applied to each new session.
     #[must_use]
-    pub fn create_session(&self) -> (String, broadcast::Receiver<String>) {
-        let id = self.create();
-        let (tx, rx) = broadcast::channel(100);
-        self.sse_channels.insert(id.clone(), tx);
-        (id, rx)
+    pub fn with_stream_config(mut self, config: StreamConfig) -> Self {
+        self.stream_config = config;
+        self
     }
 
-    /// Get a receiver for an existing SSE session.
+    /// The SSE stream registry for a session. `None` if unknown.
     #[must_use]
-    pub fn get_receiver(&self, id: &str) -> Option<broadcast::Receiver<String>> {
-        self.sse_channels.get(id).map(|tx| tx.subscribe())
+    pub fn streams(&self, id: &str) -> Option<Arc<StreamRegistry>> {
+        self.sessions.get(id).map(|s| Arc::clone(&s.streams))
     }
 
-    /// Send a message to an SSE session.
-    pub fn send(
-        &self,
-        id: &str,
-        msg: String,
-    ) -> Result<usize, broadcast::error::SendError<String>> {
-        self.sse_channels
+    /// The outbound-request registry for a session. `None` if unknown.
+    #[must_use]
+    pub fn outbound(&self, id: &str) -> Option<Arc<SessionOutbound>> {
+        self.sessions
             .get(id)
-            .ok_or_else(|| broadcast::error::SendError(msg.clone()))
-            .and_then(|tx| tx.send(msg))
+            .map(|s| Arc::clone(s.outbound_owner.outbound()))
+    }
+
+    /// The notification-hook task set for a session. `None` if unknown.
+    #[must_use]
+    pub fn hooks(&self, id: &str) -> Option<Arc<std::sync::Mutex<tokio::task::JoinSet<()>>>> {
+        self.sessions.get(id).map(|s| Arc::clone(&s.hooks))
+    }
+
+    /// Terminate and remove a session (DELETE). Dropping it drops the
+    /// `OutboundOwner`, failing all pending server-initiated requests.
+    #[must_use]
+    pub fn remove(&self, id: &str) -> bool {
+        self.sessions.remove(id).is_some()
     }
 
     /// Remove sessions older than the given duration.
@@ -302,44 +319,28 @@ mod tests {
         assert!(store.exists(&id));
     }
 
-    #[tokio::test]
-    async fn test_session_store_sse_channel() {
+    #[test]
+    fn test_session_store_peer_accessors() {
         let store = SessionStore::new();
-        let (id, mut rx) = store.create_session();
+        let id = store.create();
 
-        // Session should exist
-        assert!(store.exists(&id));
+        assert!(store.streams(&id).is_some());
+        assert!(store.outbound(&id).is_some());
+        assert!(store.hooks(&id).is_some());
 
-        // Send a message
-        let result = store.send(&id, "test message".to_string());
-        assert!(result.is_ok());
-
-        // Receive the message
-        let msg = rx.recv().await.unwrap();
-        assert_eq!(msg, "test message");
+        assert!(store.streams("non-existent").is_none());
+        assert!(store.outbound("non-existent").is_none());
+        assert!(store.hooks("non-existent").is_none());
     }
 
     #[test]
-    fn test_session_store_get_receiver() {
+    fn test_session_store_remove() {
         let store = SessionStore::new();
-        let (id, _rx) = store.create_session();
+        let id = store.create();
 
-        // Should be able to get another receiver
-        let rx2 = store.get_receiver(&id);
-        assert!(rx2.is_some());
-
-        // Non-existent session should return None
-        let rx3 = store.get_receiver("non-existent");
-        assert!(rx3.is_none());
-    }
-
-    #[test]
-    fn test_session_store_send_to_nonexistent() {
-        let store = SessionStore::new();
-
-        // Sending to non-existent session should fail
-        let result = store.send("non-existent", "test".to_string());
-        assert!(result.is_err());
+        assert!(store.remove(&id));
+        assert!(!store.exists(&id));
+        assert!(!store.remove(&id));
     }
 
     #[test]

--- a/crates/mcpkit-rocket/src/state.rs
+++ b/crates/mcpkit-rocket/src/state.rs
@@ -26,8 +26,6 @@ pub struct McpState<H> {
     pub server_info: ServerInfo,
     /// Session manager for tracking client sessions.
     pub sessions: SessionStore,
-    /// SSE session manager for Server-Sent Events.
-    pub sse_sessions: SessionStore,
     /// Validates request `Origin` headers (DNS-rebinding protection). Defaults
     /// to loopback-only.
     pub origin_validator: Arc<OriginValidator>,
@@ -35,6 +33,11 @@ pub struct McpState<H> {
     pub list_page_size: Option<usize>,
     /// Optional completion handler for `completion/complete`.
     pub completion: Option<Arc<dyn mcpkit_server::dispatch::DynCompletionHandler>>,
+    /// Timeouts applied to server-initiated requests (#153).
+    pub peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts,
+    /// Grace period a server-initiated send waits for a live stream; tunable
+    /// for tests via `McpRouter::with_reconnect_grace`.
+    pub(crate) reconnect_grace: std::time::Duration,
 }
 
 impl<H> McpState<H>
@@ -48,10 +51,11 @@ where
             handler: Arc::new(handler),
             server_info,
             sessions: SessionStore::new(),
-            sse_sessions: SessionStore::new(),
             origin_validator: Arc::new(OriginValidator::default()),
             list_page_size: None,
             completion: None,
+            peer_timeouts: mcpkit_server::adapter_peer::PeerTimeouts::default(),
+            reconnect_grace: mcpkit_server::adapter_peer::RECONNECT_GRACE,
         }
     }
 
@@ -71,10 +75,11 @@ impl<H> Clone for McpState<H> {
             handler: Arc::clone(&self.handler),
             server_info: self.server_info.clone(),
             sessions: self.sessions.clone(),
-            sse_sessions: self.sse_sessions.clone(),
             origin_validator: Arc::clone(&self.origin_validator),
             list_page_size: self.list_page_size,
             completion: self.completion.clone(),
+            peer_timeouts: self.peer_timeouts,
+            reconnect_grace: self.reconnect_grace,
         }
     }
 }
@@ -227,12 +232,9 @@ mod tests {
     fn test_mcp_state_sessions() {
         let state = McpState::new(TestHandler);
 
-        // Create sessions in both stores
-        let id1 = state.sessions.create();
-        let id2 = state.sse_sessions.create();
+        let id = state.sessions.create();
 
-        assert!(state.sessions.exists(&id1));
-        assert!(state.sse_sessions.exists(&id2));
+        assert!(state.sessions.exists(&id));
     }
 
     #[test]

--- a/crates/mcpkit-rocket/tests/integration.rs
+++ b/crates/mcpkit-rocket/tests/integration.rs
@@ -117,7 +117,7 @@ fn create_test_client() -> Client {
     let state = McpRouter::new(TestHandler).into_state();
     let rocket = rocket::build()
         .manage(state)
-        .mount("/", rocket::routes![mcp_post, mcp_sse]);
+        .mount("/", rocket::routes![mcp_post, mcp_get, mcp_delete, mcp_sse]);
     Client::tracked(rocket).expect("valid rocket instance")
 }
 

--- a/crates/mcpkit-rocket/tests/peer_e2e.rs
+++ b/crates/mcpkit-rocket/tests/peer_e2e.rs
@@ -1,0 +1,413 @@
+//! #153 PR 5 (rocket port): SSE binding rules + server-initiated requests
+//! end-to-end — the same matrix as the axum/actix/warp `peer_e2e` suites.
+
+use mcpkit_core::auth::VerifiedUser;
+use mcpkit_core::capability::ServerInfo;
+use mcpkit_core::error::McpError;
+use mcpkit_core::types::{
+    ElicitRequest, ElicitationSchema, GetPromptResult, Prompt, Resource, ResourceContents, Root,
+    Tool, ToolOutput,
+};
+use mcpkit_rocket::{McpRouter, McpState};
+use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
+use rocket::http::{ContentType, Header};
+use rocket::local::asynchronous::Client;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+#[derive(Clone, Default)]
+struct Observed {
+    initialized: Arc<AtomicBool>,
+    roots: Arc<Mutex<Option<Result<Vec<Root>, String>>>>,
+}
+
+#[derive(Clone)]
+struct H(Observed);
+
+impl ServerHandler for H {
+    fn server_info(&self) -> ServerInfo {
+        ServerInfo::new("t", "1.0.0")
+    }
+    async fn on_initialized(&self, _ctx: &Context<'_>) {
+        self.0.initialized.store(true, Ordering::SeqCst);
+    }
+    async fn on_roots_list_changed(&self, ctx: &Context<'_>) {
+        let result = ctx.list_roots().await.map_err(|e| e.to_string());
+        *self.0.roots.lock().unwrap() = Some(result);
+    }
+}
+impl ToolHandler for H {
+    async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
+        Ok(vec![Tool::new("ask")])
+    }
+    async fn call_tool(
+        &self,
+        name: &str,
+        _args: serde_json::Map<String, serde_json::Value>,
+        ctx: &Context<'_>,
+    ) -> Result<ToolOutput, McpError> {
+        match name {
+            "ask" => {
+                let schema = serde_json::from_value::<ElicitationSchema>(
+                    serde_json::json!({ "type": "object", "properties": {} }),
+                )
+                .expect("schema");
+                match ctx.elicit(ElicitRequest::new("pick a color", schema)).await {
+                    Ok(result) => Ok(ToolOutput::text(format!(
+                        "elicited: {}",
+                        serde_json::to_value(&result)
+                            .unwrap_or_default()
+                            .get("content")
+                            .and_then(|c| c.get("answer"))
+                            .and_then(|a| a.as_str())
+                            .unwrap_or("<none>")
+                    ))),
+                    Err(e) => Ok(ToolOutput::text(format!("elicit failed: {e}"))),
+                }
+            }
+            other => Err(McpError::method_not_found(other)),
+        }
+    }
+}
+impl ResourceHandler for H {
+    async fn list_resources(&self, _ctx: &Context<'_>) -> Result<Vec<Resource>, McpError> {
+        Ok(vec![])
+    }
+    async fn read_resource(
+        &self,
+        _uri: &str,
+        _ctx: &Context<'_>,
+    ) -> Result<Vec<ResourceContents>, McpError> {
+        Ok(vec![])
+    }
+}
+impl PromptHandler for H {
+    async fn list_prompts(&self, _ctx: &Context<'_>) -> Result<Vec<Prompt>, McpError> {
+        Ok(vec![])
+    }
+    async fn get_prompt(
+        &self,
+        name: &str,
+        _args: Option<serde_json::Map<String, serde_json::Value>>,
+        _ctx: &Context<'_>,
+    ) -> Result<GetPromptResult, McpError> {
+        Err(McpError::method_not_found(name))
+    }
+}
+
+mcpkit_rocket::create_mcp_routes!(H);
+
+async fn setup() -> (Arc<Client>, McpState<H>, Observed) {
+    let observed = Observed::default();
+    let state = McpRouter::new(H(observed.clone()))
+        .with_reconnect_grace(Duration::from_millis(100))
+        .into_state();
+    let rocket = rocket::build()
+        .manage(state.clone())
+        .mount("/", rocket::routes![mcp_post, mcp_get, mcp_delete, mcp_sse]);
+    let client = Client::tracked(rocket).await.expect("client");
+    (Arc::new(client), state, observed)
+}
+
+async fn post(
+    client: &Client,
+    session: Option<&str>,
+    body: serde_json::Value,
+) -> (u16, serde_json::Value) {
+    let mut req = client
+        .post("/mcp")
+        .header(ContentType::JSON)
+        .body(body.to_string());
+    if let Some(s) = session {
+        req = req.header(Header::new("mcp-session-id", s.to_string()));
+    }
+    let resp = req.dispatch().await;
+    let status = resp.status().code;
+    let text = resp.into_string().await.unwrap_or_default();
+    let json = if text.is_empty() {
+        serde_json::Value::Null
+    } else {
+        serde_json::from_str(&text).unwrap_or(serde_json::Value::Null)
+    };
+    (status, json)
+}
+
+async fn init(client: &Client) -> String {
+    let resp = client
+        .post("/mcp")
+        .header(ContentType::JSON)
+        .body(
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 0, "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-11-25",
+                    "capabilities": { "roots": {}, "elicitation": {} }
+                }
+            })
+            .to_string(),
+        )
+        .dispatch()
+        .await;
+    resp.headers()
+        .get_one("mcp-session-id")
+        .map(String::from)
+        .expect("session id")
+}
+
+fn sse_status(state: &McpState<H>, session: Option<&str>, user: Option<VerifiedUser>) -> u16 {
+    match mcpkit_rocket::handle_sse(state, session.map(String::from), None, user, None) {
+        Ok(_) => 200,
+        Err(status) => status.code,
+    }
+}
+
+async fn next_stream_request(
+    handle: &mut mcpkit_server::streams::StreamHandle,
+) -> serde_json::Value {
+    loop {
+        let event = tokio::time::timeout(Duration::from_secs(5), handle.recv())
+            .await
+            .expect("stream event within 5s")
+            .expect("stream open");
+        if event.event_type == "message" {
+            return serde_json::from_str(&event.data).expect("json-rpc message");
+        }
+    }
+}
+
+// ---- SSE binding rules (#172/#173 for rocket) ------------------------------
+
+#[tokio::test]
+async fn sse_without_session_id_is_400() {
+    let (_, state, _) = setup().await;
+    assert_eq!(sse_status(&state, None, None), 400);
+}
+
+#[tokio::test]
+async fn sse_with_unknown_session_id_is_404_and_never_adopts_it() {
+    let (_, state, _) = setup().await;
+    assert_eq!(sse_status(&state, Some("attacker-chosen-id"), None), 404);
+    assert!(!state.sessions.exists("attacker-chosen-id"));
+}
+
+#[tokio::test]
+async fn sse_with_other_users_session_is_403() {
+    let (_, state, _) = setup().await;
+    let alice = VerifiedUser::new("alice").issuer("https://idp");
+    let bob = VerifiedUser::new("bob").issuer("https://idp");
+    let sid = state.sessions.create_for_user(Some(alice));
+
+    assert_eq!(sse_status(&state, Some(&sid), Some(bob)), 403);
+    assert_eq!(sse_status(&state, Some(&sid), None), 403);
+}
+
+#[tokio::test]
+async fn sse_with_own_session_streams() {
+    let (_, state, _) = setup().await;
+    let sid = state.sessions.create();
+    assert_eq!(sse_status(&state, Some(&sid), None), 200);
+}
+
+#[tokio::test]
+async fn get_on_mcp_endpoint_serves_sse() {
+    let (client, _, _) = setup().await;
+    let sid = init(&client).await;
+    // Check only status and headers — an SSE body never ends.
+    let resp = client
+        .get("/mcp")
+        .header(Header::new("mcp-session-id", sid))
+        .dispatch()
+        .await;
+    assert_eq!(resp.status().code, 200);
+    assert!(
+        resp.content_type()
+            .is_some_and(|ct| ct.to_string().starts_with("text/event-stream")),
+        "GET on the MCP endpoint must open an SSE stream"
+    );
+}
+
+// ---- server-initiated requests (the #153 feature) --------------------------
+
+#[tokio::test]
+async fn tool_elicitation_round_trips_over_the_stream() {
+    let (client, state, _) = setup().await;
+    let sid = init(&client).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let call = {
+        let client = Arc::clone(&client);
+        let sid = sid.clone();
+        tokio::spawn(async move {
+            post(
+                &client,
+                Some(&sid),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": { "name": "ask", "arguments": {} }
+                }),
+            )
+            .await
+            .1
+        })
+    };
+
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+    let request_id = request["id"].clone();
+
+    let (status, _) = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "action": "accept", "content": { "answer": "blue" } }
+        }),
+    )
+    .await;
+    assert_eq!(status, 202);
+
+    let result = call.await.expect("join");
+    let text = result["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert_eq!(text, "elicited: blue", "tool result: {result}");
+}
+
+#[tokio::test]
+async fn roots_hook_round_trips_over_the_stream() {
+    let (client, state, observed) = setup().await;
+    let sid = init(&client).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let _ = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/roots/list_changed" }),
+    )
+    .await;
+
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "roots/list");
+    let request_id = request["id"].clone();
+
+    let _ = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "roots": [{ "uri": "file:///w", "name": "w" }] }
+        }),
+    )
+    .await;
+
+    for _ in 0..100 {
+        if observed.roots.lock().unwrap().is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    let roots = observed
+        .roots
+        .lock()
+        .unwrap()
+        .clone()
+        .expect("hook ran")
+        .expect("list_roots succeeded");
+    assert_eq!(roots.len(), 1);
+    assert_eq!(roots[0].uri, "file:///w");
+}
+
+#[tokio::test]
+async fn on_initialized_hook_fires() {
+    let (client, _, observed) = setup().await;
+    let sid = init(&client).await;
+    let _ = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "method": "notifications/initialized" }),
+    )
+    .await;
+    for _ in 0..100 {
+        if observed.initialized.load(Ordering::SeqCst) {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    panic!("on_initialized hook never fired");
+}
+
+#[tokio::test]
+async fn elicit_without_stream_fails_fast() {
+    let (client, _, _) = setup().await; // 100ms grace
+    let sid = init(&client).await;
+
+    let started = std::time::Instant::now();
+    let (_, resp) = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "ask", "arguments": {} }
+        }),
+    )
+    .await;
+    let text = resp["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.starts_with("elicit failed:"), "got: {resp}");
+    assert!(started.elapsed() < Duration::from_secs(30));
+}
+
+#[tokio::test]
+async fn delete_fails_pending_and_forgets_the_session() {
+    let (client, state, _) = setup().await;
+    let sid = init(&client).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    let call = {
+        let client = Arc::clone(&client);
+        let sid = sid.clone();
+        tokio::spawn(async move {
+            post(
+                &client,
+                Some(&sid),
+                serde_json::json!({
+                    "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+                    "params": { "name": "ask", "arguments": {} }
+                }),
+            )
+            .await
+            .1
+        })
+    };
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+
+    let resp = client
+        .delete("/mcp")
+        .header(Header::new("mcp-session-id", sid.clone()))
+        .dispatch()
+        .await;
+    assert_eq!(resp.status().code, 204);
+
+    let result = tokio::time::timeout(Duration::from_secs(5), call)
+        .await
+        .expect("pending request must fail on DELETE, not run out its timeout")
+        .expect("join");
+    let text = result["result"]["content"][0]["text"]
+        .as_str()
+        .unwrap_or_default();
+    assert!(text.starts_with("elicit failed:"), "got: {result}");
+
+    let (status, _) = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({ "jsonrpc": "2.0", "id": 9, "method": "ping" }),
+    )
+    .await;
+    assert_eq!(status, 404);
+}


### PR DESCRIPTION
PR 5c of the #153 design v3 — last of the three adapter ports (actix #181, warp #182). With this, every HTTP adapter has the full session/stream/peer substrate. Closes the adapter scope of #172/#173 (I'll close both after merge with a summary comment); #153 stays open for PR 6 (peer injection into background tasks).

## What

The rocket adapter reaches the axum baseline in one PR (substrate + peer):

- **Unified session** — `session.rs` is warp's ported file transplanted (they were parallel copies pre-port); the per-session broadcast channel (`sse_channels`) is replaced by the shared `StreamRegistry` + `OutboundOwner` + hook `JoinSet`. SSE binding enforced with the full ladder: 400 missing id / 404 unknown-and-never-adopted / 403 disallowed origin or mismatched user. **Rocket previously created a brand-new session for any GET with a missing or unknown id** — the worst deviation of the three adapters: an attacker-presented id was silently replaced with a fresh session, and unauthenticated GETs minted sessions that never initialized.
- **Single MCP endpoint** — `create_mcp_routes!` now emits `mcp_get` (GET /mcp) and `mcp_delete` (DELETE /mcp) alongside `mcp_post`; `/mcp/sse` stays as a deprecated alias; the CORS fairing allows DELETE. The 400/404/403 ladder moved out of the macro body into `handle_sse` itself, so it is testable and not re-expanded per handler type.
- **Per-stream delivery** — rocket previously fanned every message out to all connected streams with random per-emit `evt-{uuid}` ids (replay impossible; ids unstable across emits). Now on the shared registry: `{stream_id}-{seq}` ids, same-stream `Last-Event-ID` replay, `retry: 2000`, overflow-kill. Rocket's generator-style `EventStream!` makes the replay-then-live chain the simplest of the four adapters.
- **The peer** — `ctx.elicit()`/`ctx.list_roots()`/sampling work over rocket; response POSTs correlate; notification hooks dispatch off the request path; DELETE fails pending requests immediately. The store hands out plain `Arc`s (never the `OutboundOwner`), so the axum snapshot-drop hazard can't arise here by construction.

**Breaking (rocket):** the broadcast plumbing is removed — `McpState.sse_sessions`, `SessionStore::{get_receiver, send}`, and the inherent `create_session` (id + broadcast receiver) are gone; sessions are created id-only via `create`/`create_for_user`. `handle_sse` now takes the session id, origin, user, and `Last-Event-ID` and returns `Result<EventStream![], Status>`.

## Tests

The full 10-test matrix ported from the axum/actix/warp suites, adapted to rocket mechanics: `McpResponse`'s fields are private, so POSTs are driven through `rocket::local::asynchronous::Client` (with `create_mcp_routes!` expanded in the test), while the SSE side is tapped via the shared registry's `StreamHandle` — the same pattern the other suites use. The GET-routing test checks status and content-type only (an SSE body never ends). All pass, plus the transplanted session unit tests and the existing integration suite (its mount updated to the four routes). Full local gate green: fmt, clippy `-D warnings` (1.97), rustdoc, workspace tests.

Refs #153.