### PR TITLE
Release-process follow-ups: a rule that couldn't pass, a rationale that was fiction, two gates with holes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,17 @@ jobs:
             FAIL=1
           fi
 
+          # RELEASING.md declares the release it documents in its own header,
+          # using a different syntax from the dependency snippets above and
+          # living at the repo root — so neither the per-file presence check nor
+          # the stale sweep could see it. It sat at 0.6.0 for the whole 0.7.0
+          # cycle and was only caught by hand during release prep.
+          if ! grep -qE "^\*\*Version:\*\* ${VERSION}( |$)" RELEASING.md; then
+            echo "ERROR: RELEASING.md header does not declare **Version:** $VERSION"
+            grep -nE "^\*\*Version:\*\*" RELEASING.md || true
+            FAIL=1
+          fi
+
           if [ "$FAIL" -ne 0 ]; then
             exit 1
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,51 +186,48 @@ jobs:
           fi
           echo "All version references are correct!"
 
+  # Relative links and anchors in markdown — offline, no network.
+  #
+  # This job used to check external http/https links too, and that made merges
+  # depend on third-party uptime. It has now failed three distinct ways with no
+  # change to the repo: lychee resolving `file://` fixtures against the runner
+  # filesystem, rate-limit timeouts from link volume, and (2026-07-27) a 415
+  # from effective-rust.com that turned `main` red on a docs-only release-prep
+  # commit while the same URL served 200 everywhere else. Each was answered with
+  # another exclude, and the list grew every time reality surprised it.
+  #
+  # External links moved to .github/workflows/link-check-external.yml, which
+  # runs on a schedule. A broken external link is worth knowing about; it is not
+  # worth blocking a merge that did not cause it.
+  #
+  # Scope is markdown only. Rust sources are deliberately excluded: they embed
+  # `file://` fixture URIs (46 of them) that offline mode resolves and reports
+  # as missing files. Rustdoc intra-doc links are already validated by the
+  # Documentation job's `RUSTDOCFLAGS=-D warnings`.
   link-check:
-    name: Link Check
+    name: Link Check (offline)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      # Covers Rust sources as well as markdown: rustdoc comments carry real
-      # reference links, and nothing was checking them — a 404 in
-      # extension/mod.rs survived because this job only ever globbed ./docs.
-      # The example.com/fixture-host exclusions below exist because doc examples
-      # and security tests embed deliberately-unreachable URLs.
-      - name: Check links in docs and rustdoc comments
+      - name: Check relative links and anchors
         uses: lycheeverse/lychee-action@v2
         with:
+          # --include-fragments=anchor-only checks `#section` targets inside the
+          # repo. It caught a real break the http/https-only job could never
+          # see: CONTRIBUTING.md pointed at
+          # docs/versioning.md#minimum-supported-rust-version, but the heading
+          # slug is #minimum-supported-rust-version-msrv.
           args: >
+            --offline
             --verbose
             --no-progress
-            --scheme http
-            --scheme https
-            --max-retries 6
-            --retry-wait-time 3
-            --timeout 30
-            --max-concurrency 16
-            --accept 200,204,206
-            --exclude "^https://crates.io"
-            --exclude "^https://docs.rs"
-            --exclude "^https://www.reddit.com"
-            --exclude "^https://cliffle.com"
-            --exclude "^https://img.shields.io"
-            --exclude "^https?://$"
-            --exclude "^https?://([^/]*\.)?example\.(com|org|net)([/:]|$)"
-            --exclude "^https?://([^/]*\.)?example([/:]|$)"
-            --exclude "^https?://[^./:]+([/:]|$)"
-            --exclude "^https?://[^/]*(trusted|malicious|evil)"
-            --exclude "^https?://(anything|app[0-9])\.com([/:]|$)"
-            --exclude-loopback
-            --exclude "^https?://[^/]*\.(test|invalid|localhost)([/:]|$)"
-            --exclude "YOUR_USERNAME"
+            --include-fragments=anchor-only
             './docs/**/*.md'
             './README.md'
             './CONTRIBUTING.md'
             './spec/**/*.md'
-            './crates/**/src/**/*.rs'
-            './mcpkit/src/**/*.rs'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          fail: true
+          failIfEmpty: true
 
   # Diffs mcpkit's wire vocabulary against the vendored official schema.
   # Ungated on purpose: spec/** and scripts/** match no path filter in the

--- a/.github/workflows/link-check-external.yml
+++ b/.github/workflows/link-check-external.yml
@@ -1,0 +1,75 @@
+name: Link Check (external)
+
+# External http/https links, on a schedule instead of on every merge.
+#
+# This ran as part of CI until 2026-07-27 and blocked merges on third-party
+# uptime. It failed three distinct ways with no change to the repo — lychee
+# resolving `file://` fixtures against the runner filesystem, rate-limit
+# timeouts from link volume, and a 415 from effective-rust.com that turned
+# `main` red on a docs-only commit while the same URL served 200 elsewhere.
+# Each was answered with another exclude, and the list grew every time reality
+# surprised it.
+#
+# A dead external link is worth knowing about. It is not worth blocking a merge
+# that did not cause it, so this reports rather than gates. Relative links and
+# anchors — the ones a change can actually break — stay gated in ci.yml's
+# offline `link-check` job.
+#
+# The args below are carried over verbatim: every exclude encodes a real
+# incident, and dropping one silently re-opens it.
+
+on:
+  schedule:
+    # Mondays 07:00 UTC. Weekly is enough for link rot; more often mostly
+    # re-samples the same flaky endpoints.
+    - cron: '0 7 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  link-check-external:
+    name: External links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      # The example.com/fixture-host exclusions exist because doc examples and
+      # security tests embed deliberately-unreachable URLs.
+      - name: Check external links in docs and rustdoc comments
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >
+            --verbose
+            --no-progress
+            --scheme http
+            --scheme https
+            --max-retries 6
+            --retry-wait-time 3
+            --timeout 30
+            --max-concurrency 16
+            --accept 200,204,206
+            --exclude "^https://crates.io"
+            --exclude "^https://docs.rs"
+            --exclude "^https://www.reddit.com"
+            --exclude "^https://cliffle.com"
+            --exclude "^https://img.shields.io"
+            --exclude "^https?://$"
+            --exclude "^https?://([^/]*\.)?example\.(com|org|net)([/:]|$)"
+            --exclude "^https?://([^/]*\.)?example([/:]|$)"
+            --exclude "^https?://[^./:]+([/:]|$)"
+            --exclude "^https?://[^/]*(trusted|malicious|evil)"
+            --exclude "^https?://(anything|app[0-9])\.com([/:]|$)"
+            --exclude-loopback
+            --exclude "^https?://[^/]*\.(test|invalid|localhost)([/:]|$)"
+            --exclude "YOUR_USERNAME"
+            './docs/**/*.md'
+            './README.md'
+            './CONTRIBUTING.md'
+            './spec/**/*.md'
+            './crates/**/src/**/*.rs'
+            './mcpkit/src/**/*.rs'
+          fail: true
+          failIfEmpty: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This project follows the [Rust Code of Conduct](https://www.rust-lang.org/polici
 
 ### Prerequisites
 
-- Rust 1.85 or later (see [MSRV policy](docs/versioning.md#minimum-supported-rust-version))
+- Rust 1.85 or later (see [MSRV policy](docs/versioning.md#minimum-supported-rust-version-msrv))
 - Git
 - [Just](https://github.com/casey/just) command runner (recommended)
 

--- a/Justfile
+++ b/Justfile
@@ -1257,19 +1257,25 @@ release-check: ci-release wip-check panic-audit version-sync typos machete metad
 [doc("Publish all crates to crates.io (dry run)")]
 publish-dry:
     #!/usr/bin/env bash
+    set -euo pipefail
     printf '{{cyan}}[INFO]{{reset}} Publishing (dry run)...\n'
-    # Publish in dependency order
-    {{cargo}} publish --dry-run -p mcpkit-core
-    {{cargo}} publish --dry-run -p mcpkit-macros
-    {{cargo}} publish --dry-run -p mcpkit-transport
-    {{cargo}} publish --dry-run -p mcpkit-server
-    {{cargo}} publish --dry-run -p mcpkit-client
-    {{cargo}} publish --dry-run -p mcpkit-testing
-    {{cargo}} publish --dry-run -p mcpkit-axum
-    {{cargo}} publish --dry-run -p mcpkit-actix
-    {{cargo}} publish --dry-run -p mcpkit-rocket
-    {{cargo}} publish --dry-run -p mcpkit-warp
-    {{cargo}} publish --dry-run -p mcpkit
+    # One workspace-wide dry run, NOT a loop of per-crate ones.
+    #
+    # The per-crate loop this replaced could not pass before a release: every
+    # crate after mcpkit-core failed with "failed to select a version for the
+    # requirement mcpkit-core = ^X.Y.Z", because a dry run resolves internal
+    # dependencies from the registry and the new version is not published yet.
+    # 10 of 11 crates always failed, so the cardinal rule in RELEASING.md that
+    # says to run this before every publish was unfollowable.
+    #
+    # `--workspace` resolves sibling members locally and orders them itself.
+    # Verified on cargo 1.97.1 both before 0.7.0 was published and after, so it
+    # works whether or not the version already exists on crates.io.
+    #
+    # This does NOT replace scripts/publish-crates.sh for the real publish —
+    # native cargo has no skip-published/resume, which is the property the
+    # v0.6.0 incident hardened. See docs/adr/0005-v0.6.0-release-incident.md.
+    {{cargo}} publish --workspace --dry-run
     printf '{{green}}[OK]{{reset}}   Dry run complete\n'
 
 [group('release')]

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -368,7 +368,7 @@ cargo semver-checks check-release --package mcpkit
 ### Pre-publish Verification
 
 ```bash
-just publish-dry    # Dry-run publish all crates in dependency order
+just publish-dry    # cargo publish --workspace --dry-run (all 11 crates)
 ```
 
 - [ ] Run `just publish-dry` - all crates succeed

--- a/docs/adr/0005-v0.6.0-release-incident.md
+++ b/docs/adr/0005-v0.6.0-release-incident.md
@@ -73,9 +73,33 @@ Harden the release process at the class level rather than per incident:
   Trusted Publishing (OIDC) would remove long-lived tokens at the
   generator; evaluate its GA status and 11-crate fit before investing in
   further token tooling.
-- The publish-ordering logic remains a hand-rolled script embedded in
-  `release.yml`. `cargo publish --workspace` (stable since Rust 1.90) may
-  allow deleting it entirely, pending an evaluation of its partial-publish
-  re-run semantics.
+- The publish-ordering logic remains a hand-rolled script. It was extracted
+  from `release.yml` into `scripts/publish-crates.sh` with a test harness in
+  #171 (2026-07-25), so the tested logic is now the released logic.
+
+  **The `cargo publish --workspace` replacement question was re-evaluated on
+  2026-07-27 and the rejection stands.** Evidence:
+
+  - `scripts/publish-crates-test.sh` pins partial-publish re-run support: an
+    `already uploaded` crate is skipped and the run continues. That is the
+    property this incident hardened.
+  - Native cargo has no `--skip-published` and no resume; `cargo publish
+    --help` on 1.97.1 offers only `--exclude` as a manual workaround.
+    `cargo-workspaces`, `cargo-publish-all` and `cargo-workspace-v2` exist
+    specifically to supply the missing behaviour.
+  - The Cargo Book documents `--workspace` in one line ("Publish all members
+    in the workspace") and specifies nothing about already-published members,
+    resumption, atomicity or ordering.
+
+  Limit of the evidence: real non-dry-run `--workspace` re-run behaviour was
+  **not** observed, because doing so requires actually publishing. The
+  conclusion rests on the absence of a documented skip/resume mechanism, not
+  on a reproduction. Revisit if cargo grows an explicit flag.
+
+  What the re-evaluation *did* settle: `cargo publish --workspace --dry-run`
+  works, before and after the version exists on crates.io (verified on 1.97.1
+  against 0.7.0 both ways). `just publish-dry` now uses it — the previous
+  per-crate loop could never pass, since a dry run resolves internal deps from
+  the registry and 10 of 11 crates failed on the unpublished new version.
 - Unrecoverable: the exact error text of the two failed runs. This record
   exists so the causal chain does not decay with it.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -5,8 +5,29 @@
 # and by scripts/publish-crates-test.sh the same way, so the tested shell
 # semantics are the released shell semantics by construction.
 #
-# Order matters: each crate must have its dependencies published first
-# (mcpkit-macros has mcpkit-server as a dev-dependency, so server comes first).
+# Order matters: each crate must have its dependencies published first. Derived
+# from the workspace graph, normal dependencies only — a dev-dependency does not
+# gate a publish:
+#
+#   mcpkit-core      (none)
+#   mcpkit-transport  <- core
+#   mcpkit-server     <- core, transport
+#   mcpkit-macros     <- core (dev only)
+#   mcpkit-client     <- core, transport
+#   mcpkit-testing    <- core, transport, server
+#   axum/actix/rocket/warp <- core, transport, server
+#   mcpkit            <- core, transport, server, macros, client   (last)
+#
+# Several orders satisfy that; the one below is one of them. Re-derive with
+# `cargo metadata --no-deps` rather than trusting this comment.
+#
+# The note previously here claimed mcpkit-macros dev-depends on mcpkit-server,
+# so server had to precede it. That stopped being true in 3a351d5 (2025-12-23),
+# seven months before this file was written — it was transcribed stale. It was
+# also the only stated rationale for the ordering, so a later audit read it as
+# a live constraint and wrongly reported the Justfile's different-but-equally-
+# valid order as a defect.
+#
 # A real publish failure aborts the release. The only tolerated error is
 # "already uploaded/exists", so re-running after a partial publish skips the
 # crates already on crates.io instead of masking every failure (the old


### PR DESCRIPTION
The four follow-ups from the 0.7.0 post-release review, investigated before being fixed. One commit each.

### `docs(release)` — the publish-order rationale was fiction

`publish-crates.sh:9` claimed `mcpkit-macros` dev-depends on `mcpkit-server`, so server had to publish first. That stopped being true in `3a351d5` (**2025-12-23**); the script was written **2026-07-25** (#171), so it was transcribed seven months stale. macros' only internal dep is `mcpkit-core`, and it's a dev-dep, which doesn't gate a publish at all.

The order was never wrong. The *reason* was — and it was load-bearing: being the only stated justification, it was read as a live constraint during review and produced a false finding against the Justfile's different-but-equally-valid ordering. Replaced with the graph from `cargo metadata --no-deps`, plus an explicit note that several orders satisfy it.

### `fix(release)` — Cardinal Rule 3 could not be followed

RELEASING.md says always run `just publish-dry` before publishing. It looped `cargo publish --dry-run -p` over 11 crates, and a dry run resolves internal deps from the registry — so **10 of 11 always failed** with `failed to select a version for the requirement mcpkit-core = ^X.Y.Z` until that version was already published. The rule was either never run or its failure routinely ignored.

Now one `cargo publish --workspace --dry-run`. Verified on cargo 1.97.1 both before and after 0.7.0 existed on crates.io. Added `set -euo pipefail` and confirmed failures propagate (exit 101).

**The real publish is unchanged.** `scripts/publish-crates.sh` stays — native cargo has no skip-published or resume, which is exactly the partial-publish property the v0.6.0 incident hardened and `publish-crates-test.sh` pins. ADR 0005 now records the re-evaluation, the evidence, *and its limit*: real non-dry-run `--workspace` re-run behaviour was not observed, because observing it requires actually publishing.

### `ci` — version-sync couldn't see RELEASING.md

It declares its version as `**Version:** X.Y.Z` at the repo root — matching neither the dependency-pin pattern nor the `docs/` sweep. It sat at 0.6.0 for the entire 0.7.0 cycle. Now checked explicitly; verified it fails when reverted to 0.6.0.

### `ci` — link checking gated on third-party uptime

Three distinct failures with no repo change: `file://` fixtures resolved against the runner filesystem, rate-limit timeouts, and a 415 from effective-rust.com that turned `main` red on a docs-only commit while serving 200 everywhere else. Each was answered with another exclude.

Split: `link-check` is now offline + markdown-only + `--include-fragments=anchor-only` (deterministic, 4ms); external links move to a weekly `link-check-external.yml` with the previous args carried over verbatim.

**It found a real break on its first run** — invisible to the http/https-only job for as long as that job has existed. `CONTRIBUTING.md` linked `docs/versioning.md#minimum-supported-rust-version`; the slug is `#minimum-supported-rust-version-msrv`. Red before the fix, 93 OK / 0 errors after — which is the evidence the gate is real rather than decoration.

---

Verified locally: `publish-crates-test.sh` (all 3 paths), `just publish-dry`, version-sync's exact logic including a deliberate failure, lychee 0.24.2 offline before and after the anchor fix, both workflows parse, typos over the CI file list.

Not done, deliberately: version-sync's three excluded files are excluded *whole-file*, so a legitimately-old pin on one line exempts the whole file — which is how `migration-to-1.0.md` came to contradict itself. Making those line-level is a separate change.