### PR TITLE
Prepare the 0.7.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-07-27
+
 ### Spec-conformance audit
 
 An audit against the official MCP schema, vendored and pinned at
@@ -1518,7 +1520,8 @@ to make after 1.0. Migration for each is below.
 - `mcpkit-testing` crate for test utilities
 - Protocol version detection and capability negotiation
 
-[Unreleased]: https://github.com/praxiomlabs/mcpkit/compare/v0.6.0...HEAD
+[Unreleased]: https://github.com/praxiomlabs/mcpkit/compare/v0.7.0...HEAD
+[0.7.0]: https://github.com/praxiomlabs/mcpkit/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/praxiomlabs/mcpkit/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/praxiomlabs/mcpkit/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/praxiomlabs/mcpkit/compare/v0.3.0...v0.4.0

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide for releasing new versions of MCPkit to crates.io.
 
-**Version:** 0.6.0 | **MSRV:** 1.85 | **Edition:** 2024
+**Version:** 0.7.0 | **MSRV:** 1.85 | **Edition:** 2024
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -112,6 +112,7 @@ structured to vendor a second revision alongside the current one.
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 0.7.0 | 2026-07-27 | Spec conformance against the vendored 2025-11-25 schema, gated in CI; task-related `_meta`; per-adapter behavioural tests (#186, #187) |
 | 0.6.0 | 2026-06-18 | Concurrency & panic isolation, JWT/OAuth & transport hardening, macro fixes (#5–#24) |
 | 0.5.0 | 2025-12-25 | gRPC transport, Rocket/Warp integrations, deployment configs |
 | 0.4.0 | 2025-12-24 | `#[mcp_client]` macro, protocol extensions, debug tooling |

--- a/docs/migration-to-1.0.md
+++ b/docs/migration-to-1.0.md
@@ -4,7 +4,11 @@ This guide helps you migrate from mcpkit 0.x to the stable 1.0 release.
 
 ## TL;DR
 
-**If you're on 0.6.x**: No migration required. The 1.0 API is identical to 0.6.x.
+**If you're on 0.7.x**: No migration required for 1.0 as currently planned.
+
+**If you're on 0.6.x**: Migrate to 0.7.x first — that transition carried breaking
+changes. See [Pre-1.0 Breaking Changes Summary](#pre-10-breaking-changes-summary)
+below.
 
 **If you're on 0.4.x or earlier**: Follow the version-specific guides below.
 
@@ -189,6 +193,8 @@ Key changes:
 | 0.6.x → 0.7.x | Real MCP extension identifiers | Update `io.mcp*` comparisons |
 | 0.6.x → 0.7.x | MCP Apps MIME type is `text/html;profile=mcp-app` | Update comparisons |
 | 0.6.x → 0.7.x | Method-name constants moved to `mcpkit-core` | Paths unchanged (re-exported) |
+| 0.6.x → 0.7.x | `ElicitRequest`/`UrlElicitRequest` gained `task` and `meta` | Add `task: None, meta: None` to struct literals |
+| 0.6.x → 0.7.x | 16 further wire types are `#[non_exhaustive]` | Use the type's constructor instead of a struct literal |
 | 0.2.x → 0.3.x | MCP protocol default: 2025-06-18 → 2025-11-25 | No action needed |
 | 0.2.x → 0.3.x | Tasks API added | Optional: use `with_tasks()` |
 | 0.2.x → 0.3.x | Elicitation API added | Optional: use `with_elicitation()` |

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -143,6 +143,7 @@ Before declaring 1.0 stable, we will:
 | 0.4.0 | Q4 2025 | Released |
 | 0.5.0 | Q4 2025 | Released |
 | 0.6.0 | Q2 2026 | Released |
+| 0.7.0 | Q3 2026 | Released |
 | 1.0.0 Stable | 2026 | In Progress |
 
 Note: We follow a "release when ready" philosophy. The 1.0 release will occur when all criteria in the [ROADMAP.md](../ROADMAP.md) are met and the API has stabilized through community usage.


### PR DESCRIPTION
Docs-only. Cuts `[Unreleased]` to `[0.7.0] - 2026-07-27` and records the release in both history tables.

Two documentation defects surfaced while reviewing the release process, and neither is reachable by CI:

**`RELEASING.md` declared `**Version:** 0.6.0`** in its own header. `version-sync` checks `README.md` and `docs/`; a root-level file asserting a stale version sits outside its scope.

**`docs/migration-to-1.0.md` contradicted itself.** Its TL;DR said *"If you're on 0.6.x: No migration required. The 1.0 API is identical to 0.6.x"*, while the same file listed six breaking 0.6.x→0.7.x changes 180 lines later. That file is on `version-sync`'s exclude list — its old pins are intentional rollback targets — so nothing was going to catch it. The TL;DR now routes 0.6.x users through 0.7.x and no longer asserts what the unreleased 1.0 API will contain.

The 0.6.x→0.7.x table was also missing the two breaking changes from #187 (elicitation `task`/`meta`; `#[non_exhaustive]` on 16 further wire types), which landed after it was written.

Verified locally: `version-sync` (CI's exact logic), typos over the CI file list, fmt, schema baseline, `wip-check`, `metadata-check`, `cargo publish --workspace --dry-run` (all 11 crates).

Release-process findings that are **not** fixed here are in the PR discussion — they want their own change, not a release-prep commit.