### PR TITLE
feat(core)!: close misc 2025-11-25 field/type gaps (#114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Misc 2025-11-25 field/type gaps closed (#114):
+  - `ServerInfo`/`ClientInfo` gain the spec `Implementation` fields
+    `description` and `websiteUrl`, with matching builder methods.
+  - A single spec `Annotations` type (`audience: Vec<Role>`, `priority`,
+    and the previously missing `lastModified`) replaces the two divergent
+    structs. **Breaking:** `ContentAnnotations` is renamed to `Annotations`,
+    and `ResourceAnnotations` is removed — `Resource`/`ResourceTemplate`
+    annotations now use `Annotations`, so their `audience` becomes
+    `Vec<Role>` (was `Vec<String>`; the wire format for valid values —
+    `"user"`/`"assistant"` — is unchanged).
+  - `ResourceLinkContent` gains the `title`, `size`, and `icons` fields it
+    inherits from `Resource` in the spec.
+  - `ToolListChangedNotification` (`notifications/tools/list_changed`) is
+    added, matching the existing resource/prompt list-changed types.
+  - `ListResourceTemplatesRequest` is added, typing the request side of
+    `resources/templates/list`
+  ([#114](https://github.com/praxiomlabs/mcpkit/issues/114)).
+
 - **Task-augmented tools keep their peer** (#153 PR 6, the design's final
   slice): `begin_augmented_task` and `run_augmented_tool` now take the
   session peer and carry it into the spawned background future, so a

--- a/crates/mcpkit-actix/src/router.rs
+++ b/crates/mcpkit-actix/src/router.rs
@@ -329,6 +329,8 @@ mod tests {
                 title: None,
                 version: "1.0.0".to_string(),
                 protocol_version: None,
+                description: None,
+                website_url: None,
                 icons: None,
             }
         }

--- a/crates/mcpkit-axum/src/router.rs
+++ b/crates/mcpkit-axum/src/router.rs
@@ -304,6 +304,8 @@ mod tests {
                 title: None,
                 version: "1.0.0".to_string(),
                 protocol_version: None,
+                description: None,
+                website_url: None,
                 icons: None,
             }
         }

--- a/crates/mcpkit-client/src/pool.rs
+++ b/crates/mcpkit-client/src/pool.rs
@@ -412,12 +412,7 @@ impl ClientPoolBuilder {
 
     /// Set the client info.
     pub fn client_info(mut self, name: impl Into<String>, version: impl Into<String>) -> Self {
-        self.client_info = Some(ClientInfo {
-            name: name.into(),
-            title: None,
-            version: version.into(),
-            icons: None,
-        });
+        self.client_info = Some(ClientInfo::new(name, version));
         self
     }
 

--- a/crates/mcpkit-core/src/capability.rs
+++ b/crates/mcpkit-core/src/capability.rs
@@ -602,6 +602,12 @@ pub struct ServerInfo {
     /// Protocol version supported.
     #[serde(rename = "protocolVersion", skip_serializing_if = "Option::is_none")]
     pub protocol_version: Option<String>,
+    /// Optional human-readable description of what this server does.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional URL of the server's website.
+    #[serde(rename = "websiteUrl", skip_serializing_if = "Option::is_none")]
+    pub website_url: Option<String>,
     /// Optional icons the client can display for this server.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -616,8 +622,24 @@ impl ServerInfo {
             title: None,
             version: version.into(),
             protocol_version: Some(PROTOCOL_VERSION.to_string()),
+            description: None,
+            website_url: None,
             icons: None,
         }
+    }
+
+    /// Set the server's description.
+    #[must_use]
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the server's website URL.
+    #[must_use]
+    pub fn website_url(mut self, website_url: impl Into<String>) -> Self {
+        self.website_url = Some(website_url.into());
+        self
     }
 
     /// Set the server's display title.
@@ -652,6 +674,12 @@ pub struct ClientInfo {
     pub title: Option<String>,
     /// Client version.
     pub version: String,
+    /// Optional human-readable description of this client.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Optional URL of the client's website.
+    #[serde(rename = "websiteUrl", skip_serializing_if = "Option::is_none")]
+    pub website_url: Option<String>,
     /// Optional icons the server can display for this client.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub icons: Option<Vec<Icon>>,
@@ -665,8 +693,24 @@ impl ClientInfo {
             name: name.into(),
             title: None,
             version: version.into(),
+            description: None,
+            website_url: None,
             icons: None,
         }
+    }
+
+    /// Set the client's description.
+    #[must_use]
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Set the client's website URL.
+    #[must_use]
+    pub fn website_url(mut self, website_url: impl Into<String>) -> Self {
+        self.website_url = Some(website_url.into());
+        self
     }
 
     /// Set the client's display title.
@@ -1051,6 +1095,25 @@ mod tests {
         let json = serde_json::to_string(&caps)?;
         assert!(json.contains("\"tools\""));
         assert!(json.contains("\"listChanged\":true"));
+        Ok(())
+    }
+
+    #[test]
+    fn implementation_description_and_website_url_round_trip()
+    -> Result<(), Box<dyn std::error::Error>> {
+        let s = ServerInfo::new("s", "1.0")
+            .description("does things")
+            .website_url("https://example.com");
+        let json = serde_json::to_value(&s)?;
+        assert_eq!(json["description"], "does things");
+        assert_eq!(json["websiteUrl"], "https://example.com");
+
+        let c: ClientInfo = serde_json::from_value(serde_json::json!({
+            "name": "c", "version": "2.0",
+            "description": "a client", "websiteUrl": "https://client.example"
+        }))?;
+        assert_eq!(c.description.as_deref(), Some("a client"));
+        assert_eq!(c.website_url.as_deref(), Some("https://client.example"));
         Ok(())
     }
 }

--- a/crates/mcpkit-core/src/lib.rs
+++ b/crates/mcpkit-core/src/lib.rs
@@ -105,13 +105,13 @@ pub mod prelude {
     pub use crate::schema::{Schema, SchemaBuilder, SchemaType};
     pub use crate::state::{Closing, Connected, Connection, Disconnected, Initializing, Ready};
     pub use crate::types::{
+        Annotations,
         // Tool types
         CallToolResult,
         // Task types
         CancelTaskRequest,
         // Content types
         Content,
-        ContentAnnotations,
         // Sampling types
         CreateMessageRequest,
         CreateMessageResult,

--- a/crates/mcpkit-core/src/types/content.rs
+++ b/crates/mcpkit-core/src/types/content.rs
@@ -39,7 +39,7 @@ impl Content {
 
     /// Create text content with annotations.
     #[must_use]
-    pub fn text_with_annotations(text: impl Into<String>, annotations: ContentAnnotations) -> Self {
+    pub fn text_with_annotations(text: impl Into<String>, annotations: Annotations) -> Self {
         Self::Text(TextContent {
             text: text.into(),
             annotations: Some(annotations),
@@ -115,8 +115,11 @@ impl Content {
         Self::ResourceLink(ResourceLinkContent {
             uri: uri.into(),
             name: name.into(),
+            title: None,
             description: None,
             mime_type: None,
+            size: None,
+            icons: None,
             annotations: None,
             meta: None,
         })
@@ -145,7 +148,7 @@ pub struct TextContent {
     pub text: String,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<ContentAnnotations>,
+    pub annotations: Option<Annotations>,
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<super::meta::Meta>,
@@ -161,7 +164,7 @@ pub struct ImageContent {
     pub mime_type: String,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<ContentAnnotations>,
+    pub annotations: Option<Annotations>,
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<super::meta::Meta>,
@@ -177,7 +180,7 @@ pub struct AudioContent {
     pub mime_type: String,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<ContentAnnotations>,
+    pub annotations: Option<Annotations>,
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<super::meta::Meta>,
@@ -193,7 +196,7 @@ pub struct ResourceContent {
     pub resource: ResourceContents,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<ContentAnnotations>,
+    pub annotations: Option<Annotations>,
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<super::meta::Meta>,
@@ -206,15 +209,24 @@ pub struct ResourceLinkContent {
     pub uri: String,
     /// Name of the resource.
     pub name: String,
+    /// Optional human-readable display title.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
     /// Description of the resource.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     /// MIME type of the resource.
     #[serde(rename = "mimeType", skip_serializing_if = "Option::is_none")]
     pub mime_type: Option<String>,
+    /// Size of the resource in bytes, if known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub size: Option<u64>,
+    /// Optional icons the client can display for this resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icons: Option<Vec<super::metadata::Icon>>,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<ContentAnnotations>,
+    pub annotations: Option<Annotations>,
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<super::meta::Meta>,
@@ -259,24 +271,28 @@ pub struct ToolResultContent {
     pub meta: Option<super::meta::Meta>,
 }
 
-/// Annotations that can be attached to content.
+/// Annotations that can be attached to content, resources, and resource
+/// links (the spec's single `Annotations` type).
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ContentAnnotations {
-    /// Audience for this content (e.g., "user", "assistant").
+pub struct Annotations {
+    /// Intended audience (e.g., "user", "assistant").
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audience: Option<Vec<Role>>,
     /// Priority level (0.0 to 1.0).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub priority: Option<f64>,
+    /// ISO 8601 timestamp of when the annotated object was last modified.
+    #[serde(rename = "lastModified", skip_serializing_if = "Option::is_none")]
+    pub last_modified: Option<String>,
 }
 
-impl ContentAnnotations {
+impl Annotations {
     /// Create annotations for user-facing content.
     #[must_use]
     pub fn for_user() -> Self {
         Self {
             audience: Some(vec![Role::User]),
-            priority: None,
+            ..Self::default()
         }
     }
 
@@ -285,7 +301,7 @@ impl ContentAnnotations {
     pub fn for_assistant() -> Self {
         Self {
             audience: Some(vec![Role::Assistant]),
-            priority: None,
+            ..Self::default()
         }
     }
 
@@ -293,6 +309,13 @@ impl ContentAnnotations {
     #[must_use]
     pub fn with_priority(mut self, priority: f64) -> Self {
         self.priority = Some(priority.clamp(0.0, 1.0));
+        self
+    }
+
+    /// Set the last-modified timestamp (ISO 8601).
+    #[must_use]
+    pub fn with_last_modified(mut self, last_modified: impl Into<String>) -> Self {
+        self.last_modified = Some(last_modified.into());
         self
     }
 }
@@ -394,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_annotations() -> Result<(), Box<dyn std::error::Error>> {
-        let annotations = ContentAnnotations::for_user().with_priority(0.8);
+        let annotations = Annotations::for_user().with_priority(0.8);
         assert_eq!(annotations.priority, Some(0.8));
         assert!(
             annotations
@@ -433,6 +456,35 @@ mod tests {
         assert!(json.contains("\"type\":\"resource_link\""));
         assert!(json.contains("\"uri\":\"https://example.com/file.pdf\""));
         assert!(json.contains("\"name\":\"My File\""));
+        Ok(())
+    }
+
+    #[test]
+    fn annotations_last_modified_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+        let a = Annotations::for_user().with_last_modified("2025-11-25T00:00:00Z");
+        let json = serde_json::to_value(&a)?;
+        assert_eq!(json["lastModified"], "2025-11-25T00:00:00Z");
+        assert_eq!(json["audience"][0], "user");
+        let back: Annotations = serde_json::from_value(json)?;
+        assert_eq!(back.last_modified.as_deref(), Some("2025-11-25T00:00:00Z"));
+        Ok(())
+    }
+
+    #[test]
+    fn resource_link_full_fields_round_trip() -> Result<(), Box<dyn std::error::Error>> {
+        let link: ResourceLinkContent = serde_json::from_value(serde_json::json!({
+            "uri": "file:///a.txt",
+            "name": "a",
+            "title": "A file",
+            "size": 42,
+            "icons": [{"src": "https://example.com/i.png"}]
+        }))?;
+        assert_eq!(link.title.as_deref(), Some("A file"));
+        assert_eq!(link.size, Some(42));
+        assert_eq!(link.icons.as_ref().map(Vec::len), Some(1));
+        let json = serde_json::to_value(&link)?;
+        assert_eq!(json["title"], "A file");
+        assert_eq!(json["size"], 42);
         Ok(())
     }
 }

--- a/crates/mcpkit-core/src/types/resource.rs
+++ b/crates/mcpkit-core/src/types/resource.rs
@@ -4,6 +4,7 @@
 //! They can be files, database entries, API responses, or any other
 //! addressable content.
 
+use super::content::Annotations;
 use super::meta::Meta;
 use super::metadata::Icon;
 use serde::{Deserialize, Serialize};
@@ -35,7 +36,7 @@ pub struct Resource {
     pub icons: Option<Vec<Icon>>,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<ResourceAnnotations>,
+    pub annotations: Option<Annotations>,
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
@@ -113,17 +114,6 @@ impl Resource {
     }
 }
 
-/// Annotations for resources.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ResourceAnnotations {
-    /// Audience for this resource.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub audience: Option<Vec<String>>,
-    /// Priority level.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub priority: Option<f64>,
-}
-
 /// A template for dynamic resource URIs.
 ///
 /// Resource templates allow servers to expose parameterized resources
@@ -149,7 +139,7 @@ pub struct ResourceTemplate {
     pub icons: Option<Vec<Icon>>,
     /// Optional annotations.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub annotations: Option<ResourceAnnotations>,
+    pub annotations: Option<Annotations>,
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
@@ -322,6 +312,14 @@ pub struct ListResourcesResult {
     /// Optional protocol metadata (`_meta`).
     #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
     pub meta: Option<Meta>,
+}
+
+/// Request parameters for listing resource templates.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ListResourceTemplatesRequest {
+    /// Cursor for pagination.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<String>,
 }
 
 /// Response for listing resource templates.
@@ -498,5 +496,28 @@ mod tests {
         let back: UnsubscribeRequest =
             serde_json::from_value(serde_json::json!({ "uri": "file:///y" })).unwrap();
         assert_eq!(back.uri, "file:///y");
+    }
+
+    #[test]
+    fn list_resource_templates_request_cursor() -> Result<(), Box<dyn std::error::Error>> {
+        let req: ListResourceTemplatesRequest =
+            serde_json::from_value(serde_json::json!({"cursor": "c1"}))?;
+        assert_eq!(req.cursor.as_deref(), Some("c1"));
+        // Omitted cursor deserializes and serializes to an empty object.
+        let empty: ListResourceTemplatesRequest = serde_json::from_value(serde_json::json!({}))?;
+        assert_eq!(serde_json::to_value(&empty)?, serde_json::json!({}));
+        Ok(())
+    }
+
+    #[test]
+    fn resource_annotations_use_spec_type() -> Result<(), Box<dyn std::error::Error>> {
+        let r: Resource = serde_json::from_value(serde_json::json!({
+            "uri": "u", "name": "n",
+            "annotations": {"audience": ["user"], "priority": 0.5, "lastModified": "2025-01-01T00:00:00Z"}
+        }))?;
+        let a = r.annotations.as_ref().expect("annotations");
+        assert_eq!(a.audience.as_ref().map(Vec::len), Some(1));
+        assert_eq!(a.last_modified.as_deref(), Some("2025-01-01T00:00:00Z"));
+        Ok(())
     }
 }

--- a/crates/mcpkit-core/src/types/tool.rs
+++ b/crates/mcpkit-core/src/types/tool.rs
@@ -626,6 +626,11 @@ pub struct CallToolRequest {
     pub task: Option<super::task::TaskMetadata>,
 }
 
+/// Notification that the tool list has changed
+/// (`notifications/tools/list_changed`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ToolListChangedNotification {}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -826,6 +831,14 @@ mod tests {
         let json = serde_json::to_string(&tool)?;
         assert!(json.contains("\"name\":\"test\""));
         assert!(json.contains("\"inputSchema\""));
+        Ok(())
+    }
+
+    #[test]
+    fn tool_list_changed_notification_is_empty_object() -> Result<(), Box<dyn std::error::Error>> {
+        let n = ToolListChangedNotification::default();
+        assert_eq!(serde_json::to_value(&n)?, serde_json::json!({}));
+        let _: ToolListChangedNotification = serde_json::from_value(serde_json::json!({}))?;
         Ok(())
     }
 }

--- a/crates/mcpkit-rocket/src/router.rs
+++ b/crates/mcpkit-rocket/src/router.rs
@@ -331,6 +331,8 @@ mod tests {
                 title: None,
                 version: "1.0.0".to_string(),
                 protocol_version: None,
+                description: None,
+                website_url: None,
                 icons: None,
             }
         }

--- a/crates/mcpkit-warp/src/router.rs
+++ b/crates/mcpkit-warp/src/router.rs
@@ -395,6 +395,8 @@ mod tests {
                 title: None,
                 version: "1.0.0".to_string(),
                 protocol_version: None,
+                description: None,
+                website_url: None,
                 icons: None,
             }
         }

--- a/mcpkit/tests/initialization_compliance.rs
+++ b/mcpkit/tests/initialization_compliance.rs
@@ -17,12 +17,7 @@ fn test_protocol_version() {
 
 #[test]
 fn test_client_info() {
-    let info = ClientInfo {
-        name: "test-client".to_string(),
-        title: None,
-        version: "1.0.0".to_string(),
-        icons: None,
-    };
+    let info = ClientInfo::new("test-client", "1.0.0");
 
     let json = serde_json::to_value(&info).unwrap();
     assert_eq!(json["name"], "test-client");
@@ -43,12 +38,7 @@ fn test_server_info() {
 
 #[test]
 fn test_initialize_request() {
-    let client_info = ClientInfo {
-        name: "my-client".to_string(),
-        title: None,
-        version: "1.0.0".to_string(),
-        icons: None,
-    };
+    let client_info = ClientInfo::new("my-client", "1.0.0");
 
     let request = InitializeRequest {
         protocol_version: PROTOCOL_VERSION.to_string(),


### PR DESCRIPTION
Closes the five divergences from the spec audit in one PR (none grew enough to warrant splitting, per the issue's note).

## What

- **`Implementation` fields** — `ServerInfo`/`ClientInfo` gain `description` and `websiteUrl` (serde-renamed), with `description()`/`website_url()` builder methods matching the existing `title()`/`icons()` style. Additive.
- **`Annotations` unification** — one spec `Annotations` type (`audience: Vec<Role>`, `priority`, and the previously missing `lastModified`) replaces the two divergent structs. **Breaking:** `ContentAnnotations` → `Annotations` (rename), `ResourceAnnotations` removed; `Resource`/`ResourceTemplate` annotations now use `Annotations`, so their `audience` becomes `Vec<Role>` (was `Vec<String>`). `Role` serializes lowercase, so the wire format for the spec's valid values (`"user"`/`"assistant"`) is unchanged — only non-spec audience strings, which the spec never permitted, stop deserializing. No downstream crate in the workspace used either old type.
- **`ResourceLinkContent`** — gains `title`, `size`, and `icons`, the `Resource` fields the spec's `ResourceLink` inherits.
- **`ToolListChangedNotification`** — `notifications/tools/list_changed` gets its typed (empty) struct, matching the existing resource/prompt list-changed types. The method constants and client dispatch already existed; only the type was missing.
- **`ListResourceTemplatesRequest`** — types the request side of `resources/templates/list` (`cursor` for pagination), mirroring `ListResourcesRequest`.

## Tests

Serde round-trips per gap: `lastModified` rename and audience roles, `websiteUrl`/`description` on both info types, ResourceLink's new fields, the templates-request cursor (and empty-object form), and the empty tool list-changed notification. Full local gate green: fmt, clippy `-D warnings` (1.97), rustdoc, workspace tests (the gate caught four adapter test-module `ServerInfo` literals and two `ClientInfo` literals in the compliance tests, updated to constructors).

Spec: https://modelcontextprotocol.io/specification/2025-11-25/schema

Closes #114.