### PR TITLE
Re-audit against the pinned 2025-11-25 schema: close a spec MUST, and make two gate rows capable of failing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,29 @@ to make after 1.0. Migration for each is below.
    `mcpkit_core::methods`.** Paths are unchanged; only code expecting them to be
    *defined* in `mcpkit-server` needs adjusting.
 
+7. **`ElicitRequest` and `UrlElicitRequest` gain `task` and `meta` fields.**
+   The schema declares both on `ElicitRequestFormParams` and
+   `ElicitRequestURLParams`; mcpkit modelled neither, so a server could not
+   emit the `io.modelcontextprotocol/related-task` `_meta` the spec **requires**
+   of an elicitation raised by a task-augmented tool call. Serialized output is
+   unchanged when unset.
+   *Migration:* struct-literal construction must add `task: None, meta: None`;
+   `ElicitRequest::new`/`text`/`confirm`/`choice` and `UrlElicitRequest::new`
+   are unaffected.
+
+8. **16 further wire types are `#[non_exhaustive]`** — the `_meta`-bearing
+   types with no struct-literal construction anywhere in the workspace
+   (`AudioContent`, `ImageContent`, `ResourceContent`, `ResourceLinkContent`,
+   `ToolResultContent`, `ToolUseContent`, `CancelledNotificationParams`,
+   `ElicitRequest`, `ElicitResult`, `UrlElicitRequest`, `ListPromptsResult`,
+   `ListResourcesResult`, `ListResourceTemplatesResult`, `ReadResourceResult`,
+   `Root`, `SamplingMessage`). A later schema revision can add a field to any
+   of them without a major release. The 17 types users routinely build by hand
+   — `Tool`, `Prompt`, `Resource`, `GetPromptResult` and the other results —
+   are deliberately left constructible.
+   *Migration:* replace struct-literal construction with the type's
+   constructor, or `..Default::default()` where one exists.
+
 ### Added
 
 - Spec method and notification names in `mcpkit_core::methods`, so every crate
@@ -74,6 +97,22 @@ to make after 1.0. Migration for each is below.
   `RuntimeConfig::default_task_poll_interval_ms`, so a server can suggest a
   polling rate. Defaults to absent, which is legal.
 - `_meta` on `InitializeRequest` and 21 further types.
+- **The related-task `_meta` the spec requires on task-related messages.**
+  `Context::with_related_task` marks a context as belonging to a task, and
+  every outbound request it makes — `elicitation/create`,
+  `sampling/createMessage` — then carries
+  `io.modelcontextprotocol/related-task`. Applied automatically by
+  `run_augmented_tool`, so all five dispatch paths inherit it. Previously
+  `inject_related_task` was applied to `tasks/result` payloads only, leaving
+  the spec's MUST unsatisfiable through the public API. `tasks/get`,
+  `tasks/result`, `tasks/cancel` and `notifications/tasks/status` are
+  deliberately excluded, per the spec's SHOULD NOT.
+- `scripts/schema-diff.sh` resolves types whose Rust name differs from the
+  `$def` name via an alias map, so Tier 2 covers 79 types rather than 75.
+  `ElicitRequestFormParams`, `ElicitRequestURLParams`, `EmbeddedResource` and
+  `ResourceLink` were previously reported as having "no 1:1 Rust type" when
+  they simply had a different one — which is how the elicitation `_meta` gap
+  stayed invisible.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,12 @@ to make after 1.0. Migration for each is below.
   the spec's MUST unsatisfiable through the public API. `tasks/get`,
   `tasks/result`, `tasks/cancel` and `notifications/tasks/status` are
   deliberately excluded, per the spec's SHOULD NOT.
+- Per-adapter behavioural conformance tests. `notifications_never_draw_a_response`
+  (four client-sent notifications plus an unknown one) and
+  `capabilities_are_honoured_exactly_as_advertised` now run on all four HTTP
+  adapters, not just in-process. Each adapter decides both in its own
+  `handle_mcp_post` rather than in the shared `route_*` helpers, so passing on
+  one said nothing about the other three.
 - `scripts/schema-diff.sh` resolves types whose Rust name differs from the
   `$def` name via an alias map, so Tier 2 covers 79 types rather than 75.
   `ElicitRequestFormParams`, `ElicitRequestURLParams`, `EmbeddedResource` and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ categories = ["api-bindings", "asynchronous", "network-programming"]
 # Serialization
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-schemars = "1.0"
 
 # Error handling
 thiserror = "2.0"

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ vendored spec — see the tables for what is checked and how.
 
 | Requirement | Status | Notes |
 |-------------|--------|-------|
-| Full MCP 2025-11-25 compliance | ✅ Complete | All 31 schema-defined methods. The CI vocabulary diff proves the names exist in the sources, not that each is routed — routing and behaviour are covered by `mcpkit/tests/protocol_behaviour_conformance.rs`. Structural conformance covers every `$def` with a same-named type — 75 of 145, the rest being envelopes, unions and aliases with no 1:1 Rust type — with no outstanding field gaps |
+| Full MCP 2025-11-25 compliance | ✅ Complete | All 31 schema-defined methods. The CI vocabulary diff compares the schema against the declared constants in `mcpkit-core/src/methods.rs`, in both directions — it proves the names match, not that each is routed. Routing is shared: all five dispatch paths reach the same `route_*` helpers. Behaviour is verified in-process by `mcpkit/tests/protocol_behaviour_conformance.rs` and per-adapter by each `tests/peer_e2e.rs` (pre-initialize/session rejection, capability gating, notifications drawing no response, related-task `_meta`). Structural conformance covers every `$def` with a same-named type plus those resolved by the alias map — 79 of 145; the remaining 66 are envelopes, unions and abstract bases with no single Rust counterpart — with no outstanding field gaps |
 | Protocol version negotiation | ✅ Complete | All 4 published versions; table-driven conformance tests |
 | OAuth 2.1 + PKCE support | ✅ Complete | RFC 9728, 8414, 7636 compliant |
 | Tasks (async operations) | ✅ Complete | Full task lifecycle support |

--- a/crates/mcpkit-actix/tests/peer_e2e.rs
+++ b/crates/mcpkit-actix/tests/peer_e2e.rs
@@ -497,3 +497,78 @@ async fn task_augmented_tool_elicits_over_the_stream() {
     }
     assert_eq!(text, "elicited: blue");
 }
+
+/// Spec: a notification carries no id and MUST NOT draw a response — including
+/// one the server does not handle, and one whose params are missing.
+///
+/// Asserted on this dispatch path specifically. Each adapter decides this in
+/// its own `handle_mcp_post`, not in the shared `route_*` helpers, so passing
+/// on one adapter says nothing about the other three.
+#[tokio::test]
+async fn notifications_never_draw_a_response() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+
+    for method in [
+        "notifications/initialized",
+        "notifications/cancelled",
+        "notifications/roots/list_changed",
+        "notifications/progress",
+        "notifications/not_a_real_method",
+    ] {
+        let (status, body) = post(
+            &state,
+            Some(&sid),
+            serde_json::json!({ "jsonrpc": "2.0", "method": method }),
+        )
+        .await;
+        assert_eq!(
+            body,
+            serde_json::Value::Null,
+            "{method} drew a response body"
+        );
+        assert_eq!(status.as_u16(), 202, "{method} should be accepted with 202");
+    }
+}
+
+/// Spec: a server honours exactly the capabilities it advertised. This handler
+/// declares no `completion`, so `completion/complete` must be method-not-found
+/// (-32601) — the literal is spelled out rather than referenced through the
+/// constant that produces it.
+#[tokio::test]
+async fn capabilities_are_honoured_exactly_as_advertised() {
+    let (state, _) = test_state();
+    let (_, init_result) = post(
+        &state,
+        None,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": { "protocolVersion": "2025-11-25", "capabilities": {} }
+        }),
+    )
+    .await;
+    assert!(
+        init_result["result"]["capabilities"]
+            .get("completion")
+            .is_none(),
+        "handler advertised completion it does not implement: {init_result}"
+    );
+    let sid = init(&state).await;
+
+    let (_, body) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "completion/complete",
+            "params": {
+                "ref": { "type": "ref/prompt", "name": "p" },
+                "argument": { "name": "a", "value": "" }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(
+        body["error"]["code"], -32601,
+        "unadvertised completion/complete must be method-not-found: {body}"
+    );
+}

--- a/crates/mcpkit-actix/tests/peer_e2e.rs
+++ b/crates/mcpkit-actix/tests/peer_e2e.rs
@@ -456,6 +456,15 @@ async fn task_augmented_tool_elicits_over_the_stream() {
     // PR 6: the peer survives into the spawned task).
     let request = next_stream_request(&mut stream).await;
     assert_eq!(request["method"], "elicitation/create");
+    // Spec MUST (2025-11-25 tasks, "Associating Task-Related Messages"): an
+    // elicitation a task-augmented tool call depends on carries that call's
+    // task id. Key spelled out on purpose — asserting against the constant
+    // that produces it would pass even if the constant were wrong.
+    assert_eq!(
+        request["params"]["_meta"]["io.modelcontextprotocol/related-task"]["taskId"],
+        serde_json::json!(task_id),
+        "elicitation/create raised by a task-augmented tool must carry related-task _meta"
+    );
     let request_id = request["id"].clone();
     let _ = post(
         &state,

--- a/crates/mcpkit-axum/tests/peer_e2e.rs
+++ b/crates/mcpkit-axum/tests/peer_e2e.rs
@@ -412,6 +412,15 @@ async fn task_augmented_tool_elicits_over_the_stream() {
     // PR 6: the peer survives into the spawned task).
     let request = next_stream_request(&mut stream).await;
     assert_eq!(request["method"], "elicitation/create");
+    // Spec MUST (2025-11-25 tasks, "Associating Task-Related Messages"): an
+    // elicitation a task-augmented tool call depends on carries that call's
+    // task id. Key spelled out on purpose — asserting against the constant
+    // that produces it would pass even if the constant were wrong.
+    assert_eq!(
+        request["params"]["_meta"]["io.modelcontextprotocol/related-task"]["taskId"],
+        serde_json::json!(task_id),
+        "elicitation/create raised by a task-augmented tool must carry related-task _meta"
+    );
     let request_id = request["id"].clone();
     let _ = post(
         &state,

--- a/crates/mcpkit-axum/tests/peer_e2e.rs
+++ b/crates/mcpkit-axum/tests/peer_e2e.rs
@@ -453,3 +453,77 @@ async fn task_augmented_tool_elicits_over_the_stream() {
     }
     assert_eq!(text, "elicited: blue");
 }
+
+/// Spec: a notification carries no id and MUST NOT draw a response — including
+/// one the server does not handle, and one whose params are missing.
+///
+/// Asserted on this dispatch path specifically. Each adapter decides this in
+/// its own `handle_mcp_post`, not in the shared `route_*` helpers, so passing
+/// on one adapter says nothing about the other three.
+#[tokio::test]
+async fn notifications_never_draw_a_response() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+
+    for method in [
+        "notifications/initialized",
+        "notifications/cancelled",
+        "notifications/roots/list_changed",
+        "notifications/progress",
+        "notifications/not_a_real_method",
+    ] {
+        let (body, _) = post(
+            &state,
+            Some(&sid),
+            serde_json::json!({ "jsonrpc": "2.0", "method": method }),
+        )
+        .await;
+        assert_eq!(
+            body,
+            serde_json::Value::Null,
+            "{method} drew a response body"
+        );
+    }
+}
+
+/// Spec: a server honours exactly the capabilities it advertised. This handler
+/// declares no `completion`, so `completion/complete` must be method-not-found
+/// (-32601) — the literal is spelled out rather than referenced through the
+/// constant that produces it.
+#[tokio::test]
+async fn capabilities_are_honoured_exactly_as_advertised() {
+    let (state, _) = test_state();
+    let (init_result, sid) = post(
+        &state,
+        None,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": { "protocolVersion": "2025-11-25", "capabilities": {} }
+        }),
+    )
+    .await;
+    let sid = sid.expect("session id");
+    assert!(
+        init_result["result"]["capabilities"]
+            .get("completion")
+            .is_none(),
+        "handler advertised completion it does not implement: {init_result}"
+    );
+
+    let (body, _) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "completion/complete",
+            "params": {
+                "ref": { "type": "ref/prompt", "name": "p" },
+                "argument": { "name": "a", "value": "" }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(
+        body["error"]["code"], -32601,
+        "unadvertised completion/complete must be method-not-found: {body}"
+    );
+}

--- a/crates/mcpkit-core/src/tasks.rs
+++ b/crates/mcpkit-core/src/tasks.rs
@@ -656,10 +656,21 @@ impl TaskManager {
 // Dispatch
 // ============================================================================
 
-/// Attach `_meta["io.modelcontextprotocol/related-task"]` to a `tasks/result`
-/// payload (spec MUST for `tasks/result` responses). Merges with any existing
-/// `_meta` keys.
-fn inject_related_task(mut payload: Value, id: &TaskId) -> Value {
+/// Attach `_meta["io.modelcontextprotocol/related-task"]` to a JSON payload.
+/// Merges with any existing `_meta` keys.
+///
+/// Spec: *"All requests, notifications, and responses related to a task MUST
+/// include the `io.modelcontextprotocol/related-task` key in their `_meta`
+/// field"*. That covers both the `tasks/result` payload and every outbound
+/// request a task makes while it runs — an `elicitation/create` raised by a
+/// task-augmented tool call must carry the same task id as the tool call.
+///
+/// Do **not** apply this to `tasks/get`, `tasks/result` or `tasks/cancel`
+/// requests, nor to `notifications/tasks/status`: the spec says the `taskId`
+/// parameter is the source of truth there and a requestor SHOULD NOT duplicate
+/// it in `_meta`.
+#[must_use]
+pub fn inject_related_task(mut payload: Value, id: &TaskId) -> Value {
     if let Value::Object(map) = &mut payload {
         if let Value::Object(meta) = map
             .entry("_meta")

--- a/crates/mcpkit-core/src/types/content.rs
+++ b/crates/mcpkit-core/src/types/content.rs
@@ -156,6 +156,7 @@ pub struct TextContent {
 
 /// Image content (base64 encoded).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ImageContent {
     /// Base64-encoded image data.
     pub data: String,
@@ -172,6 +173,7 @@ pub struct ImageContent {
 
 /// Audio content (base64 encoded).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct AudioContent {
     /// Base64-encoded audio data.
     pub data: String,
@@ -191,6 +193,7 @@ pub struct AudioContent {
 /// The resource payload is nested under `resource` to match the spec's
 /// `EmbeddedResource` (`{ "type": "resource", "resource": { "uri": .. } }`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ResourceContent {
     /// The embedded resource contents.
     pub resource: ResourceContents,
@@ -204,6 +207,7 @@ pub struct ResourceContent {
 
 /// A link to a resource (not embedded inline, just a URI reference).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ResourceLinkContent {
     /// URI of the resource.
     pub uri: String,
@@ -235,6 +239,7 @@ pub struct ResourceLinkContent {
 /// A tool call the model wants to make, in a sampling message
 /// (`type: "tool_use"`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ToolUseContent {
     /// Unique id correlating this call with its later `tool_result`.
     pub id: String,
@@ -250,6 +255,7 @@ pub struct ToolUseContent {
 /// The result of a tool call, fed back into a sampling message
 /// (`type: "tool_result"`).
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ToolResultContent {
     /// The id of the `tool_use` this result corresponds to.
     #[serde(rename = "toolUseId")]

--- a/crates/mcpkit-core/src/types/elicitation.rs
+++ b/crates/mcpkit-core/src/types/elicitation.rs
@@ -19,6 +19,7 @@ pub enum ElicitMode {
 
 /// A form-mode request to elicit information from the user.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ElicitRequest {
     /// The elicitation mode. Absent is equivalent to [`ElicitMode::Form`].
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -28,6 +29,18 @@ pub struct ElicitRequest {
     /// The schema describing what input is expected.
     #[serde(rename = "requestedSchema")]
     pub requested_schema: ElicitationSchema,
+    /// Request task-augmented execution. A client that declared
+    /// `tasks.requests.elicitation.create` replies with a `CreateTaskResult`
+    /// immediately; the `ElicitResult` is retrieved later via `tasks/result`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<super::task::TaskMetadata>,
+    /// Optional protocol metadata (`_meta`).
+    ///
+    /// Per spec, an elicitation that a task-augmented request depends on MUST
+    /// carry `io.modelcontextprotocol/related-task` here with the associated
+    /// task id.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl ElicitRequest {
@@ -38,6 +51,8 @@ impl ElicitRequest {
             mode: None,
             message: message.into(),
             requested_schema: schema,
+            task: None,
+            meta: None,
         }
     }
 
@@ -84,6 +99,7 @@ impl ElicitRequest {
 /// unguessable and bound to a verified user identity, and MUST NOT carry
 /// credentials in the URL.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct UrlElicitRequest {
     /// The elicitation mode (always [`ElicitMode::Url`]).
     pub mode: ElicitMode,
@@ -95,6 +111,18 @@ pub struct UrlElicitRequest {
     pub elicitation_id: String,
     /// The URL the user should navigate to.
     pub url: String,
+    /// Request task-augmented execution. A client that declared
+    /// `tasks.requests.elicitation.create` replies with a `CreateTaskResult`
+    /// immediately; the `ElicitResult` is retrieved later via `tasks/result`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task: Option<super::task::TaskMetadata>,
+    /// Optional protocol metadata (`_meta`).
+    ///
+    /// Per spec, an elicitation that a task-augmented request depends on MUST
+    /// carry `io.modelcontextprotocol/related-task` here with the associated
+    /// task id.
+    #[serde(rename = "_meta", default, skip_serializing_if = "Option::is_none")]
+    pub meta: Option<Meta>,
 }
 
 impl UrlElicitRequest {
@@ -110,6 +138,8 @@ impl UrlElicitRequest {
             message: message.into(),
             elicitation_id: elicitation_id.into(),
             url: url.into(),
+            task: None,
+            meta: None,
         }
     }
 }
@@ -363,6 +393,7 @@ impl PropertySchema {
 
 /// Result of an elicitation request.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ElicitResult {
     /// The action taken by the user.
     pub action: ElicitAction,

--- a/crates/mcpkit-core/src/types/notifications.rs
+++ b/crates/mcpkit-core/src/types/notifications.rs
@@ -47,6 +47,7 @@ impl ProgressNotificationParams {
 /// `request_id` is optional on the wire; per the spec it MUST be provided when
 /// cancelling non-task requests (and MUST NOT be used to cancel tasks).
 #[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct CancelledNotificationParams {
     /// The id of the request being cancelled.
     #[serde(rename = "requestId", default, skip_serializing_if = "Option::is_none")]

--- a/crates/mcpkit-core/src/types/prompt.rs
+++ b/crates/mcpkit-core/src/types/prompt.rs
@@ -286,6 +286,7 @@ pub struct ListPromptsRequest {
 
 /// Response for listing prompts.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ListPromptsResult {
     /// The list of available prompts.
     pub prompts: Vec<Prompt>,

--- a/crates/mcpkit-core/src/types/resource.rs
+++ b/crates/mcpkit-core/src/types/resource.rs
@@ -306,6 +306,7 @@ pub struct ListResourcesRequest {
 
 /// Response for listing resources.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ListResourcesResult {
     /// The list of available resources.
     pub resources: Vec<Resource>,
@@ -330,6 +331,7 @@ pub struct ListResourceTemplatesRequest {
 
 /// Response for listing resource templates.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ListResourceTemplatesResult {
     /// The list of resource templates.
     #[serde(rename = "resourceTemplates")]
@@ -354,6 +356,7 @@ pub struct ReadResourceRequest {
 
 /// Response for reading a resource.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct ReadResourceResult {
     /// The resource contents.
     pub contents: Vec<ResourceContents>,

--- a/crates/mcpkit-core/src/types/roots.rs
+++ b/crates/mcpkit-core/src/types/roots.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 /// A root a client exposes to servers (typically a project directory).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct Root {
     /// URI of the root (e.g. `file:///home/user/project`).
     pub uri: String,

--- a/crates/mcpkit-core/src/types/sampling.rs
+++ b/crates/mcpkit-core/src/types/sampling.rs
@@ -79,6 +79,7 @@ pub struct ToolChoice {
 
 /// A message in a sampling conversation.
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[non_exhaustive]
 pub struct SamplingMessage {
     /// The role of the message sender.
     pub role: Role,

--- a/crates/mcpkit-rocket/tests/peer_e2e.rs
+++ b/crates/mcpkit-rocket/tests/peer_e2e.rs
@@ -480,3 +480,78 @@ async fn task_augmented_tool_elicits_over_the_stream() {
     }
     assert_eq!(text, "elicited: blue");
 }
+
+/// Spec: a notification carries no id and MUST NOT draw a response — including
+/// one the server does not handle, and one whose params are missing.
+///
+/// Asserted on this dispatch path specifically. Each adapter decides this in
+/// its own `handle_mcp_post`, not in the shared `route_*` helpers, so passing
+/// on one adapter says nothing about the other three.
+#[tokio::test]
+async fn notifications_never_draw_a_response() {
+    let (client, _state, _) = setup().await;
+    let sid = init(&client).await;
+
+    for method in [
+        "notifications/initialized",
+        "notifications/cancelled",
+        "notifications/roots/list_changed",
+        "notifications/progress",
+        "notifications/not_a_real_method",
+    ] {
+        let (status, body) = post(
+            &client,
+            Some(&sid),
+            serde_json::json!({ "jsonrpc": "2.0", "method": method }),
+        )
+        .await;
+        assert_eq!(
+            body,
+            serde_json::Value::Null,
+            "{method} drew a response body"
+        );
+        assert_eq!(status, 202, "{method} should be accepted with 202");
+    }
+}
+
+/// Spec: a server honours exactly the capabilities it advertised. This handler
+/// declares no `completion`, so `completion/complete` must be method-not-found
+/// (-32601) — the literal is spelled out rather than referenced through the
+/// constant that produces it.
+#[tokio::test]
+async fn capabilities_are_honoured_exactly_as_advertised() {
+    let (client, _state, _) = setup().await;
+    let (_, init_result) = post(
+        &client,
+        None,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": { "protocolVersion": "2025-11-25", "capabilities": {} }
+        }),
+    )
+    .await;
+    assert!(
+        init_result["result"]["capabilities"]
+            .get("completion")
+            .is_none(),
+        "handler advertised completion it does not implement: {init_result}"
+    );
+    let sid = init(&client).await;
+
+    let (_, body) = post(
+        &client,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "completion/complete",
+            "params": {
+                "ref": { "type": "ref/prompt", "name": "p" },
+                "argument": { "name": "a", "value": "" }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(
+        body["error"]["code"], -32601,
+        "unadvertised completion/complete must be method-not-found: {body}"
+    );
+}

--- a/crates/mcpkit-rocket/tests/peer_e2e.rs
+++ b/crates/mcpkit-rocket/tests/peer_e2e.rs
@@ -439,6 +439,15 @@ async fn task_augmented_tool_elicits_over_the_stream() {
     // PR 6: the peer survives into the spawned task).
     let request = next_stream_request(&mut stream).await;
     assert_eq!(request["method"], "elicitation/create");
+    // Spec MUST (2025-11-25 tasks, "Associating Task-Related Messages"): an
+    // elicitation a task-augmented tool call depends on carries that call's
+    // task id. Key spelled out on purpose — asserting against the constant
+    // that produces it would pass even if the constant were wrong.
+    assert_eq!(
+        request["params"]["_meta"]["io.modelcontextprotocol/related-task"]["taskId"],
+        serde_json::json!(task_id),
+        "elicitation/create raised by a task-augmented tool must carry related-task _meta"
+    );
     let request_id = request["id"].clone();
     let _ = post(
         &client,

--- a/crates/mcpkit-server/src/context.rs
+++ b/crates/mcpkit-server/src/context.rs
@@ -52,6 +52,7 @@ use mcpkit_core::types::logging::{LoggingLevel, LoggingMessageNotificationParams
 use mcpkit_core::types::notifications::ProgressNotificationParams;
 use mcpkit_core::types::roots::{ListRootsResult, Root};
 use mcpkit_core::types::sampling::{CreateMessageRequest, CreateMessageResult};
+use mcpkit_core::types::task::TaskId;
 use std::borrow::Cow;
 use std::future::Future;
 use std::pin::Pin;
@@ -120,6 +121,13 @@ pub struct Context<'a> {
     peer: &'a dyn Peer,
     /// Cancellation token for this request.
     cancel: CancellationToken,
+    /// The task this request is executing as part of, if any.
+    ///
+    /// Set by [`run_augmented_tool`](crate::router::run_augmented_tool) for a
+    /// task-augmented tool call. When present, every outbound request this
+    /// context makes carries `io.modelcontextprotocol/related-task` in its
+    /// `_meta`, which the spec requires of task-related messages.
+    related_task: Option<TaskId>,
 }
 
 /// Sentinel [`RequestId`] for notification-scoped contexts (see
@@ -147,6 +155,7 @@ impl<'a> Context<'a> {
             protocol_version,
             peer,
             cancel: CancellationToken::new(),
+            related_task: None,
         }
     }
 
@@ -169,6 +178,7 @@ impl<'a> Context<'a> {
             protocol_version,
             peer,
             cancel,
+            related_task: None,
         }
     }
 
@@ -195,6 +205,42 @@ impl<'a> Context<'a> {
             protocol_version,
             peer,
             cancel: CancellationToken::new(),
+            related_task: None,
+        }
+    }
+
+    /// Associate this context with a task.
+    ///
+    /// Every outbound request made through it then carries
+    /// `_meta["io.modelcontextprotocol/related-task"]` with `task_id`, which
+    /// the spec requires of messages related to a task:
+    ///
+    /// > All requests, notifications, and responses related to a task **MUST**
+    /// > include the `io.modelcontextprotocol/related-task` key in their
+    /// > `_meta` field […] an elicitation that a task-augmented tool call
+    /// > depends on **MUST** share the same related task ID with that tool
+    /// > call's task.
+    ///
+    /// Applied automatically by the task-augmented tool path; call this only
+    /// when driving a task yourself.
+    #[must_use]
+    pub fn with_related_task(mut self, task_id: TaskId) -> Self {
+        self.related_task = Some(task_id);
+        self
+    }
+
+    /// The task this request is part of, if any.
+    #[must_use]
+    pub const fn related_task(&self) -> Option<&TaskId> {
+        self.related_task.as_ref()
+    }
+
+    /// Stamp the related-task `_meta` onto outbound request params, if this
+    /// context belongs to a task.
+    fn tag_related_task(&self, params: serde_json::Value) -> serde_json::Value {
+        match self.related_task.as_ref() {
+            Some(id) => mcpkit_core::tasks::inject_related_task(params, id),
+            None => params,
         }
     }
 
@@ -357,7 +403,7 @@ impl<'a> Context<'a> {
             ));
         }
 
-        let params = serde_json::to_value(&request).map_err(McpError::from)?;
+        let params = self.tag_related_task(serde_json::to_value(&request).map_err(McpError::from)?);
         let result = self.request("elicitation/create", Some(params)).await?;
         serde_json::from_value(result).map_err(McpError::from)
     }
@@ -415,7 +461,7 @@ impl<'a> Context<'a> {
             ));
         }
 
-        let params = serde_json::to_value(&request).map_err(McpError::from)?;
+        let params = self.tag_related_task(serde_json::to_value(&request).map_err(McpError::from)?);
         let result = self.request("elicitation/create", Some(params)).await?;
         serde_json::from_value(result).map_err(McpError::from)
     }
@@ -440,7 +486,7 @@ impl<'a> Context<'a> {
             ));
         }
 
-        let params = serde_json::to_value(&request).map_err(McpError::from)?;
+        let params = self.tag_related_task(serde_json::to_value(&request).map_err(McpError::from)?);
         let result = self.request("sampling/createMessage", Some(params)).await?;
         serde_json::from_value(result).map_err(McpError::from)
     }

--- a/crates/mcpkit-server/src/router.rs
+++ b/crates/mcpkit-server/src/router.rs
@@ -671,7 +671,11 @@ pub async fn run_augmented_tool(
             protocol_version,
             peer.as_ref(),
         ),
-    };
+    }
+    // Spec: every request this tool raises while it runs — an
+    // `elicitation/create`, a `sampling/createMessage` — MUST carry the same
+    // related task id. Set once here so all 5 dispatch paths inherit it.
+    .with_related_task(handle.id().clone());
     match call_tool_json(handler.as_ref(), &name, args, &ctx).await {
         // Per spec, a tool result with `isError: true` moves the task to
         // `failed`, while `tasks/result` still returns that result.

--- a/crates/mcpkit-warp/tests/peer_e2e.rs
+++ b/crates/mcpkit-warp/tests/peer_e2e.rs
@@ -490,3 +490,78 @@ async fn task_augmented_tool_elicits_over_the_stream() {
     }
     assert_eq!(text, "elicited: blue");
 }
+
+/// Spec: a notification carries no id and MUST NOT draw a response — including
+/// one the server does not handle, and one whose params are missing.
+///
+/// Asserted on this dispatch path specifically. Each adapter decides this in
+/// its own `handle_mcp_post`, not in the shared `route_*` helpers, so passing
+/// on one adapter says nothing about the other three.
+#[tokio::test]
+async fn notifications_never_draw_a_response() {
+    let (state, _) = test_state();
+    let sid = init(&state).await;
+
+    for method in [
+        "notifications/initialized",
+        "notifications/cancelled",
+        "notifications/roots/list_changed",
+        "notifications/progress",
+        "notifications/not_a_real_method",
+    ] {
+        let (status, body) = post(
+            &state,
+            Some(&sid),
+            serde_json::json!({ "jsonrpc": "2.0", "method": method }),
+        )
+        .await;
+        assert_eq!(
+            body,
+            serde_json::Value::Null,
+            "{method} drew a response body"
+        );
+        assert_eq!(status, 202, "{method} should be accepted with 202");
+    }
+}
+
+/// Spec: a server honours exactly the capabilities it advertised. This handler
+/// declares no `completion`, so `completion/complete` must be method-not-found
+/// (-32601) — the literal is spelled out rather than referenced through the
+/// constant that produces it.
+#[tokio::test]
+async fn capabilities_are_honoured_exactly_as_advertised() {
+    let (state, _) = test_state();
+    let (_, init_result) = post(
+        &state,
+        None,
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 0, "method": "initialize",
+            "params": { "protocolVersion": "2025-11-25", "capabilities": {} }
+        }),
+    )
+    .await;
+    assert!(
+        init_result["result"]["capabilities"]
+            .get("completion")
+            .is_none(),
+        "handler advertised completion it does not implement: {init_result}"
+    );
+    let sid = init(&state).await;
+
+    let (_, body) = post(
+        &state,
+        Some(&sid),
+        serde_json::json!({
+            "jsonrpc": "2.0", "id": 1, "method": "completion/complete",
+            "params": {
+                "ref": { "type": "ref/prompt", "name": "p" },
+                "argument": { "name": "a", "value": "" }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(
+        body["error"]["code"], -32601,
+        "unadvertised completion/complete must be method-not-found: {body}"
+    );
+}

--- a/crates/mcpkit-warp/tests/peer_e2e.rs
+++ b/crates/mcpkit-warp/tests/peer_e2e.rs
@@ -449,6 +449,15 @@ async fn task_augmented_tool_elicits_over_the_stream() {
     // PR 6: the peer survives into the spawned task).
     let request = next_stream_request(&mut stream).await;
     assert_eq!(request["method"], "elicitation/create");
+    // Spec MUST (2025-11-25 tasks, "Associating Task-Related Messages"): an
+    // elicitation a task-augmented tool call depends on carries that call's
+    // task id. Key spelled out on purpose — asserting against the constant
+    // that produces it would pass even if the constant were wrong.
+    assert_eq!(
+        request["params"]["_meta"]["io.modelcontextprotocol/related-task"]["taskId"],
+        serde_json::json!(task_id),
+        "elicitation/create raised by a task-augmented tool must carry related-task _meta"
+    );
     let request_id = request["id"].clone();
     let _ = post(
         &state,

--- a/scripts/schema-diff.sh
+++ b/scripts/schema-diff.sh
@@ -14,11 +14,17 @@
 #   3. Closed enum variants— the 3 $defs carrying an `enum` array
 #   4. Content types       — the 16 $defs carrying a `const` on properties.type
 #
-# Direction rules (see the audit brief):
-#   Rows 1 and 2 are reported IN-SCHEMA-NOT-IN-MCPKIT only. The mcpkit side is a
-#   deliberately wide literal extraction; its complement is ~562 arbitrary Rust
-#   string literals and carries no conformance signal.
-#   Rows 3 and 4 are reported in both directions.
+# All four rows are reported in BOTH directions. Rows 1 and 2 previously
+# compared the schema against a wide literal sweep of crates/*/src and so were
+# reported one way only — and, it turned out, could not fail at all: the sweep
+# is saturated by doc comments and inline tests, so renaming a routing constant
+# left the gate green. They now compare against the declared constant set in
+# mcpkit-core/src/methods.rs, which is precise in both directions.
+#
+# What this still cannot see: whether a method is ROUTED. A constant can exist
+# and be dispatched nowhere, and it can be routed on some of the five dispatch
+# paths (the server runtime plus four HTTP adapters) and not others. Routing and
+# behaviour are the job of the test suite, not of this script.
 #
 # Usage:
 #   scripts/schema-diff.sh              human-readable report
@@ -163,48 +169,63 @@ printf 'schema sha256: %s\n' "$(sha256sum "$SCHEMA" | cut -d' ' -f1)"
 printf 'defs: %s\n' "$(jq '.["$defs"] | length' "$SCHEMA")"
 
 # ===========================================================================
-# Wide mcpkit literal extraction (shared by rows 1 and 2).
+# mcpkit method-constant extraction (shared by rows 1 and 2).
 #
-# Deliberately wide: `initialize` and `ping` contain no slash, so a
-# "<ns>/<method>" filter would silently drop them — including the one the
-# whole negotiation claim rests on. Extract broadly, intersect one way.
+# The declared `pub const NAME: &str = "..."` set in mcpkit-core's methods.rs —
+# the single place the wire names live, and what every crate routes on.
+#
+# This was a WIDE literal sweep of crates/*/src, and that made rows 1 and 2
+# incapable of failing. Every spec method also appears in doc comments, inline
+# #[cfg(test)] blocks and hand-written client call sites — measured: all 31
+# occur in >=4 distinct places, none only in its constant. Renaming TOOLS_LIST
+# to "tools/lst" left the gate green, as did renaming
+# "notifications/initialized". A row that cannot regress is decoration.
+#
+# Against the constant set both rows are precise, so BOTH directions are
+# meaningful and reported: a missing member means mcpkit cannot serve a spec
+# method, an extra one means it declares a name the spec does not define.
 # ===========================================================================
-grep -rhoE '"[a-z][a-zA-Z_/]*"' "$SRC_GLOB"/*/src --include='*.rs' 2>/dev/null |
-	tr -d '"' | sort -u > "$WORK/mcpkit_literals.txt"
+METHODS_RS="crates/mcpkit-core/src/methods.rs"
+[ -f "$METHODS_RS" ] || { echo "error: $METHODS_RS not found" >&2; exit 1; }
+grep -oE 'pub const [A-Z_]+: &str = "[^"]+"' "$METHODS_RS" |
+	grep -oE '"[^"]+"' | tr -d '"' | sort -u > "$WORK/mcpkit_methods.txt"
 
 # ===========================================================================
-# Row 1 — method names
+# Row 1 — method names (both directions)
 # ===========================================================================
 jq -r '.["$defs"] | to_entries[] | select(.value.properties.method.const)
        | .value.properties.method.const' "$SCHEMA" | sort -u > "$WORK/schema_methods.txt"
 
-hr "Row 1: method names (schema-side difference only)"
-printf 'wide literals from %s/*/src : %s\n' "$SRC_GLOB" "$(wc -l < "$WORK/mcpkit_literals.txt")"
-printf 'schema methods                : %s\n' "$(wc -l < "$WORK/schema_methods.txt")"
-printf 'intersect with schema methods : %s / %s\n' \
-	"$(both_in "$WORK/schema_methods.txt" "$WORK/mcpkit_literals.txt" | wc -l)" \
-	"$(wc -l < "$WORK/schema_methods.txt")"
-printf 'in-schema-not-in-mcpkit       :\n'
-only_in "$WORK/schema_methods.txt" "$WORK/mcpkit_literals.txt" | sed 's/^/  /' || true
-only_in "$WORK/schema_methods.txt" "$WORK/mcpkit_literals.txt" | grep -q . || printf '  (none)\n'
-only_in "$WORK/schema_methods.txt" "$WORK/mcpkit_literals.txt" | emit 'method in-schema-not-in-mcpkit'
+hr "Row 1: method names (both directions)"
+printf 'mcpkit method constants : %s (%s)\n' \
+	"$(wc -l < "$WORK/mcpkit_methods.txt")" "$METHODS_RS"
+printf 'schema methods          : %s\n' "$(wc -l < "$WORK/schema_methods.txt")"
+printf 'both                    : %s\n' \
+	"$(both_in "$WORK/schema_methods.txt" "$WORK/mcpkit_methods.txt" | wc -l)"
+printf 'in-schema-not-in-mcpkit :%s\n' \
+	"$(only_in "$WORK/schema_methods.txt" "$WORK/mcpkit_methods.txt" | paste -sd, - | sed 's/^/ /;s/^ $/ (none)/')"
+printf 'in-mcpkit-not-in-schema :%s\n' \
+	"$(only_in "$WORK/mcpkit_methods.txt" "$WORK/schema_methods.txt" | paste -sd, - | sed 's/^/ /;s/^ $/ (none)/')"
+only_in "$WORK/schema_methods.txt" "$WORK/mcpkit_methods.txt" | emit 'method in-schema-not-in-mcpkit'
+only_in "$WORK/mcpkit_methods.txt" "$WORK/schema_methods.txt" | emit 'method in-mcpkit-not-in-schema'
 
 # ===========================================================================
-# Row 2 — notification methods
+# Row 2 — notification methods (both directions)
 # ===========================================================================
 { grep '^notifications/' "$WORK/schema_methods.txt" || true; } | sort -u > "$WORK/schema_notifs.txt"
-grep '^notifications/' "$WORK/mcpkit_literals.txt" | sort -u > "$WORK/mcpkit_notifs.txt" || true
+{ grep '^notifications/' "$WORK/mcpkit_methods.txt" || true; } | sort -u > "$WORK/mcpkit_notifs.txt"
 
-hr "Row 2: notification methods (schema-side difference only)"
-printf 'mcpkit notifications/* literals: %s\n' "$(wc -l < "$WORK/mcpkit_notifs.txt")"
-printf 'schema notification methods    : %s\n' "$(wc -l < "$WORK/schema_notifs.txt")"
-printf 'intersect                      : %s / %s\n' \
-	"$(both_in "$WORK/schema_notifs.txt" "$WORK/mcpkit_notifs.txt" | wc -l)" \
-	"$(wc -l < "$WORK/schema_notifs.txt")"
-printf 'in-schema-not-in-mcpkit        :\n'
-only_in "$WORK/schema_notifs.txt" "$WORK/mcpkit_notifs.txt" | sed 's/^/  /' || true
-only_in "$WORK/schema_notifs.txt" "$WORK/mcpkit_notifs.txt" | grep -q . || printf '  (none)\n'
+hr "Row 2: notification methods (both directions)"
+printf 'mcpkit notification constants: %s\n' "$(wc -l < "$WORK/mcpkit_notifs.txt")"
+printf 'schema notification methods  : %s\n' "$(wc -l < "$WORK/schema_notifs.txt")"
+printf 'both                         : %s\n' \
+	"$(both_in "$WORK/schema_notifs.txt" "$WORK/mcpkit_notifs.txt" | wc -l)"
+printf 'in-schema-not-in-mcpkit      :%s\n' \
+	"$(only_in "$WORK/schema_notifs.txt" "$WORK/mcpkit_notifs.txt" | paste -sd, - | sed 's/^/ /;s/^ $/ (none)/')"
+printf 'in-mcpkit-not-in-schema      :%s\n' \
+	"$(only_in "$WORK/mcpkit_notifs.txt" "$WORK/schema_notifs.txt" | paste -sd, - | sed 's/^/ /;s/^ $/ (none)/')"
 only_in "$WORK/schema_notifs.txt" "$WORK/mcpkit_notifs.txt" | emit 'notification in-schema-not-in-mcpkit'
+only_in "$WORK/mcpkit_notifs.txt" "$WORK/schema_notifs.txt" | emit 'notification in-mcpkit-not-in-schema'
 
 # ===========================================================================
 # Row 3 — closed enum variants (both directions, per enum)

--- a/scripts/schema-diff.sh
+++ b/scripts/schema-diff.sh
@@ -432,7 +432,36 @@ extract_struct_flat() {
 	done
 }
 
-hr "Tier 2: structural field diff (every \$def with a same-named mcpkit struct)"
+# ---------------------------------------------------------------------------
+# Alias map: $def name -> mcpkit type name, for types that ARE 1:1 but are
+# spelled differently.
+#
+# Name-based auto-discovery silently skips these, and "no same-named type" was
+# being reported as "no 1:1 Rust type" — which was wrong, and hid a real
+# conformance failure (elicitation params carry no `_meta`, a spec MUST for
+# task-related messages). Anything added here gets diffed like any other type.
+#
+# Deliberately NOT aliased:
+#   TextResourceContents / BlobResourceContents -> ResourceContents
+#     mcpkit flattens both siblings into one struct which is already diffed
+#     against the `ResourceContents` def; aliasing would double-report it.
+#   PromptReference / ResourceTemplateReference -> CompletionRef::{Prompt,Resource}
+#     enum variants, not structs — extract_struct cannot read them. Their
+#     discriminators are covered by Row 4.
+#   StringSchema / NumberSchema / BooleanSchema / *EnumSchema -> PropertySchema
+#     one open-typed struct models all seven; a deliberate modelling choice
+#     already recorded in the baseline.
+alias_for() {
+	case "$1" in
+	ElicitRequestFormParams) echo ElicitRequest ;;
+	ElicitRequestURLParams)  echo UrlElicitRequest ;;
+	EmbeddedResource)        echo ResourceContent ;;
+	ResourceLink)            echo ResourceLinkContent ;;
+	*)                       echo "" ;;
+	esac
+}
+
+hr "Tier 2: structural field diff (every \$def with a same-named or aliased mcpkit struct)"
 unresolved=0
 diffcount=0
 
@@ -440,6 +469,7 @@ diffcount=0
 # discovered rather than listed, so a type added to either side is picked up
 # instead of silently staying unchecked — the hardcoded 7-type list this
 # replaced left 138 defs unexamined and made the sample look like coverage.
+# Defs whose Rust counterpart has a different name are resolved via alias_for().
 #
 # For a `*Request` def the schema node is the JSON-RPC envelope (id/jsonrpc/
 # method/params) while the same-named Rust struct is the params, so when a def
@@ -448,23 +478,29 @@ TIER2="$(
 	jq -r '.["$defs"] | to_entries[]
 	       | .key + "|" + (if (.value.properties.params) then "params" else "self" end)' "$SCHEMA" |
 	while IFS='|' read -r ty kind; do
+		rust="$ty"
 		file="$(grep -rl "^pub struct $ty\b" "$SRC_GLOB"/*/src --include='*.rs' 2>/dev/null | awk 'NR==1')"
-		[ -n "$file" ] || continue
+		if [ -z "$file" ]; then
+			rust="$(alias_for "$ty")"
+			[ -n "$rust" ] || continue
+			file="$(grep -rl "^pub struct $rust\b" "$SRC_GLOB"/*/src --include='*.rs' 2>/dev/null | awk 'NR==1')"
+			[ -n "$file" ] || { echo "warn: alias $ty -> $rust not found in sources" >&2; continue; }
+		fi
 		if [ "$kind" = params ]; then
-			printf '%s|%s|.["$defs"].%s.properties.params\n' "$ty" "$file" "$ty"
+			printf '%s|%s|.["$defs"].%s.properties.params|%s\n' "$ty" "$file" "$ty" "$rust"
 		else
-			printf '%s|%s|.["$defs"].%s\n' "$ty" "$file" "$ty"
+			printf '%s|%s|.["$defs"].%s|%s\n' "$ty" "$file" "$ty" "$rust"
 		fi
 	done
 )"
 
-while IFS='|' read -r ty file path; do
+while IFS='|' read -r ty file path rust; do
 	[ -n "$ty" ] || continue
 	jq -r "$RESOLVE_JQ . as \$root | $path | resolve(\$root)
 	       | (.required) as \$r | .properties | keys[] as \$k
 	       | \$k + \"\t\" + (if (\$r | index(\$k)) then \"req\" else \"opt\" end)" \
 		"$SCHEMA" | sort > "$WORK/s2.txt"
-	extract_struct_flat "$file" "$ty" | sort > "$WORK/m2.txt"
+	extract_struct_flat "$file" "$rust" | sort > "$WORK/m2.txt"
 
 	# A schema node that resolves to zero properties is one this resolver cannot
 	# expand — an `anyOf` union (ElicitRequestParams) or an abstract JSON-RPC base
@@ -477,7 +513,11 @@ while IFS='|' read -r ty file path; do
 		continue
 	fi
 
-	printf '\n%s  (%s)\n' "$ty" "$file"
+	if [ "$rust" != "$ty" ]; then
+		printf '\n%s -> %s  (%s)  [alias]\n' "$ty" "$rust" "$file"
+	else
+		printf '\n%s  (%s)\n' "$ty" "$file"
+	fi
 	printf '  schema path: %s\n' "$path"
 	# `type` is the tagged-union discriminator. mcpkit supplies it from the
 	# enum wrapper (#[serde(tag = "type")]), never as a struct field, so its

--- a/spec/schema-diff-baseline.txt
+++ b/spec/schema-diff-baseline.txt
@@ -14,6 +14,18 @@
 # appears below, which is the point — if any of them regresses, a line appears
 # here and the job fails.
 #
+# That last sentence was FALSE for the method rows until the constant-set
+# rewrite. They compared the schema against a wide literal sweep of
+# crates/*/src, which every spec method also hits via doc comments, inline
+# tests and client call sites — so renaming a routing constant left this file
+# unchanged and the job green. Both breaks are now caught, and each row is
+# reported in both directions. Re-verify rather than trust this paragraph:
+# rename a constant in mcpkit-core/src/methods.rs and confirm the job fails.
+#
+# What these rows still do NOT prove is that a method is routed, on any of the
+# five dispatch paths. That is the test suite's job — see
+# mcpkit/tests/protocol_behaviour_conformance.rs.
+#
 # Everything below is a content-type discriminator, and every entry is
 # deliberate:
 #
@@ -34,16 +46,26 @@
 #
 #
 # ---------------------------------------------------------------------------
-# Tier 2 (structural). Every $def with a same-named mcpkit struct is diffed —
-# 75 types. `type` discriminators are filtered (mcpkit supplies them from the
+# Tier 2 (structural). Every $def with a same-named mcpkit struct is diffed,
+# plus those resolved through the alias map in schema-diff.sh — 79 types.
+# `type` discriminators are filtered (mcpkit supplies them from the
 # #[serde(tag = "type")] enum wrapper, never as a struct field), and 4 defs are
 # reported UNRESOLVED rather than diffed because this resolver cannot expand an
 # `anyOf` union (ElicitRequestParams) or an abstract JSON-RPC base
 # (Request/Notification).
 #
-# The 21 missing `_meta` fields recorded here previously are closed: every type
-# the schema declares `_meta` on now carries it. What remains is one modelling
-# difference, and it is benign:
+# The alias map exists because "no same-named Rust type" was being read as "no
+# 1:1 Rust type". Four defs had one under a different name, and two of them
+# — ElicitRequestFormParams and ElicitRequestURLParams — were missing `task`
+# and `_meta` the whole time. That is not cosmetic: the spec REQUIRES
+# `io.modelcontextprotocol/related-task` in `_meta` on an elicitation raised by
+# a task-augmented tool call, so the omission made the MUST unsatisfiable.
+# Anything reported as unmatched should be checked for a differently-named
+# counterpart before being written off as un-diffable.
+#
+# `_meta` coverage is now complete for every type that has one to carry: the 21
+# recorded here previously, plus the two elicitation param types. What remains
+# is one modelling difference, and it is benign:
 #
 #   `ResourceContents blob|text` — the schema splits TextResourceContents and
 #   BlobResourceContents into sibling defs extending ResourceContents; mcpkit


### PR DESCRIPTION
Re-run of the conformance audit against the vendored schema, then the fix pass. The pin, the baseline and every Tier 1/Tier 2 number from #186 held. What the re-run found was that parts of the gate could not fail — and, behind one of the claims that hid it, a spec **MUST** that no mcpkit server could satisfy.

## The conformance failure

`docs/specification/2025-11-25/basic/utilities/tasks.mdx`, "Associating Task-Related Messages":

> All requests, notifications, and responses related to a task **MUST** include the `io.modelcontextprotocol/related-task` key in their `_meta` field […] an elicitation that a task-augmented tool call depends on **MUST** share the same related task ID with that tool call's task.

The schema could not settle this — `_meta` is optional *there*, so the machine-readable artifact and the prose disagree, and the prose wins. `ElicitRequest`/`UrlElicitRequest` had no `_meta` field at all, `Context::elicit` serializes the struct straight into params, and `inject_related_task` had exactly one call site (`tasks/result`). The requirement was unsatisfiable through the public API, on a path that ships (`task_augmented_tool_elicits_over_the_stream`).

Fixed in two parts, because the field alone is not enough: `ServerContext` had no notion of the task a handler runs inside (zero hits for `task_id`/`TaskId`), so nothing could populate it. `run_augmented_tool` now sets it once — the single seam all four adapters and the server runtime reach via `begin_augmented_task`.

## Why it was invisible

`scripts/schema-diff.sh` matched `$def`s to Rust types by name only and reported everything unmatched as "no 1:1 Rust type". Four had one under a different name. An alias map takes Tier 2 from 75 to 79 types and surfaced the gap immediately.

Separately, Tier 1 rows 1–2 compared the schema against a **wide literal sweep** of `crates/*/src`. That set is saturated — every spec method also appears in doc comments, inline tests and client call sites (measured: all 31 occur in ≥4 places, none only in its constant). Renaming `TOOLS_LIST` to `"tools/lst"` left the job green. They now compare against the declared `pub const` set, in both directions.

The rename was still caught elsewhere, by `method_constants_cover_the_spec_exactly` in the `test` job — so this was misattributed protection, not an open hole. The baseline header asserted the guarantee for itself; corrected, with the reason it was wrong.

## Commits

| | |
|---|---|
| `b36ed12` | alias map + elicitation `task`/`_meta` + `#[non_exhaustive]` on 16 free wire types — **breaking** |
| `98d793f` | related-task `_meta` on outbound requests, all five dispatch paths |
| `b8e1d3f` | rows 1–2 compare against the constant set; baseline header corrected |
| `bd19bcc` | drop unused `schemars` workspace dep |
| `cf69932` | behavioural invariants asserted per adapter; ROADMAP row corrected |

## Every check was broken before being trusted

| Break | Result |
|---|---|
| remove `_meta` from `UrlElicitRequest` | schema gate fails — invisible before the alias map |
| `TOOLS_LIST` → `"tools/lst"` | now caught; passed before |
| `notifications/initialized` → `…initialised` | now caught; passed before |
| remove `.with_related_task(...)` | all four adapter tests fail |
| re-send notifications as requests | `notifications/initialized drew a response body` |

## Scope notes

- `#[non_exhaustive]` covers the 16 `_meta`-bearing types with **zero** struct-literal sites in the workspace. The 17 users build by hand (`Tool`, `Prompt`, `Resource`, `GetPromptResult`, …) are deliberately left constructible — 97 sites between them. "Zero internal sites" is not "no downstream breakage"; it is still breaking, which is acceptable only pre-1.0.
- Pre-initialize rejection was **not** duplicated per adapter: over Streamable HTTP that is a request without `mcp-session-id`, already covered on all four. The adapters returning 400 for a session-less `ping` is the correct binding-specific form, not a divergence.
- `D.1` (server run-loop normalization, ADR 0006) remains open and is out of scope here.

Local gate green: 1469 tests, fmt, clippy `-D warnings`, docs, typos (CI file scope), machete, shellcheck, schema baseline.