### PR TITLE
feat(server)!: carry the session peer into task-augmented tools (#153 PR 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Task-augmented tools keep their peer** (#153 PR 6, the design's final
+  slice): `begin_augmented_task` and `run_augmented_tool` now take the
+  session peer and carry it into the spawned background future, so a
+  task-augmented tool on any HTTP adapter can `ctx.elicit()` /
+  `ctx.list_roots()` / sample mid-task — the request rides the session's
+  SSE stream and the client's response POST correlates as usual, while
+  notifications ride the store-and-drop path and never fail the tool.
+  This closes the last `NoOpPeer` in the adapters (the #122 limitation
+  note above is amended accordingly). **Breaking:**
+  `begin_augmented_task` and `run_augmented_tool` gain a
+  `peer: Arc<dyn Peer>` parameter, and the adapters'
+  `create_response_for_request` peer parameter is now
+  `Arc<dyn Peer>` (was `&dyn Peer`)
+  ([#153](https://github.com/praxiomlabs/mcpkit/issues/153)).
+
 - **The rocket adapter reaches the axum baseline** (#153 PR 5, last of the
   three ports — every adapter now has the full session/stream/peer substrate):
   unified session registry (SSE binding: 400 missing id / 404
@@ -358,11 +373,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - **Per-session isolation:** each MCP session owns its task store (mirroring the
     stdio runtime's per-connection store), so one session cannot read or cancel
     another's tasks.
-  - **Limitations (documented):** an adapter background task runs with a
-    `NoOpPeer`, so it cannot make server-to-client requests (elicitation/sampling)
-    and its notifications/logging/progress are dropped; cancellation via
-    `tasks/cancel` still trips the tool's `ctx.cancelled()`. Background tasks are
-    fire-and-forget (no graceful shutdown drain)
+  - **Limitations (documented):** background tasks are fire-and-forget (no
+    graceful shutdown drain). (An earlier limitation — adapter background
+    tasks ran with a `NoOpPeer` and could not make server-to-client
+    requests — was lifted by #153: the session peer is carried into the
+    spawned task.) Cancellation via `tasks/cancel` trips the tool's
+    `ctx.cancelled()`
     ([#122](https://github.com/praxiomlabs/mcpkit/issues/122)).
 - Inbound client-notification dispatch to `ServerHandler` hooks (#141). The stdio
   `ServerRuntime` previously logged `notifications/initialized` and never invoked

--- a/crates/mcpkit-actix/src/handler.rs
+++ b/crates/mcpkit-actix/src/handler.rs
@@ -181,13 +181,13 @@ where
             // ctx.elicit()/ctx.list_roots()/sampling; the request rides the
             // session's SSE stream and the client answers via a response POST
             // correlated below.
-            let peer: Box<dyn mcpkit_server::Peer> = match &session {
-                Some(s) => Box::new(session_peer(
+            let peer: std::sync::Arc<dyn mcpkit_server::Peer> = match &session {
+                Some(s) => std::sync::Arc::new(session_peer(
                     &state,
                     Arc::clone(&s.streams),
                     Arc::clone(s.outbound_owner.outbound()),
                 )),
-                None => Box::new(NoOpPeer),
+                None => std::sync::Arc::new(NoOpPeer),
             };
             // Release the snapshot before awaiting: it holds the session's
             // OutboundOwner, and a request blocked in ctx.elicit() must not
@@ -199,7 +199,7 @@ where
                 protocol_version,
                 &client_caps,
                 task_store.as_ref(),
-                peer.as_ref(),
+                peer,
             )
             .await;
 
@@ -310,7 +310,7 @@ async fn create_response_for_request<H>(
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
     task_store: Option<&Arc<TaskManager>>,
-    peer: &dyn mcpkit_server::Peer,
+    peer: std::sync::Arc<dyn mcpkit_server::Peer>,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -330,7 +330,7 @@ where
         client_caps,
         &server_caps,
         protocol_version,
-        peer,
+        peer.as_ref(),
     );
 
     match method {
@@ -355,6 +355,7 @@ where
                         client_caps.clone(),
                         server_caps.clone(),
                         protocol_version,
+                        std::sync::Arc::clone(&peer),
                     )
                     .await
                     {

--- a/crates/mcpkit-actix/tests/peer_e2e.rs
+++ b/crates/mcpkit-actix/tests/peer_e2e.rs
@@ -10,7 +10,7 @@ use mcpkit_core::capability::ServerInfo;
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
     ElicitRequest, ElicitationSchema, GetPromptResult, Prompt, Resource, ResourceContents, Root,
-    Tool, ToolOutput,
+    TaskSupport, Tool, ToolOutput,
 };
 use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -40,7 +40,7 @@ impl ServerHandler for H {
 }
 impl ToolHandler for H {
     async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
-        Ok(vec![Tool::new("ask")])
+        Ok(vec![Tool::new("ask").task_support(TaskSupport::Optional)])
     }
     async fn call_tool(
         &self,
@@ -427,4 +427,64 @@ async fn delete_fails_pending_and_forgets_the_session() {
     )
     .await;
     assert_eq!(status, actix_web::http::StatusCode::NOT_FOUND);
+}
+
+#[actix_rt::test]
+async fn task_augmented_tool_elicits_over_the_stream() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    // A task-augmented call replies immediately with CreateTaskResult...
+    let created = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "ask", "arguments": {}, "task": {} }
+        }),
+    )
+    .await
+    .1;
+    let task_id = created["result"]["task"]["taskId"]
+        .as_str()
+        .expect("taskId")
+        .to_string();
+
+    // ...while the background tool elicits over the session stream (#153
+    // PR 6: the peer survives into the spawned task).
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+    let request_id = request["id"].clone();
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "action": "accept", "content": { "answer": "blue" } }
+        }),
+    )
+    .await;
+
+    // tasks/result yields the tool result once the elicited answer lands.
+    let mut text = String::new();
+    for _ in 0..100 {
+        let result = post(
+            &state,
+            Some(&sid),
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 9, "method": "tasks/result",
+                "params": { "taskId": task_id }
+            }),
+        )
+        .await
+        .1;
+        if let Some(t) = result["result"]["content"][0]["text"].as_str() {
+            text = t.to_string();
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(text, "elicited: blue");
 }

--- a/crates/mcpkit-axum/src/handler.rs
+++ b/crates/mcpkit-axum/src/handler.rs
@@ -205,13 +205,13 @@ where
             // call ctx.elicit()/ctx.list_roots()/sampling; the request rides
             // the session's SSE stream and the client answers via a response
             // POST correlated below.
-            let peer: Box<dyn mcpkit_server::Peer> = match &session {
-                Some(s) => Box::new(session_peer(
+            let peer: std::sync::Arc<dyn mcpkit_server::Peer> = match &session {
+                Some(s) => std::sync::Arc::new(session_peer(
                     &state,
                     Arc::clone(&s.streams),
                     Arc::clone(s.outbound_owner.outbound()),
                 )),
-                None => Box::new(NoOpPeer),
+                None => std::sync::Arc::new(NoOpPeer),
             };
             // Release the snapshot before awaiting: it holds the session's
             // OutboundOwner, and a request blocked in ctx.elicit() must not
@@ -223,7 +223,7 @@ where
                 protocol_version,
                 &client_caps,
                 task_store.as_ref(),
-                peer.as_ref(),
+                peer,
             )
             .await;
 
@@ -349,7 +349,7 @@ async fn create_response_for_request<H>(
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
     task_store: Option<&Arc<TaskManager>>,
-    peer: &dyn mcpkit_server::Peer,
+    peer: std::sync::Arc<dyn mcpkit_server::Peer>,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -369,7 +369,7 @@ where
         client_caps,
         &server_caps,
         protocol_version,
-        peer,
+        peer.as_ref(),
     );
 
     match method {
@@ -394,6 +394,7 @@ where
                         client_caps.clone(),
                         server_caps.clone(),
                         protocol_version,
+                        std::sync::Arc::clone(&peer),
                     )
                     .await
                     {

--- a/crates/mcpkit-axum/tests/peer_e2e.rs
+++ b/crates/mcpkit-axum/tests/peer_e2e.rs
@@ -14,7 +14,7 @@ use mcpkit_core::capability::ServerInfo;
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
     ElicitRequest, ElicitationSchema, GetPromptResult, Prompt, Resource, ResourceContents, Root,
-    Tool, ToolOutput,
+    TaskSupport, Tool, ToolOutput,
 };
 use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -44,7 +44,7 @@ impl ServerHandler for H {
 }
 impl ToolHandler for H {
     async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
-        Ok(vec![Tool::new("ask")])
+        Ok(vec![Tool::new("ask").task_support(TaskSupport::Optional)])
     }
     async fn call_tool(
         &self,
@@ -383,4 +383,64 @@ async fn delete_fails_pending_and_forgets_the_session() {
         resp.get("result").is_none(),
         "expected session-not-found, got: {resp}"
     );
+}
+
+#[tokio::test]
+async fn task_augmented_tool_elicits_over_the_stream() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    // A task-augmented call replies immediately with CreateTaskResult...
+    let created = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "ask", "arguments": {}, "task": {} }
+        }),
+    )
+    .await
+    .0;
+    let task_id = created["result"]["task"]["taskId"]
+        .as_str()
+        .expect("taskId")
+        .to_string();
+
+    // ...while the background tool elicits over the session stream (#153
+    // PR 6: the peer survives into the spawned task).
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+    let request_id = request["id"].clone();
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "action": "accept", "content": { "answer": "blue" } }
+        }),
+    )
+    .await;
+
+    // tasks/result yields the tool result once the elicited answer lands.
+    let mut text = String::new();
+    for _ in 0..100 {
+        let result = post(
+            &state,
+            Some(&sid),
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 9, "method": "tasks/result",
+                "params": { "taskId": task_id }
+            }),
+        )
+        .await
+        .0;
+        if let Some(t) = result["result"]["content"][0]["text"].as_str() {
+            text = t.to_string();
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(text, "elicited: blue");
 }

--- a/crates/mcpkit-rocket/src/handler.rs
+++ b/crates/mcpkit-rocket/src/handler.rs
@@ -362,12 +362,14 @@ where
             // correlated below. The store hands out plain Arcs (never the
             // OutboundOwner), so holding these across the await cannot keep
             // DELETE/reap from failing pending requests.
-            let peer: Box<dyn mcpkit_server::Peer> = match (
+            let peer: std::sync::Arc<dyn mcpkit_server::Peer> = match (
                 state.sessions.streams(&session_id),
                 state.sessions.outbound(&session_id),
             ) {
-                (Some(streams), Some(outbound)) => Box::new(session_peer(state, streams, outbound)),
-                _ => Box::new(NoOpPeer),
+                (Some(streams), Some(outbound)) => {
+                    std::sync::Arc::new(session_peer(state, streams, outbound))
+                }
+                _ => std::sync::Arc::new(NoOpPeer),
             };
             let response = create_response_for_request(
                 state,
@@ -375,7 +377,7 @@ where
                 protocol_version,
                 &client_caps,
                 task_store.as_ref(),
-                peer.as_ref(),
+                peer,
             )
             .await;
 
@@ -484,7 +486,7 @@ async fn create_response_for_request<H>(
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
     task_store: Option<&Arc<TaskManager>>,
-    peer: &dyn mcpkit_server::Peer,
+    peer: std::sync::Arc<dyn mcpkit_server::Peer>,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -504,7 +506,7 @@ where
         client_caps,
         &server_caps,
         protocol_version,
-        peer,
+        peer.as_ref(),
     );
 
     match method {
@@ -529,6 +531,7 @@ where
                         client_caps.clone(),
                         server_caps.clone(),
                         protocol_version,
+                        std::sync::Arc::clone(&peer),
                     )
                     .await
                     {

--- a/crates/mcpkit-rocket/tests/peer_e2e.rs
+++ b/crates/mcpkit-rocket/tests/peer_e2e.rs
@@ -6,7 +6,7 @@ use mcpkit_core::capability::ServerInfo;
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
     ElicitRequest, ElicitationSchema, GetPromptResult, Prompt, Resource, ResourceContents, Root,
-    Tool, ToolOutput,
+    TaskSupport, Tool, ToolOutput,
 };
 use mcpkit_rocket::{McpRouter, McpState};
 use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
@@ -39,7 +39,7 @@ impl ServerHandler for H {
 }
 impl ToolHandler for H {
     async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
-        Ok(vec![Tool::new("ask")])
+        Ok(vec![Tool::new("ask").task_support(TaskSupport::Optional)])
     }
     async fn call_tool(
         &self,
@@ -410,4 +410,64 @@ async fn delete_fails_pending_and_forgets_the_session() {
     )
     .await;
     assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn task_augmented_tool_elicits_over_the_stream() {
+    let (client, state, _) = setup().await;
+    let sid = init(&client).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    // A task-augmented call replies immediately with CreateTaskResult...
+    let created = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "ask", "arguments": {}, "task": {} }
+        }),
+    )
+    .await
+    .1;
+    let task_id = created["result"]["task"]["taskId"]
+        .as_str()
+        .expect("taskId")
+        .to_string();
+
+    // ...while the background tool elicits over the session stream (#153
+    // PR 6: the peer survives into the spawned task).
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+    let request_id = request["id"].clone();
+    let _ = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "action": "accept", "content": { "answer": "blue" } }
+        }),
+    )
+    .await;
+
+    // tasks/result yields the tool result once the elicited answer lands.
+    let mut text = String::new();
+    for _ in 0..100 {
+        let result = post(
+            &client,
+            Some(&sid),
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 9, "method": "tasks/result",
+                "params": { "taskId": task_id }
+            }),
+        )
+        .await
+        .1;
+        if let Some(t) = result["result"]["content"][0]["text"].as_str() {
+            text = t.to_string();
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(text, "elicited: blue");
 }

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -693,12 +693,14 @@ pub async fn call_tool_json(
 /// through the task-store `handle`.
 ///
 /// Built for HTTP adapters, which spawn this onto their own executor after
-/// replying with the initial `CreateTaskResult`. The background context uses a
-/// [`NoOpPeer`](crate::context::NoOpPeer): a task-augmented tool on an adapter
-/// cannot make server-to-client requests (elicitation/sampling) and its
-/// notifications/logging/progress are dropped. Cancellation still works — the
-/// handle's cancellation token is wired into the context, so a cooperative tool
-/// awaiting `ctx.cancelled()` observes `tasks/cancel`.
+/// replying with the initial `CreateTaskResult`. The background context carries
+/// the session `peer` (#153), so a task-augmented tool can make
+/// server-to-client requests (elicitation/sampling/roots) and its notifications
+/// ride the session's SSE stream like any other outbound message (store-and-drop
+/// without a live stream — they never fail the tool). Cancellation works too —
+/// the handle's cancellation token is wired into the context, so a cooperative
+/// tool awaiting `ctx.cancelled()` observes `tasks/cancel`.
+#[allow(clippy::too_many_arguments)]
 pub async fn run_augmented_tool(
     handler: std::sync::Arc<dyn DynToolHandler>,
     handle: crate::capability::tasks::TaskHandle,
@@ -707,9 +709,9 @@ pub async fn run_augmented_tool(
     client_caps: mcpkit_core::capability::ClientCapabilities,
     server_caps: mcpkit_core::capability::ServerCapabilities,
     protocol_version: mcpkit_core::protocol_version::ProtocolVersion,
+    peer: std::sync::Arc<dyn crate::context::Peer>,
 ) {
-    use crate::context::{Context, NoOpPeer};
-    let peer = NoOpPeer;
+    use crate::context::Context;
     let request_id = mcpkit_core::protocol::RequestId::String(handle.id().as_str().to_string());
     let ctx = match handle.cancel_token() {
         Some(token) => Context::with_cancellation(
@@ -718,7 +720,7 @@ pub async fn run_augmented_tool(
             &client_caps,
             &server_caps,
             protocol_version,
-            &peer,
+            peer.as_ref(),
             token,
         ),
         None => Context::new(
@@ -727,7 +729,7 @@ pub async fn run_augmented_tool(
             &client_caps,
             &server_caps,
             protocol_version,
-            &peer,
+            peer.as_ref(),
         ),
     };
     match call_tool_json(handler.as_ref(), &name, args, &ctx).await {
@@ -772,8 +774,9 @@ pub enum AugmentedTaskOutcome {
 /// Mirrors the stdio runtime's `try_begin_task`: detect the `task` field, gate on
 /// the tool's declared `taskSupport`, create the task, and return the initial
 /// `CreateTaskResult` plus a background future the caller spawns. Only call this
-/// for the `tools/call` method. See [`run_augmented_tool`] for the background
-/// context's limitations (no server-to-client from the tool).
+/// for the `tools/call` method. The `peer` is carried into the background
+/// context (#153), so the tool keeps its server-to-client request capability
+/// after the initial `CreateTaskResult` reply.
 pub async fn begin_augmented_task(
     handler: std::sync::Arc<dyn DynToolHandler>,
     store: &std::sync::Arc<crate::capability::tasks::TaskManager>,
@@ -781,6 +784,7 @@ pub async fn begin_augmented_task(
     client_caps: mcpkit_core::capability::ClientCapabilities,
     server_caps: mcpkit_core::capability::ServerCapabilities,
     protocol_version: mcpkit_core::protocol_version::ProtocolVersion,
+    peer: std::sync::Arc<dyn crate::context::Peer>,
 ) -> AugmentedTaskOutcome {
     use mcpkit_core::types::TaskSupport;
 
@@ -847,6 +851,7 @@ pub async fn begin_augmented_task(
         client_caps,
         server_caps,
         protocol_version,
+        peer,
     );
     AugmentedTaskOutcome::Started(create_result, Box::pin(fut))
 }

--- a/crates/mcpkit-warp/src/handler.rs
+++ b/crates/mcpkit-warp/src/handler.rs
@@ -255,14 +255,14 @@ where
             // correlated below. The store hands out plain Arcs (never the
             // OutboundOwner), so holding these across the await cannot keep
             // DELETE/reap from failing pending requests.
-            let peer: Box<dyn mcpkit_server::Peer> = match (
+            let peer: std::sync::Arc<dyn mcpkit_server::Peer> = match (
                 state.sessions.streams(&session_id),
                 state.sessions.outbound(&session_id),
             ) {
                 (Some(streams), Some(outbound)) => {
-                    Box::new(session_peer(&state, streams, outbound))
+                    std::sync::Arc::new(session_peer(&state, streams, outbound))
                 }
-                _ => Box::new(NoOpPeer),
+                _ => std::sync::Arc::new(NoOpPeer),
             };
             let response = create_response_for_request(
                 &state,
@@ -270,7 +270,7 @@ where
                 protocol_version,
                 &client_caps,
                 task_store.as_ref(),
-                peer.as_ref(),
+                peer,
             )
             .await;
 
@@ -399,7 +399,7 @@ async fn create_response_for_request<H>(
     protocol_version: ProtocolVersion,
     client_caps: &ClientCapabilities,
     task_store: Option<&Arc<TaskManager>>,
-    peer: &dyn mcpkit_server::Peer,
+    peer: std::sync::Arc<dyn mcpkit_server::Peer>,
 ) -> mcpkit_core::protocol::Response
 where
     H: ServerHandler + ToolHandler + ResourceHandler + PromptHandler + Send + Sync + 'static,
@@ -419,7 +419,7 @@ where
         client_caps,
         &server_caps,
         protocol_version,
-        peer,
+        peer.as_ref(),
     );
 
     match method {
@@ -444,6 +444,7 @@ where
                         client_caps.clone(),
                         server_caps.clone(),
                         protocol_version,
+                        std::sync::Arc::clone(&peer),
                     )
                     .await
                     {

--- a/crates/mcpkit-warp/tests/peer_e2e.rs
+++ b/crates/mcpkit-warp/tests/peer_e2e.rs
@@ -6,7 +6,7 @@ use mcpkit_core::capability::ServerInfo;
 use mcpkit_core::error::McpError;
 use mcpkit_core::types::{
     ElicitRequest, ElicitationSchema, GetPromptResult, Prompt, Resource, ResourceContents, Root,
-    Tool, ToolOutput,
+    TaskSupport, Tool, ToolOutput,
 };
 use mcpkit_server::{Context, PromptHandler, ResourceHandler, ServerHandler, ToolHandler};
 use mcpkit_warp::{McpRouter, McpState};
@@ -37,7 +37,7 @@ impl ServerHandler for H {
 }
 impl ToolHandler for H {
     async fn list_tools(&self, _ctx: &Context<'_>) -> Result<Vec<Tool>, McpError> {
-        Ok(vec![Tool::new("ask")])
+        Ok(vec![Tool::new("ask").task_support(TaskSupport::Optional)])
     }
     async fn call_tool(
         &self,
@@ -420,4 +420,64 @@ async fn delete_fails_pending_and_forgets_the_session() {
     )
     .await;
     assert_eq!(status, 404);
+}
+
+#[tokio::test]
+async fn task_augmented_tool_elicits_over_the_stream() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+    let registry = state.sessions.streams(&sid).expect("session");
+    let (mut stream, _prime) = registry.open("connected", sid.clone());
+
+    // A task-augmented call replies immediately with CreateTaskResult...
+    let created = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 7, "method": "tools/call",
+            "params": { "name": "ask", "arguments": {}, "task": {} }
+        }),
+    )
+    .await
+    .1;
+    let task_id = created["result"]["task"]["taskId"]
+        .as_str()
+        .expect("taskId")
+        .to_string();
+
+    // ...while the background tool elicits over the session stream (#153
+    // PR 6: the peer survives into the spawned task).
+    let request = next_stream_request(&mut stream).await;
+    assert_eq!(request["method"], "elicitation/create");
+    let request_id = request["id"].clone();
+    let _ = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": request_id,
+            "result": { "action": "accept", "content": { "answer": "blue" } }
+        }),
+    )
+    .await;
+
+    // tasks/result yields the tool result once the elicited answer lands.
+    let mut text = String::new();
+    for _ in 0..100 {
+        let result = post(
+            &state,
+            Some(&sid),
+            serde_json::json!({
+                "jsonrpc": "2.0", "id": 9, "method": "tasks/result",
+                "params": { "taskId": task_id }
+            }),
+        )
+        .await
+        .1;
+        if let Some(t) = result["result"]["content"][0]["text"].as_str() {
+            text = t.to_string();
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    }
+    assert_eq!(text, "elicited: blue");
 }


### PR DESCRIPTION
PR 6 of the #153 design v3 — the final slice. With this, #153 is fully implemented: every request path on every adapter (including spawned background tasks) carries a real session peer.

## What

`begin_augmented_task` and `run_augmented_tool` (the shared helpers behind the HTTP adapters' task-augmented `tools/call`) now take the session peer and carry it into the spawned background future. Previously the background context was hard-coded to `NoOpPeer` — a task-augmented tool could not elicit, sample, or list roots, and its notifications were dropped (the documented #122 limitation). Now:

- A task-augmented tool on any adapter can `ctx.elicit()` / `ctx.list_roots()` / sample mid-task: the JSON-RPC request rides the session's SSE stream, and the client's response POST correlates against the session's pending server-initiated requests exactly as in the synchronous path.
- Notifications from a background task ride the store-and-drop path (design v3 note): with no live stream they are buffered/dropped by the registry, never failing the tool.
- The stdio runtime is untouched — its `run_task` already built a real `TransportPeer`; this closes the gap for the adapters only.
- The gating context inside `begin_augmented_task` keeps `NoOpPeer` (it only resolves the tool's declared `taskSupport`; a pure predicate needs no peer).
- The #122 changelog limitation note is amended in place (still under [Unreleased]).

**Breaking:** `begin_augmented_task` and `run_augmented_tool` gain a `peer: Arc<dyn Peer>` parameter, and the four adapters' `create_response_for_request` peer parameter changes `&dyn Peer` → `Arc<dyn Peer>` (the spawned future needs an owned handle).

## Tests

Each adapter's `peer_e2e` suite gains `task_augmented_tool_elicits_over_the_stream`: `tools/call` with a `task` field returns `CreateTaskResult` immediately; the background tool's `elicitation/create` arrives over the session stream; the response POST correlates; `tasks/result` yields the elicited answer. All four pass (axum/actix/warp/rocket). Full local gate green: fmt, clippy `-D warnings` (1.97; one `#[allow(too_many_arguments)]` on the 8-arg helper, matching the repo's existing convention), rustdoc, workspace tests.

Closes #153.