### PR TITLE
CI: cut the wait — seed the cross-platform cache, move macOS off the PR path, make cross-check real

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -398,16 +398,32 @@ jobs:
   test-matrix:
     name: Test (${{ matrix.os }})
     needs: [changes, test]
-    if: ${{ github.event_name == 'pull_request' && needs.changes.outputs.code == 'true' }}
+    # Also runs on pushes to main — not because main needs the coverage, but
+    # because rust-cache can only be RESTORED from the current branch or the
+    # base branch. While this job was pull_request-only, main never wrote an
+    # entry, so every PR started cold. Measured on PR #189: the Windows job
+    # logged "No cache found." and took 12m52s, four times the ubuntu Test
+    # Suite, and it is the single longest job in the pipeline.
+    if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest]
+        # macOS moved to .github/workflows/cross-platform.yml (scheduled). It
+        # cost 6m16s on every PR and, across the last 40 CI runs, failed zero
+        # times. Windows stays on the PR path: it has caught exactly one real
+        # break (4ae4f9f), which is one more than macOS.
+        os: [windows-latest]
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.96
       - uses: Swatinem/rust-cache@v2
+        with:
+          # Without this, PRs write ~GB entries scoped to their own ref that
+          # nothing else can restore, while competing for the 10 GB Actions
+          # cache limit and LRU-evicting main's entries. Same reasoning as the
+          # clippy/check jobs above.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       # Use --features full instead of --all-features to exclude regenerate-proto
       # (protobuf-src fails to build on Windows due to abseil-cpp linker issues)
       - run: cargo test -p mcpkit-transport --features full
@@ -526,10 +542,8 @@ jobs:
 
           # Mirrors each job's `if:` expression. Keep in sync when a job's
           # gating changes — a stale predicate here re-opens the hole.
-          gated=0   # clippy, check, test, deny, docs, msrv
+          gated=0   # clippy, check, test, deny, docs, msrv, test-matrix
           if [ "$CODE" = "true" ] || [ "$EVENT" = "push" ]; then gated=1; fi
-          matrix=0  # test-matrix: pull_request AND code
-          if [ "$EVENT" = "pull_request" ] && [ "$CODE" = "true" ]; then matrix=1; fi
           sem=0     # semver: (pull_request OR push) AND code
           if { [ "$EVENT" = "pull_request" ] || [ "$EVENT" = "push" ]; } && [ "$CODE" = "true" ]; then sem=1; fi
           pub=0     # publish-script: release-tooling OR push
@@ -549,7 +563,11 @@ jobs:
           require deny          '${{ needs.deny.result }}'          "$gated"
           require docs          '${{ needs.docs.result }}'          "$gated"
           require msrv          '${{ needs.msrv.result }}'          "$gated"
-          require test-matrix   '${{ needs.test-matrix.result }}'   "$matrix"
+          # test-matrix now shares the `gated` predicate: it gained the
+          # `|| push` arm so pushes to main seed the rust-cache entry that PRs
+          # restore from. It previously had its own `pull_request AND code`
+          # predicate here.
+          require test-matrix   '${{ needs.test-matrix.result }}'   "$gated"
           require semver        '${{ needs.semver.result }}'        "$sem"
           require publish-script '${{ needs.publish-script.result }}' "$pub"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,12 +157,37 @@ jobs:
 
           # No doc may pin any OTHER mcpkit version — this catches partially
           # bumped files, which the per-file presence check alone would pass.
-          # Allowlisted: files where old versions are intentional (migration
-          # rollback targets, stability policy examples, point-in-time ADRs).
-          STALE=$(grep -rnE "mcpkit(-[a-z]+)? = \"[0-9]" README.md docs/ \
-              --exclude=migration-to-1.0.md \
-              --exclude=api-stability.md \
-              --exclude-dir=adr \
+          #
+          # Exemptions are per line, not per file. This used to pass
+          # --exclude=migration-to-1.0.md --exclude=api-stability.md
+          # --exclude-dir=adr, because each holds legitimately-old versions
+          # (migration paths, post-1.0 contract examples, point-in-time ADRs).
+          # But a whole-file exclusion means one justified pin exempts every
+          # other line in that file forever — so a genuinely stale install
+          # snippet added to any of them would never be caught.
+          #
+          # A pin is exempt only where explicitly marked:
+          #   <!-- version-sync:ok — reason -->    on the line before a fenced
+          #                                        block, exempting that block
+          #   mcpkit = "1"  <!-- version-sync:ok -->   inline, one line
+          # HTML comments render invisibly, so this costs readers nothing and
+          # keeps the justification at the point of use.
+          STALE=$(find README.md docs -name '*.md' -print0 \
+            | xargs -0 awk '
+                /<!-- *version-sync:ok/ {
+                  if ($0 ~ /mcpkit[a-z-]* *= *"/) { next }
+                  pending = 1; next
+                }
+                /^[ \t]*```/ {
+                  if (in_block) { in_block = 0; exempt = 0 }
+                  else { in_block = 1; exempt = pending; pending = 0 }
+                  next
+                }
+                /mcpkit(-[a-z]+)? *= *"[0-9]/ {
+                  if (in_block && exempt) next
+                  print FILENAME ":" FNR ":" $0
+                }
+              ' \
             | grep -vE "mcpkit(-[a-z]+)? = \"$MAJOR_MINOR\"" || true)
           if [ -n "$STALE" ]; then
             echo "ERROR: stale mcpkit version references (expected $MAJOR_MINOR):"

--- a/.github/workflows/cross-platform.yml
+++ b/.github/workflows/cross-platform.yml
@@ -1,0 +1,58 @@
+name: Cross-platform
+
+# macOS coverage, on a schedule instead of on every pull request.
+#
+# It ran in ci.yml's `test-matrix` until 2026-07-27, costing 6m16s on every PR.
+# Across the 40 CI runs sampled at the time it had failed zero times, while the
+# Windows leg — which stays on the PR path — had caught one real break
+# (4ae4f9f, a cfg(unix) type referenced from an ungated test).
+#
+# The trade: a macOS-only regression is now caught within a week, or on demand
+# before a release, rather than within 6 minutes of opening a PR. Given the
+# measured hit rate that is a good trade; if macOS starts failing here, move it
+# back onto the PR path rather than leaving this note stale.
+#
+# Windows is included here too as a belt-and-braces run against the cache-cold
+# path — ci.yml only exercises it warm once main has seeded a cache entry.
+
+on:
+  schedule:
+    # Mondays 06:00 UTC, ahead of the weekly link check so a red week surfaces
+    # in one sitting.
+    - cron: '0 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@1.96
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Scheduled runs are on main, so this both restores and seeds the
+          # shared entry rather than writing a scope nothing can read.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      # --features full rather than --all-features excludes regenerate-proto
+      # (protobuf-src fails on Windows with abseil-cpp linker errors).
+      - run: cargo test -p mcpkit-transport --features full
+      # --all-features is safe here: regenerate-proto is only reachable through
+      # mcpkit-transport, which is excluded, so the rest of the workspace still
+      # gets its feature-gated code exercised cross-platform.
+      - run: cargo test --workspace --exclude mcpkit-transport --all-features
+      - name: Remove trybuild scratch before cache save
+        if: always()
+        shell: bash
+        run: rm -rf target/tests

--- a/Justfile
+++ b/Justfile
@@ -1013,12 +1013,12 @@ version-sync:
     fi
     printf '{{green}}[OK]{{reset}}   Version sync passed (v%s)\n' "$MAJOR_MINOR"
 
-[group('ci')]
-[doc("Standard CI pipeline (matches GitHub Actions)")]
 # cross-check runs early and cheaply (~32s cold, ~3s warm) so a Windows-only
 # compile break is caught here instead of 13 minutes into a CI run. It is the
 # only cross-platform coverage available locally — see the recipe for why msvc
 # and apple-darwin cannot work on a Linux box.
+[group('ci')]
+[doc("Standard CI pipeline (matches GitHub Actions)")]
 ci: fmt-check clippy cross-check test-locked doc-check link-check version-sync
     #!/usr/bin/env bash
     printf '\n{{bold}}{{blue}}══════ CI Pipeline Complete ══════{{reset}}\n\n'

--- a/Justfile
+++ b/Justfile
@@ -273,44 +273,47 @@ rebuild: clean build
 [doc("Cross-platform compilation check (per RELEASING.md Platform Notes)")]
 cross-check:
     #!/usr/bin/env bash
+    set -euo pipefail
     printf '\n{{bold}}{{blue}}══════ Cross-Platform Check ══════{{reset}}\n\n'
 
-    # Check native platform
     printf '{{cyan}}[INFO]{{reset}} Checking native platform ({{platform}})...\n'
-    {{cargo}} check --workspace --all-features
+    {{cargo}} check --workspace --all-features --all-targets
 
-    # Check Linux target (if not already on Linux)
-    if [ "{{platform}}" != "linux" ]; then
-        printf '{{cyan}}[INFO]{{reset}} Checking x86_64-unknown-linux-gnu...\n'
-        if rustup target list --installed | grep -q "x86_64-unknown-linux-gnu"; then
-            {{cargo}} check --workspace --all-features --target x86_64-unknown-linux-gnu
-        else
-            printf '{{yellow}}[WARN]{{reset}} Target not installed: rustup target add x86_64-unknown-linux-gnu\n'
-        fi
-    fi
-
-    # Check macOS target (if not already on macOS)
-    if [ "{{platform}}" != "macos" ]; then
-        printf '{{cyan}}[INFO]{{reset}} Checking x86_64-apple-darwin...\n'
-        if rustup target list --installed | grep -q "x86_64-apple-darwin"; then
-            {{cargo}} check --workspace --all-features --target x86_64-apple-darwin
-        else
-            printf '{{yellow}}[WARN]{{reset}} Target not installed (requires macOS SDK or cross)\n'
-        fi
-    fi
-
-    # Check Windows target (if not already on Windows)
+    # Windows, for real. This is the only cross target that works at full scope
+    # on a Linux box, and it is worth ~13 minutes of CI wait.
+    #
+    # Why gnu and not msvc: `cargo check` needs no linker for pure Rust, so a
+    # single crate checks fine against msvc or apple-darwin. At --all-features
+    # --all-targets the workspace pulls in C build scripts (ring, zstd-sys) that
+    # DO need a C cross-compiler for the target. mingw-w64 supplies one for
+    # x86_64-pc-windows-gnu; nothing here supplies one for msvc or darwin, and
+    # both fail on those build scripts. macOS additionally needs an SDK that
+    # Apple's licence ties to Apple hardware.
+    #
+    # Scope mirrors the Windows job: mcpkit-transport is excluded because its
+    # regenerate-proto feature fails on Windows (abseil-cpp linker errors).
+    #
+    # --all-targets matters. The only Windows failure in this repo's history
+    # (4ae4f9f) was a cfg(unix) type referenced from an ungated *test*, which a
+    # lib-only check would miss entirely.
+    #
+    # This CHECKS, it does not RUN. Running needs real Windows: Wine could not
+    # load the test binaries (missing bcryptprimitives.dll, no display driver).
     if [ "{{platform}}" != "windows" ]; then
-        printf '{{cyan}}[INFO]{{reset}} Checking x86_64-pc-windows-msvc...\n'
-        if rustup target list --installed | grep -q "x86_64-pc-windows-msvc"; then
-            {{cargo}} check --workspace --all-features --target x86_64-pc-windows-msvc
-        else
-            printf '{{yellow}}[WARN]{{reset}} Target not installed (requires Windows SDK or cross)\n'
+        printf '{{cyan}}[INFO]{{reset}} Checking x86_64-pc-windows-gnu (workspace, all targets)...\n'
+        if ! rustup target list --installed | grep -q "x86_64-pc-windows-gnu"; then
+            printf '{{red}}[ERR]{{reset}}  Target missing. Run: rustup target add x86_64-pc-windows-gnu\n'
+            exit 1
         fi
+        if ! command -v x86_64-w64-mingw32-gcc >/dev/null; then
+            printf '{{red}}[ERR]{{reset}}  mingw-w64 missing. Install it (Debian: apt install mingw-w64)\n'
+            exit 1
+        fi
+        {{cargo}} check --target x86_64-pc-windows-gnu \
+            --workspace --exclude mcpkit-transport --all-features --all-targets
     fi
 
     printf '{{green}}[OK]{{reset}}   Cross-platform check complete\n'
-    printf '{{cyan}}[INFO]{{reset}} For full cross-compilation, install cross: cargo install cross\n'
 
 # ============================================================================
 # TESTING RECIPES
@@ -1012,7 +1015,11 @@ version-sync:
 
 [group('ci')]
 [doc("Standard CI pipeline (matches GitHub Actions)")]
-ci: fmt-check clippy test-locked doc-check link-check version-sync
+# cross-check runs early and cheaply (~32s cold, ~3s warm) so a Windows-only
+# compile break is caught here instead of 13 minutes into a CI run. It is the
+# only cross-platform coverage available locally — see the recipe for why msvc
+# and apple-darwin cannot work on a Linux box.
+ci: fmt-check clippy cross-check test-locked doc-check link-check version-sync
     #!/usr/bin/env bash
     printf '\n{{bold}}{{blue}}══════ CI Pipeline Complete ══════{{reset}}\n\n'
     printf '{{green}}[OK]{{reset}}   All CI checks passed\n'

--- a/docs/adr/0004-runtime-agnostic-design.md
+++ b/docs/adr/0004-runtime-agnostic-design.md
@@ -97,6 +97,7 @@ pub trait Transport: Send + Sync {
 ### Example Usage
 
 **With Tokio (default):**
+<!-- version-sync:ok — point-in-time architectural record; frozen at the version it was written against -->
 ```toml
 [dependencies]
 mcpkit-transport = "0.5"  # tokio-runtime is default

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -257,6 +257,7 @@ Security fixes take precedence over API stability. We follow responsible disclos
 
 These updates are safe and won't break your code:
 
+<!-- version-sync:ok — illustrates the post-1.0 semver contract, not a current install snippet -->
 ```toml
 # Any 1.x.y version is compatible with 1.0.0
 mcpkit = "1"
@@ -269,6 +270,7 @@ mcpkit = "1.0"
 
 If we release 2.0.0 with breaking changes:
 
+<!-- version-sync:ok — illustrates the post-1.0 semver contract, not a current install snippet -->
 ```toml
 # This pins to 1.x and won't get 2.0 changes
 mcpkit = "1"

--- a/docs/migration-to-1.0.md
+++ b/docs/migration-to-1.0.md
@@ -46,6 +46,7 @@ See [API Stability](api-stability.md) for the complete tier definitions.
 
 Update the dependency:
 
+<!-- version-sync:ok — documents the 0.x -> 1.0 migration; the versions here are the path, not an install snippet -->
 ```toml
 # Before
 mcpkit = "0.6"
@@ -73,6 +74,7 @@ point at every site. If you only use the builders, there is nothing to do.
 
 #### Step 1: Update Dependency
 
+<!-- version-sync:ok — documents the 0.x -> 1.0 migration; the versions here are the path, not an install snippet -->
 ```toml
 mcpkit = "1"
 ```
@@ -128,6 +130,7 @@ let caps = ServerCapabilities::new()
 
 #### Step 1: Update Dependency
 
+<!-- version-sync:ok — documents the 0.x -> 1.0 migration; the versions here are the path, not an install snippet -->
 ```toml
 mcpkit = "1"
 ```
@@ -216,7 +219,7 @@ Key changes:
 
 ### Upgrade Process
 
-- [ ] Update `Cargo.toml`: `mcpkit = "1"`
+- [ ] Update `Cargo.toml`: `mcpkit = "1"`  <!-- version-sync:ok -->
 - [ ] Run `cargo build` and fix any compile errors
 - [ ] Address deprecation warnings: `cargo build 2>&1 | grep -i deprecated`
 - [ ] Run test suite: `cargo test`
@@ -255,6 +258,7 @@ If migration causes critical issues, you can roll back to your previous version.
 
 ### Rolling Back to 0.6.x
 
+<!-- version-sync:ok — documents the 0.x -> 1.0 migration; the versions here are the path, not an install snippet -->
 ```toml
 # Revert Cargo.toml
 mcpkit = "0.6"
@@ -268,6 +272,7 @@ cargo build
 
 ### Rolling Back to 0.2.x or Earlier
 
+<!-- version-sync:ok — documents the 0.x -> 1.0 migration; the versions here are the path, not an install snippet -->
 ```toml
 # Revert Cargo.toml
 mcpkit = "0.2"


### PR DESCRIPTION
Four changes aimed at the 13-minute PR wait, each grounded in a measurement rather than a guess.

## The measurements first

Per-check elapsed on PR #189, and which jobs have ever failed across the last 40 CI runs:

| Check | Time | Failures in 40 runs |
|---|---|---|
| Test (windows-latest) | **12m52s** | 1 |
| Test (macos-latest) | 6m16s | **0** |
| Semver Check | 6m6s | 0 |
| Test Suite (ubuntu) | 3m15s | 0 |
| *the other 13 checks* | ≤57s | 8 |

Two jobs consumed 19 minutes per PR and caught one thing between them. That one thing (`4ae4f9f`) was a **compile error** — a `cfg(unix)` type referenced from an ungated test.

## 1 — The Windows job builds cold on every PR

`test-matrix` ran on `pull_request` only. rust-cache can only be restored from the current branch or the base branch, so main never wrote an entry there. Confirmed in the PR #189 log: **`No cache found.`**

It also had no `save-if`, so each PR wrote ~GB entries scoped to its own ref that nothing could restore, competing for the 10 GB limit. Both halves fixed the way `clippy`/`check` already were.

## 2 — macOS off the PR path

Moved to `cross-platform.yml`, weekly + `workflow_dispatch`. Windows stays on PRs — it has caught one real break, one more than macOS. The trade is stated in the workflow: a macOS regression now surfaces within a week or on demand, not within 6 minutes.

`ci-success` updated in step; its own comment warns a stale predicate there re-opens the hole, and `test-matrix`'s `if:` changed.

## 3 — `cross-check` was decoration; now it's a gate

The recipe existed but: no `set -euo pipefail`; printed WARN and continued when a target was missing; **no `--all-targets`**, so it could not have caught `4ae4f9f`; didn't exclude `mcpkit-transport`; and nothing called it.

Now enforced, wired into `ci` (so `pre-push`), scoped to `x86_64-pc-windows-gnu` — the only target that works here. `cargo check` needs no linker for pure Rust, so a single crate checks fine against msvc or apple-darwin, but at `--all-features --all-targets` the workspace pulls in C build scripts (`ring`, `zstd-sys`) needing a C cross-compiler. mingw-w64 supplies one; nothing supplies msvc or darwin, and macOS additionally needs an SDK Apple ties to Apple hardware.

**Verified by breaking it:** re-creating `4ae4f9f`'s shape makes `just cross-check` exit 101; reverting returns 0. **32s cold, 3s warm, vs 12m52s of CI wait.**

It checks, it does not run. Wine could not load the test binaries (missing `bcryptprimitives.dll`, no display driver).

## 4 — version-sync exemptions are per line, not per file

Three files were excluded wholesale because each legitimately pins old versions. One justified pin exempted every other line in that file forever. Now marked at the point of use with `<!-- version-sync:ok — reason -->`, which renders invisibly. Nine markers cover twelve pins; eight of those are forward references (`1`, `1.0`, `2`) describing the 1.0 contract.

Verified both directions: clean with markers, and adding `mcpkit = "0.6"` to `api-stability.md` — previously exempt wholesale — is now flagged at its line.

Scope note: this closes the *pin* gap, not the one I cited as motivation. `migration-to-1.0.md`'s "no migration required" contradiction was prose, which this check doesn't read.

---

Also included: `fix(just)` for a parse error I introduced in commit 3 and initially missed because my verification read adjacent output as a success line instead of checking the exit code.

Local gate green: fmt, cross-check, schema baseline, typos, shellcheck, all three workflows parse.