### PR TITLE
CI audit: a false MSRV claim, a fuzzer discarding its findings, and three gates that couldn't fail

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,14 +1,33 @@
 # cargo-audit configuration
 # https://rustsec.org/
+#
+# KEEP IN SYNC WITH deny.toml's [advisories] ignore list.
+#
+# These two files suppressed advisories independently and had drifted into
+# *disjoint* sets: deny.toml ignored RUSTSEC-2023-0071 and RUSTSEC-2025-0134,
+# this file ignored only RUSTSEC-2024-0436. Neither was a superset, so the real
+# suppression surface was three advisories while each file looked complete.
+#
+# The drift was not cosmetic. Because this file did not carry
+# RUSTSEC-2023-0071, `cargo audit` failed — and so did `just audit`, and
+# therefore `just ci-full` and `just release-check`, which depend on it. That
+# was true before this file was touched; verified by running cargo audit
+# against the previous config.
+#
+# Rationale for each suppression lives in deny.toml, not here — duplicating the
+# written risk assessments is how the two lists drifted in the first place.
+# deny.toml is also the copy CI enforces (the `deny` job); cargo-audit runs only
+# from `just audit`. So: add to deny.toml first, mirror the ID here.
+#
+# Removed 2026-07-27: RUSTSEC-2024-0436 (paste, unmaintained). `paste` is no
+# longer in the dependency tree at all — the workspace resolves `pastey` — so
+# the entry was silencing an advisory for a crate that is not present.
 
 [advisories]
-# Advisories to ignore with documented rationale
 ignore = [
-    # RUSTSEC-2024-0436: paste crate no longer maintained
-    # - Only pulled in through rmcp (dev-dependency for comparison benchmarks)
-    # - Not used in production code paths
-    # - See: https://rustsec.org/advisories/RUSTSEC-2024-0436
-    "RUSTSEC-2024-0436",
+    # Mirrors deny.toml. See there for the full risk assessment of each.
+    "RUSTSEC-2023-0071", # rsa / Marvin timing sidechannel — no fix available
+    "RUSTSEC-2025-0134", # rustls-pemfile unmaintained, via tonic 0.12
 ]
 
 # Treat unmaintained crates as warnings, not errors

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,13 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
+  # Trim debuginfo in CI: measurably faster compiles and much smaller target
+  # dirs, which shrinks every rust-cache entry and compounds the save-if fix.
+  # line-tables-only keeps file/line backtraces; only interactive-debugger
+  # detail is lost, which no CI job uses. Set via env rather than Cargo.toml so
+  # local builds keep full debuginfo.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 # Least-privilege default. Every job inherits read-only unless it declares more;
 # the two jobs that file issues and the one that cuts a release opt in
@@ -325,7 +332,17 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      - run: cargo test --all-features
+      - uses: taiki-e/install-action@nextest
+      # nextest runs each test in its own process: faster, and a panicking test
+      # cannot take others down with it. It does NOT run doctests, so those get
+      # their own step below — without it this job would silently drop 82 tests
+      # (verified: 1387 nextest + 82 doctests = 1469, cargo test's total).
+      #
+      # --locked was missing here while the local `test-locked` recipe had it,
+      # so CI could silently resolve past a drifted lockfile that local runs
+      # would reject. Now CI is the stricter of the two.
+      - run: cargo nextest run --locked --workspace --all-features
+      - run: cargo test --locked --doc --workspace --all-features
       # trybuild spins up a throwaway cargo project under target/tests; remove it
       # so the rust-cache save step doesn't trip over its torn-down scratch dirs
       # (harmless ENOENT annotations otherwise).
@@ -513,7 +530,17 @@ jobs:
       # across runs, so the unchanging published baseline is not rebuilt on every
       # PR (which was ~half the job). It installs the toolchain and checks the
       # whole workspace (skipping `publish = false` crates) by default.
+      # Advisory, not blocking, while the crate is pre-1.0. Breaking changes are
+      # expected here and are recorded in CHANGELOG with migration notes; the
+      # 6-minute wait was the single largest remaining item on the PR critical
+      # path after the macOS move.
+      #
+      # This is a deliberate non-gate, unlike the accidental ones this repo has
+      # been removing: the job still runs and its result is visible, it simply
+      # does not fail the build. Revisit at 1.0, when a breaking change stops
+      # being routine and starts being a major-version event.
       - name: Check semver
+        continue-on-error: true
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           rust-toolchain: "1.96"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,31 @@ jobs:
           mapfile -t scripts < <(git ls-files '*.sh')
           printf 'checking %d script(s)\n' "${#scripts[@]}"
           shellcheck -S warning "${scripts[@]}"
+      # deny.toml and .cargo/audit.toml suppress advisories independently and had
+      # drifted into disjoint sets — deny.toml carried two IDs, audit.toml a
+      # third and different one. That was not cosmetic: because audit.toml
+      # lacked RUSTSEC-2023-0071, `cargo audit` failed, and with it `just audit`,
+      # `just ci-full` and `just release-check`.
+      #
+      # Compares the parsed `ignore` arrays, not raw greps — the IDs also appear
+      # in prose comments, which a naive grep reports as a phantom difference.
+      - name: Advisory ignore lists are in sync
+        run: |
+          set -euo pipefail
+          extract() {
+            python3 -c "
+          import re,sys
+          s = open(sys.argv[1]).read()
+          m = re.search(r'ignore\s*=\s*\[(.*?)\]', s, re.S)
+          print('\n'.join(sorted(re.findall(r'\"(RUSTSEC-[0-9-]+)\"', m.group(1)))) if m else '')
+          " "$1"
+          }
+          if ! diff <(extract deny.toml) <(extract .cargo/audit.toml); then
+            echo "::error::deny.toml and .cargo/audit.toml ignore different advisory sets."
+            echo "Add to deny.toml first (CI enforces it), then mirror the ID in .cargo/audit.toml."
+            exit 1
+          fi
+          echo "Advisory ignore lists match."
 
   version-sync:
     name: Version Sync

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
+# Least-privilege default. Every job inherits read-only unless it declares more;
+# the two jobs that file issues and the one that cuts a release opt in
+# explicitly below. Previously every job ran on the default token scope.
+permissions:
+  contents: read
+
 jobs:
   # ==========================================================================
   # Change detection - lets PRs that touch no Rust/build files skip the heavy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,20 +401,46 @@ jobs:
   # MSRV - Minimum Supported Rust Version
   # ==========================================================================
 
+  # The toolchain is read from Cargo.toml at runtime rather than hardcoded here,
+  # so the declared MSRV and the version verified against it cannot drift apart.
+  #
+  # They had. The job checked `--lib -p mcpkit` only, which passes because the
+  # umbrella crate's dependency closure excludes actix — while mcpkit-actix,
+  # published and inheriting the same rust-version, could not build on the
+  # declared 1.85 at all (actix-http 3.12.1 and time 0.3.47 both require 1.88).
+  # The scope is now the whole workspace, so a crate that cannot meet the
+  # declared floor fails here instead of on a user's machine.
+  #
+  # The old comment blamed wiremock 0.6+ for the narrow scope. That was wrong on
+  # its own terms: wiremock is a dev-dependency, and `cargo check` without
+  # --all-targets never compiles dev-dependencies.
   msrv:
-    name: MSRV (1.85)
+    name: MSRV
     runs-on: ubuntu-latest
     needs: [changes, fmt, clippy, check]
     if: ${{ needs.changes.outputs.code == 'true' || github.event_name == 'push' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@1.85
+      - name: Read declared MSRV from Cargo.toml
+        id: msrv
+        run: |
+          set -euo pipefail
+          V=$(cargo metadata --no-deps --format-version 1 \
+              | jq -r '[.packages[].rust_version] | map(select(. != null)) | unique | .[]')
+          if [ "$(printf '%s\n' "$V" | wc -l)" -ne 1 ]; then
+            echo "::error::crates declare more than one rust-version; this job assumes a single workspace floor:"
+            printf '%s\n' "$V"
+            exit 1
+          fi
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Declared MSRV: $V"
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
       - uses: Swatinem/rust-cache@v2
         with:
           save-if: ${{ github.ref == 'refs/heads/main' }}
-      # Only check library code compiles with MSRV, not tests/dev-dependencies
-      # (wiremock 0.6+ requires Rust 1.87 for let chains)
-      - run: cargo check --all-features --lib -p mcpkit
+      - run: cargo check --workspace --all-features
 
   # ==========================================================================
   # Cross-platform matrix - PRs only, and only when code changed (skip docs PRs)

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -58,8 +58,13 @@ jobs:
         with:
           workspaces: fuzz -> target
 
-      - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+      # Prebuilt binary rather than `cargo install cargo-fuzz`, which compiled
+      # the tool from source at an unpinned version. rust-cache made it a no-op
+      # on a warm cache, so the cost only bit on cold or evicted caches — but
+      # the version was never pinned either way.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
 
       - name: Skip if specific target requested
         if: ${{ github.event.inputs.target != '' && github.event.inputs.target != matrix.target }}
@@ -123,8 +128,13 @@ jobs:
         with:
           workspaces: fuzz -> target
 
-      - name: Install cargo-fuzz
-        run: cargo install cargo-fuzz
+      # Prebuilt binary rather than `cargo install cargo-fuzz`, which compiled
+      # the tool from source at an unpinned version. rust-cache made it a no-op
+      # on a warm cache, so the cost only bit on cold or evicted caches — but
+      # the version was never pinned either way.
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-fuzz
 
       # These were previously a single step running a loop that only echoed
       # "Restoring corpus for $target" — no cache was ever restored. Since

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -26,6 +26,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default. Every job inherits read-only unless it declares more;
+# the two jobs that file issues and the one that cuts a release opt in
+# explicitly below. Previously every job ran on the default token scope.
+permissions:
+  contents: read
+
 jobs:
   fuzz:
     name: Fuzz Testing
@@ -185,6 +191,8 @@ jobs:
 
   notify-on-crash:
     name: Notify on Crash
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     needs: fuzz
     if: failure() && github.event_name == 'schedule'

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -76,7 +76,13 @@ jobs:
           cargo +nightly fuzz run ${{ matrix.target }} -- \
             -max_total_time=${DURATION} \
             -print_final_stats=1
-        continue-on-error: true
+        # NO continue-on-error here. It was the reason this entire pipeline was
+        # dead: a failed step under continue-on-error leaves the JOB green, so
+        # `if: failure()` on the crash-artifact upload below, and on the
+        # notify-on-crash job, never became true. A crash produced a green run,
+        # no artifacts and no issue — the fuzzer ran nightly and its findings
+        # were discarded. `fail-fast: false` on the matrix means one target
+        # crashing still lets the other five finish.
 
       - name: Save fuzz corpus
         uses: actions/cache/save@v5
@@ -114,11 +120,52 @@ jobs:
       - name: Install cargo-fuzz
         run: cargo install cargo-fuzz
 
-      - name: Restore all corpus caches
-        run: |
-          for target in fuzz_jsonrpc_message fuzz_jsonrpc_request fuzz_jsonrpc_response fuzz_progress_token fuzz_jsonrpc_structured fuzz_protocol_version; do
-            echo "Restoring corpus for $target"
-          done
+      # These were previously a single step running a loop that only echoed
+      # "Restoring corpus for $target" — no cache was ever restored. Since
+      # fuzz/corpus/ is gitignored and was in no cache path here, the summary
+      # below then reported "No corpus" for all six targets on every run.
+      - name: Restore corpus (fuzz_jsonrpc_message)
+        uses: actions/cache/restore@v5
+        with:
+          path: fuzz/corpus/fuzz_jsonrpc_message
+          key: fuzz-corpus-fuzz_jsonrpc_message-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-fuzz_jsonrpc_message-
+      - name: Restore corpus (fuzz_jsonrpc_request)
+        uses: actions/cache/restore@v5
+        with:
+          path: fuzz/corpus/fuzz_jsonrpc_request
+          key: fuzz-corpus-fuzz_jsonrpc_request-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-fuzz_jsonrpc_request-
+      - name: Restore corpus (fuzz_jsonrpc_response)
+        uses: actions/cache/restore@v5
+        with:
+          path: fuzz/corpus/fuzz_jsonrpc_response
+          key: fuzz-corpus-fuzz_jsonrpc_response-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-fuzz_jsonrpc_response-
+      - name: Restore corpus (fuzz_progress_token)
+        uses: actions/cache/restore@v5
+        with:
+          path: fuzz/corpus/fuzz_progress_token
+          key: fuzz-corpus-fuzz_progress_token-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-fuzz_progress_token-
+      - name: Restore corpus (fuzz_jsonrpc_structured)
+        uses: actions/cache/restore@v5
+        with:
+          path: fuzz/corpus/fuzz_jsonrpc_structured
+          key: fuzz-corpus-fuzz_jsonrpc_structured-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-fuzz_jsonrpc_structured-
+      - name: Restore corpus (fuzz_protocol_version)
+        uses: actions/cache/restore@v5
+        with:
+          path: fuzz/corpus/fuzz_protocol_version
+          key: fuzz-corpus-fuzz_protocol_version-${{ github.sha }}
+          restore-keys: |
+            fuzz-corpus-fuzz_protocol_version-
 
       - name: Generate coverage report
         working-directory: fuzz

--- a/.github/workflows/proto-check.yml
+++ b/.github/workflows/proto-check.yml
@@ -18,6 +18,12 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default. Every job inherits read-only unless it declares more;
+# the two jobs that file issues and the one that cuts a release opt in
+# explicitly below. Previously every job ran on the default token scope.
+permissions:
+  contents: read
+
 jobs:
   proto-drift:
     name: Proto Drift Check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,12 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+# Least-privilege default. Every job inherits read-only unless it declares more;
+# the two jobs that file issues and the one that cuts a release opt in
+# explicitly below. Previously every job ran on the default token scope.
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate Release

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -29,6 +29,12 @@ env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
 
+# Least-privilege default. Every job inherits read-only unless it declares more;
+# the two jobs that file issues and the one that cuts a release opt in
+# explicitly below. Previously every job ran on the default token scope.
+permissions:
+  contents: read
+
 jobs:
   # ==========================================================================
   # Benchmark Suite - Run all criterion benchmarks
@@ -227,6 +233,8 @@ jobs:
 
   notify-on-failure:
     name: Notify on Failure
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     # stability-test included: it is schedule-only, so without it here a
     # stability failure on the weekly run filed no issue and surfaced nowhere.

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -178,88 +178,18 @@ jobs:
   # Performance Regression Detection
   # ==========================================================================
 
-  regression-check:
-    name: Regression Check
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: dtolnay/rust-toolchain@1.96
-
-      - uses: Swatinem/rust-cache@v2
-
-      - name: Restore baseline from main
-        uses: actions/cache/restore@v5
-        with:
-          path: target/criterion-baseline
-          key: criterion-baseline-${{ runner.os }}
-          restore-keys: |
-            criterion-baseline-
-
-      - name: Run benchmarks on PR
-        run: |
-          # Run benchmarks and save to different directory
-          # Use --benches to skip lib tests which don't understand criterion options
-          cargo bench --package mcpkit-benches --benches -- \
-            --sample-size 50 \
-            --measurement-time 5 \
-            --save-baseline pr-benchmark
-
-      - name: Compare with baseline
-        run: |
-          echo "# Performance Comparison" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          # Check for significant regressions (>10% slower)
-          REGRESSION_FOUND=false
-
-          for bench in serialization tool_invocation transport memory; do
-            baseline_dir="target/criterion-baseline/${bench}"
-            pr_dir="target/criterion/${bench}"
-
-            if [ -d "$baseline_dir" ] && [ -d "$pr_dir" ]; then
-              echo "## ${bench^}" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-
-              # Compare estimates
-              for pr_estimate in $(find "$pr_dir" -name "estimates.json" 2>/dev/null); do
-                group=$(dirname "$pr_estimate" | xargs basename)
-                baseline_estimate="${baseline_dir}/${group}/new/estimates.json"
-
-                if [ -f "$baseline_estimate" ]; then
-                  baseline_mean=$(jq -r '.mean.point_estimate // 0' "$baseline_estimate" 2>/dev/null)
-                  pr_mean=$(jq -r '.mean.point_estimate // 0' "$pr_estimate" 2>/dev/null)
-
-                  if [ "$baseline_mean" != "0" ] && [ "$pr_mean" != "0" ]; then
-                    change=$(echo "scale=2; (($pr_mean - $baseline_mean) / $baseline_mean) * 100" | bc 2>/dev/null || echo "0")
-
-                    if [ "$(echo "$change > 10" | bc)" -eq 1 ]; then
-                      echo "⚠️ **${group}**: +${change}% (regression)" >> $GITHUB_STEP_SUMMARY
-                      REGRESSION_FOUND=true
-                    elif [ "$(echo "$change < -10" | bc)" -eq 1 ]; then
-                      echo "✅ **${group}**: ${change}% (improvement)" >> $GITHUB_STEP_SUMMARY
-                    else
-                      echo "➖ **${group}**: ${change}% (within tolerance)" >> $GITHUB_STEP_SUMMARY
-                    fi
-                  fi
-                fi
-              done
-              echo "" >> $GITHUB_STEP_SUMMARY
-            fi
-          done
-
-          if [ "$REGRESSION_FOUND" = true ]; then
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "⚠️ **Warning:** Significant performance regressions detected (>10% slower)" >> $GITHUB_STEP_SUMMARY
-            echo "Please review the changes and ensure the regression is acceptable." >> $GITHUB_STEP_SUMMARY
-          fi
-
-  # ==========================================================================
-  # Long-Running Stability Test
-  # ==========================================================================
+  # regression-check was removed here. It was gated `if: github.event_name ==
+  # 'pull_request'` while this workflow triggers only on schedule and
+  # workflow_dispatch — deliberately, per the comment above benchmarks: criterion
+  # on shared runners is too noisy to gate a PR on. So the job could never run.
+  #
+  # It would not have worked if resurrected: its restore step declared
+  # target/criterion-baseline while the benchmarks job saves to target/criterion,
+  # so the comparison loop would have read an empty directory and found no
+  # regressions by construction.
+  #
+  # If perf regression gating is wanted, it needs a design that accounts for
+  # shared-runner noise — not a revival of these ~80 lines.
 
   stability-test:
     name: Long-Running Stability
@@ -298,7 +228,9 @@ jobs:
   notify-on-failure:
     name: Notify on Failure
     runs-on: ubuntu-latest
-    needs: [benchmarks, stress-test]
+    # stability-test included: it is schedule-only, so without it here a
+    # stability failure on the weekly run filed no issue and surfaced nowhere.
+    needs: [benchmarks, stress-test, stability-test]
     if: failure() && github.event_name == 'schedule'
     steps:
       - name: Create issue on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **MSRV raised to 1.88** (was 1.85). The previous declaration was not accurate:
+  `mcpkit-actix` is published inheriting the workspace `rust-version`, and its
+  dependency closure (`actix-http` 3.12.1, `time` 0.3.47) has required 1.88
+  since before 0.7.0 shipped — so a user on 1.85 got a resolver error, not a
+  build. CI did not catch it because the MSRV job checked only
+  `--lib -p mcpkit`, whose closure excludes actix.
+
+  The job now reads `rust-version` out of `Cargo.toml` at runtime instead of
+  hardcoding a toolchain, and checks the whole workspace, so the declared floor
+  and the verified floor cannot drift apart again.
+
+  If you are on 1.85–1.87 and using `mcpkit`, `mcpkit-core`, `mcpkit-server`,
+  `mcpkit-client`, `mcpkit-transport`, `mcpkit-macros`, `mcpkit-testing`,
+  `mcpkit-axum`, `mcpkit-rocket` or `mcpkit-warp`, those did build on 1.85 and
+  now declare 1.88. Pin `mcpkit = "=0.7.0"` if you need to stay below 1.88.
+
 ## [0.7.0] - 2026-07-27
 
 ### Spec-conformance audit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This project follows the [Rust Code of Conduct](https://www.rust-lang.org/polici
 
 ### Prerequisites
 
-- Rust 1.85 or later (see [MSRV policy](docs/versioning.md#minimum-supported-rust-version-msrv))
+- Rust 1.88 or later (see [MSRV policy](docs/versioning.md#minimum-supported-rust-version-msrv))
 - Git
 - [Just](https://github.com/casey/just) command runner (recommended)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ members = [
 [workspace.package]
 version = "0.7.0"
 edition = "2024"
-rust-version = "1.85"
+rust-version = "1.88"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/praxiomlabs/mcpkit"
 homepage = "https://github.com/praxiomlabs/mcpkit"

--- a/Justfile
+++ b/Justfile
@@ -591,14 +591,6 @@ semver:
     {{cargo}} semver-checks check-release
     printf '{{green}}[OK]{{reset}}   Semver check passed\n'
 
-[group('security')]
-[doc("Supply chain security audit via cargo-vet")]
-vet:
-    #!/usr/bin/env bash
-    printf '{{cyan}}[INFO]{{reset}} Running supply chain audit...\n'
-    {{cargo}} vet
-    printf '{{green}}[OK]{{reset}}   Supply chain audit passed\n'
-
 [group('lint')]
 [doc("Run all lints (fmt + clippy)")]
 lint: fmt-check clippy

--- a/Justfile
+++ b/Justfile
@@ -372,16 +372,26 @@ test-ignored:
 [doc("Run tests with cargo-nextest (faster, parallel)")]
 nextest:
     #!/usr/bin/env bash
+    set -euo pipefail
     printf '\n{{bold}}{{blue}}══════ Running Tests (nextest) ══════{{reset}}\n\n'
+    # nextest does not run doctests. Without this line the recipe silently runs
+    # 82 fewer tests than `cargo test` (1387 vs 1469) while looking like a full
+    # suite.
     {{cargo}} nextest run --workspace --all-features -j {{jobs}}
+    {{cargo}} test --doc --workspace --all-features
     printf '{{green}}[OK]{{reset}}   All tests passed\n'
 
 [group('test')]
 [doc("Run tests with nextest and locked dependencies")]
 nextest-locked:
     #!/usr/bin/env bash
+    set -euo pipefail
     printf '\n{{bold}}{{blue}}══════ Running Tests (nextest, locked) ══════{{reset}}\n\n'
+    # nextest does not run doctests. Without this line the recipe silently runs
+    # 82 fewer tests than `cargo test` (1387 vs 1469) while looking like a full
+    # suite.
     {{cargo}} nextest run --workspace --all-features --locked -j {{jobs}}
+    {{cargo}} test --doc --workspace --all-features --locked
     printf '{{green}}[OK]{{reset}}   All tests passed (locked)\n'
 
 [group('test')]
@@ -1019,7 +1029,7 @@ version-sync:
 # and apple-darwin cannot work on a Linux box.
 [group('ci')]
 [doc("Standard CI pipeline (matches GitHub Actions)")]
-ci: fmt-check clippy cross-check test-locked doc-check link-check version-sync
+ci: fmt-check clippy cross-check nextest-locked doc-check link-check version-sync
     #!/usr/bin/env bash
     printf '\n{{bold}}{{blue}}══════ CI Pipeline Complete ══════{{reset}}\n\n'
     printf '{{green}}[OK]{{reset}}   All CI checks passed\n'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Crates.io](https://img.shields.io/crates/v/mcpkit.svg)](https://crates.io/crates/mcpkit)
 [![Documentation](https://docs.rs/mcpkit/badge.svg)](https://docs.rs/mcpkit)
 [![License](https://img.shields.io/crates/l/mcpkit.svg)](LICENSE-MIT)
-[![MSRV](https://img.shields.io/badge/MSRV-1.85-blue.svg)](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/)
+[![MSRV](https://img.shields.io/badge/MSRV-1.88-blue.svg)](https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/)
 [![MCP Protocol](https://img.shields.io/badge/MCP-2025--11--25-green.svg)](https://modelcontextprotocol.io/specification/2025-11-25)
 
 A Rust SDK for the Model Context Protocol (MCP) that simplifies server development through a unified `#[mcp_server]` macro.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,7 +2,7 @@
 
 Comprehensive guide for releasing new versions of MCPkit to crates.io.
 
-**Version:** 0.7.0 | **MSRV:** 1.85 | **Edition:** 2024
+**Version:** 0.7.0 | **MSRV:** 1.88 | **Edition:** 2024
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ vendored spec — see the tables for what is checked and how.
 | Requirement | Status | Notes |
 |-------------|--------|-------|
 | API stability commitment | ✅ Complete | [docs/api-stability.md](docs/api-stability.md) |
-| MSRV policy | ✅ Complete | Rust 1.85+ (Edition 2024) |
+| MSRV policy | ✅ Complete | Rust 1.88+ (Edition 2024) |
 | Semver compliance | ✅ Complete | Following cargo guidelines |
 | Migration guide from 0.x | ✅ Complete | [docs/migration-to-1.0.md](docs/migration-to-1.0.md) |
 

--- a/crates/mcpkit-client/src/client.rs
+++ b/crates/mcpkit-client/src/client.rs
@@ -609,10 +609,10 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
         match notification.method.as_ref() {
             "notifications/cancelled" => {
                 // Handle cancellation notifications
-                if let Some(params) = &notification.params {
-                    if let Some(request_id) = params.get("requestId") {
-                        debug!(?request_id, "Server cancelled request");
-                    }
+                if let Some(params) = &notification.params
+                    && let Some(request_id) = params.get("requestId")
+                {
+                    debug!(?request_id, "Server cancelled request");
                 }
             }
             "notifications/progress" => {
@@ -631,11 +631,11 @@ impl<T: Transport + 'static, H: ClientHandler + 'static> Client<T, H> {
                 }
             }
             "notifications/resources/updated" => {
-                if let Some(params) = notification.params {
-                    if let Some(uri) = params.get("uri").and_then(|v| v.as_str()) {
-                        debug!(uri = %uri, "Resource updated");
-                        handler.on_resource_updated(uri.to_string()).await;
-                    }
+                if let Some(params) = notification.params
+                    && let Some(uri) = params.get("uri").and_then(|v| v.as_str())
+                {
+                    debug!(uri = %uri, "Resource updated");
+                    handler.on_resource_updated(uri.to_string()).await;
                 }
             }
             "notifications/resources/list_changed" => {

--- a/crates/mcpkit-core/src/auth/jwt.rs
+++ b/crates/mcpkit-core/src/auth/jwt.rs
@@ -475,19 +475,18 @@ pub fn validate_claims(claims: &TokenClaims, validation: &TokenValidation) -> Re
         .map_or(0, |d| d.as_secs());
 
     // Validate expiration (use saturating arithmetic to prevent overflow)
-    if validation.validate_exp {
-        if let Some(exp) = claims.exp {
-            if now > exp.saturating_add(validation.leeway_seconds) {
-                return Err(JwtError::Expired);
-            }
-        }
+    if validation.validate_exp
+        && let Some(exp) = claims.exp
+        && now > exp.saturating_add(validation.leeway_seconds)
+    {
+        return Err(JwtError::Expired);
     }
 
     // Validate not before (use saturating arithmetic to prevent overflow)
-    if let Some(nbf) = claims.nbf {
-        if now.saturating_add(validation.leeway_seconds) < nbf {
-            return Err(JwtError::NotYetValid);
-        }
+    if let Some(nbf) = claims.nbf
+        && now.saturating_add(validation.leeway_seconds) < nbf
+    {
+        return Err(JwtError::NotYetValid);
     }
 
     // Validate issuer

--- a/crates/mcpkit-core/src/debug/inspector.rs
+++ b/crates/mcpkit-core/src/debug/inspector.rs
@@ -204,21 +204,20 @@ impl MessageInspector {
         let record = MessageRecord::new(direction, message.clone());
 
         // Track pending requests for response time calculation
-        if let Message::Request(ref req) = message {
-            if let Ok(mut pending) = self.pending_requests.write() {
-                pending.insert(req.id.clone(), (Instant::now(), req.method.to_string()));
-            }
+        if let Message::Request(ref req) = message
+            && let Ok(mut pending) = self.pending_requests.write()
+        {
+            pending.insert(req.id.clone(), (Instant::now(), req.method.to_string()));
         }
 
         // Calculate response time for completed requests
-        if let Message::Response(ref res) = message {
-            if let Ok(mut pending) = self.pending_requests.write() {
-                if let Some((start, method)) = pending.remove(&res.id) {
-                    let duration = start.elapsed();
-                    if let Ok(mut times) = self.response_times.write() {
-                        times.entry(method).or_default().push(duration);
-                    }
-                }
+        if let Message::Response(ref res) = message
+            && let Ok(mut pending) = self.pending_requests.write()
+            && let Some((start, method)) = pending.remove(&res.id)
+        {
+            let duration = start.elapsed();
+            if let Ok(mut times) = self.response_times.write() {
+                times.entry(method).or_default().push(duration);
             }
         }
 

--- a/crates/mcpkit-core/src/debug/recorder.rs
+++ b/crates/mcpkit-core/src/debug/recorder.rs
@@ -232,63 +232,63 @@ impl SessionRecorder {
 
     /// Stop recording.
     pub fn stop(&self, reason: Option<String>) {
-        if let Ok(mut state) = self.state.write() {
-            if state.recording {
-                state.events.push(SessionEvent::SessionEnded {
-                    offset: self.started.elapsed(),
-                    reason,
-                });
-                state.recording = false;
-            }
+        if let Ok(mut state) = self.state.write()
+            && state.recording
+        {
+            state.events.push(SessionEvent::SessionEnded {
+                offset: self.started.elapsed(),
+                reason,
+            });
+            state.recording = false;
         }
     }
 
     /// Record a sent message.
     pub fn record_sent(&self, message: Message) {
-        if let Ok(mut state) = self.state.write() {
-            if state.recording {
-                state.events.push(SessionEvent::MessageSent {
-                    offset: self.started.elapsed(),
-                    message,
-                });
-            }
+        if let Ok(mut state) = self.state.write()
+            && state.recording
+        {
+            state.events.push(SessionEvent::MessageSent {
+                offset: self.started.elapsed(),
+                message,
+            });
         }
     }
 
     /// Record a received message.
     pub fn record_received(&self, message: Message) {
-        if let Ok(mut state) = self.state.write() {
-            if state.recording {
-                state.events.push(SessionEvent::MessageReceived {
-                    offset: self.started.elapsed(),
-                    message,
-                });
-            }
+        if let Ok(mut state) = self.state.write()
+            && state.recording
+        {
+            state.events.push(SessionEvent::MessageReceived {
+                offset: self.started.elapsed(),
+                message,
+            });
         }
     }
 
     /// Record an error.
     pub fn record_error(&self, error: impl Into<String>) {
-        if let Ok(mut state) = self.state.write() {
-            if state.recording {
-                state.events.push(SessionEvent::Error {
-                    offset: self.started.elapsed(),
-                    error: error.into(),
-                });
-            }
+        if let Ok(mut state) = self.state.write()
+            && state.recording
+        {
+            state.events.push(SessionEvent::Error {
+                offset: self.started.elapsed(),
+                error: error.into(),
+            });
         }
     }
 
     /// Record a custom event.
     pub fn record_custom(&self, name: impl Into<String>, data: serde_json::Value) {
-        if let Ok(mut state) = self.state.write() {
-            if state.recording {
-                state.events.push(SessionEvent::Custom {
-                    offset: self.started.elapsed(),
-                    name: name.into(),
-                    data,
-                });
-            }
+        if let Ok(mut state) = self.state.write()
+            && state.recording
+        {
+            state.events.push(SessionEvent::Custom {
+                offset: self.started.elapsed(),
+                name: name.into(),
+                data,
+            });
         }
     }
 

--- a/crates/mcpkit-core/src/extension/discovery.rs
+++ b/crates/mcpkit-core/src/extension/discovery.rs
@@ -117,17 +117,16 @@ impl ExtensionQuery {
 
             if let Some(ext) = extension {
                 // Check version if specified
-                if let Some(min_version) = self.min_versions.get(name) {
-                    if let Some(ref actual_version) = ext.version {
-                        if !version_satisfies(actual_version, min_version) {
-                            version_mismatches.push(VersionMismatch {
-                                extension: name.clone(),
-                                required: min_version.clone(),
-                                actual: actual_version.clone(),
-                            });
-                            continue;
-                        }
-                    }
+                if let Some(min_version) = self.min_versions.get(name)
+                    && let Some(ref actual_version) = ext.version
+                    && !version_satisfies(actual_version, min_version)
+                {
+                    version_mismatches.push(VersionMismatch {
+                        extension: name.clone(),
+                        required: min_version.clone(),
+                        actual: actual_version.clone(),
+                    });
+                    continue;
                 }
                 found.insert(name.clone(), ext.clone());
             } else if *requirement == ExtensionRequirement::Required {
@@ -158,17 +157,16 @@ impl ExtensionQuery {
             let extension = registry.as_ref().and_then(|r| r.get(name));
 
             if let Some(ext) = extension {
-                if let Some(min_version) = self.min_versions.get(name) {
-                    if let Some(ref actual_version) = ext.version {
-                        if !version_satisfies(actual_version, min_version) {
-                            version_mismatches.push(VersionMismatch {
-                                extension: name.clone(),
-                                required: min_version.clone(),
-                                actual: actual_version.clone(),
-                            });
-                            continue;
-                        }
-                    }
+                if let Some(min_version) = self.min_versions.get(name)
+                    && let Some(ref actual_version) = ext.version
+                    && !version_satisfies(actual_version, min_version)
+                {
+                    version_mismatches.push(VersionMismatch {
+                        extension: name.clone(),
+                        required: min_version.clone(),
+                        actual: actual_version.clone(),
+                    });
+                    continue;
                 }
                 found.insert(name.clone(), ext.clone());
             } else if *requirement == ExtensionRequirement::Required {

--- a/crates/mcpkit-core/src/tasks.rs
+++ b/crates/mcpkit-core/src/tasks.rs
@@ -671,16 +671,15 @@ impl TaskManager {
 /// it in `_meta`.
 #[must_use]
 pub fn inject_related_task(mut payload: Value, id: &TaskId) -> Value {
-    if let Value::Object(map) = &mut payload {
-        if let Value::Object(meta) = map
+    if let Value::Object(map) = &mut payload
+        && let Value::Object(meta) = map
             .entry("_meta")
             .or_insert_with(|| Value::Object(serde_json::Map::new()))
-        {
-            meta.insert(
-                RELATED_TASK_META_KEY.to_string(),
-                serde_json::json!({ "taskId": id.as_str() }),
-            );
-        }
+    {
+        meta.insert(
+            RELATED_TASK_META_KEY.to_string(),
+            serde_json::json!({ "taskId": id.as_str() }),
+        );
     }
     payload
 }

--- a/crates/mcpkit-macros/src/client.rs
+++ b/crates/mcpkit-macros/src/client.rs
@@ -101,20 +101,20 @@ pub fn expand_mcp_client(attr: TokenStream, item: TokenStream) -> Result<TokenSt
 /// Find and remove a handler method from the impl block.
 fn find_and_remove_handler(impl_block: &mut ItemImpl, handler_name: &str) -> Option<HandlerMethod> {
     for item in &mut impl_block.items {
-        if let ImplItem::Fn(method) = item {
-            if let Some(idx) = find_handler_attr(&method.attrs, handler_name) {
-                // Remove the handler attribute
-                method.attrs.remove(idx);
+        if let ImplItem::Fn(method) = item
+            && let Some(idx) = find_handler_attr(&method.attrs, handler_name)
+        {
+            // Remove the handler attribute
+            method.attrs.remove(idx);
 
-                let is_async = method.sig.asyncness.is_some();
-                let returns_result = is_result_type(&method.sig.output);
+            let is_async = method.sig.asyncness.is_some();
+            let returns_result = is_result_type(&method.sig.output);
 
-                return Some(HandlerMethod {
-                    name: method.sig.ident.clone(),
-                    is_async,
-                    returns_result,
-                });
-            }
+            return Some(HandlerMethod {
+                name: method.sig.ident.clone(),
+                is_async,
+                returns_result,
+            });
         }
     }
     None

--- a/crates/mcpkit-macros/src/codegen.rs
+++ b/crates/mcpkit-macros/src/codegen.rs
@@ -262,10 +262,10 @@ fn type_to_json_schema(ty: &Type) -> TokenStream {
 /// Return the first generic type argument of a path segment (e.g. `T` in
 /// `Option<T>` or `Vec<T>`), if present.
 fn first_type_arg(segment: &syn::PathSegment) -> Option<&Type> {
-    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-        if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-            return Some(inner);
-        }
+    if let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return Some(inner);
     }
     None
 }
@@ -288,14 +288,12 @@ pub fn extract_param(arg: &mut FnArg) -> syn::Result<Option<ToolParam>> {
             let doc = attrs
                 .iter()
                 .filter_map(|attr| {
-                    if attr.path().is_ident("doc") {
-                        if let syn::Meta::NameValue(nv) = &attr.meta {
-                            if let syn::Expr::Lit(lit) = &nv.value {
-                                if let syn::Lit::Str(s) = &lit.lit {
-                                    return Some(s.value().trim().to_string());
-                                }
-                            }
-                        }
+                    if attr.path().is_ident("doc")
+                        && let syn::Meta::NameValue(nv) = &attr.meta
+                        && let syn::Expr::Lit(lit) = &nv.value
+                        && let syn::Lit::Str(s) = &lit.lit
+                    {
+                        return Some(s.value().trim().to_string());
                     }
                     None
                 })
@@ -336,10 +334,10 @@ pub fn extract_param(arg: &mut FnArg) -> syn::Result<Option<ToolParam>> {
 
 /// Check if a type is Option<T>.
 fn is_option_type(ty: &Type) -> bool {
-    if let Type::Path(path) = ty {
-        if let Some(segment) = path.path.segments.last() {
-            return segment.ident == "Option";
-        }
+    if let Type::Path(path) = ty
+        && let Some(segment) = path.path.segments.last()
+    {
+        return segment.ident == "Option";
     }
     false
 }
@@ -348,10 +346,10 @@ fn is_option_type(ty: &Type) -> bool {
 pub fn is_result_type(ret: &ReturnType) -> bool {
     match ret {
         ReturnType::Type(_, ty) => {
-            if let Type::Path(path) = ty.as_ref() {
-                if let Some(segment) = path.path.segments.last() {
-                    return segment.ident == "Result";
-                }
+            if let Type::Path(path) = ty.as_ref()
+                && let Some(segment) = path.path.segments.last()
+            {
+                return segment.ident == "Result";
             }
             false
         }

--- a/crates/mcpkit-macros/src/derive.rs
+++ b/crates/mcpkit-macros/src/derive.rs
@@ -137,14 +137,12 @@ fn extract_doc_comment(attrs: &[syn::Attribute]) -> Option<String> {
     let docs: Vec<String> = attrs
         .iter()
         .filter_map(|attr| {
-            if attr.path().is_ident("doc") {
-                if let syn::Meta::NameValue(nv) = &attr.meta {
-                    if let syn::Expr::Lit(lit) = &nv.value {
-                        if let syn::Lit::Str(s) = &lit.lit {
-                            return Some(s.value().trim().to_string());
-                        }
-                    }
-                }
+            if attr.path().is_ident("doc")
+                && let syn::Meta::NameValue(nv) = &attr.meta
+                && let syn::Expr::Lit(lit) = &nv.value
+                && let syn::Lit::Str(s) = &lit.lit
+            {
+                return Some(s.value().trim().to_string());
             }
             None
         })
@@ -159,26 +157,23 @@ fn extract_doc_comment(attrs: &[syn::Attribute]) -> Option<String> {
 
 /// Check if a type is Option<T>.
 fn is_option_type(ty: &Type) -> bool {
-    if let Type::Path(path) = ty {
-        if let Some(segment) = path.path.segments.last() {
-            return segment.ident == "Option";
-        }
+    if let Type::Path(path) = ty
+        && let Some(segment) = path.path.segments.last()
+    {
+        return segment.ident == "Option";
     }
     false
 }
 
 /// Get the inner type of Option<T>.
 fn get_option_inner_type(ty: &Type) -> Option<&Type> {
-    if let Type::Path(path) = ty {
-        if let Some(segment) = path.path.segments.last() {
-            if segment.ident == "Option" {
-                if let PathArguments::AngleBracketed(args) = &segment.arguments {
-                    if let Some(GenericArgument::Type(inner)) = args.args.first() {
-                        return Some(inner);
-                    }
-                }
-            }
-        }
+    if let Type::Path(path) = ty
+        && let Some(segment) = path.path.segments.last()
+        && segment.ident == "Option"
+        && let PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(GenericArgument::Type(inner)) = args.args.first()
+    {
+        return Some(inner);
     }
     None
 }
@@ -212,18 +207,17 @@ fn type_to_json_schema(ty: &Type) -> TokenStream {
             }
             _ if path_str.starts_with("Vec<") => {
                 // Handle Vec<T>
-                if let Some(segment) = path.path.segments.last() {
-                    if let PathArguments::AngleBracketed(args) = &segment.arguments {
-                        if let Some(GenericArgument::Type(inner)) = args.args.first() {
-                            let inner_schema = type_to_json_schema(inner);
-                            return quote! {
-                                serde_json::json!({
-                                    "type": "array",
-                                    "items": #inner_schema
-                                })
-                            };
-                        }
-                    }
+                if let Some(segment) = path.path.segments.last()
+                    && let PathArguments::AngleBracketed(args) = &segment.arguments
+                    && let Some(GenericArgument::Type(inner)) = args.args.first()
+                {
+                    let inner_schema = type_to_json_schema(inner);
+                    return quote! {
+                        serde_json::json!({
+                            "type": "array",
+                            "items": #inner_schema
+                        })
+                    };
                 }
                 quote!(serde_json::json!({"type": "array"}))
             }

--- a/crates/mcpkit-macros/src/prompt.rs
+++ b/crates/mcpkit-macros/src/prompt.rs
@@ -58,14 +58,14 @@ fn validate_prompt_method(method: &ImplItemFn) -> Result<()> {
     }
 
     // Check that receiver is &self (not &mut self or self)
-    if let Some(receiver) = method.sig.receiver() {
-        if receiver.mutability.is_some() {
-            return Err(Error::new_spanned(
-                receiver,
-                "prompt methods should take &self, not &mut self\n\
+    if let Some(receiver) = method.sig.receiver()
+        && receiver.mutability.is_some()
+    {
+        return Err(Error::new_spanned(
+            receiver,
+            "prompt methods should take &self, not &mut self\n\
                  help: use interior mutability (e.g., Mutex, RwLock) if you need to modify state",
-            ));
-        }
+        ));
     }
 
     Ok(())

--- a/crates/mcpkit-macros/src/resource.rs
+++ b/crates/mcpkit-macros/src/resource.rs
@@ -60,14 +60,14 @@ fn validate_resource_method(method: &ImplItemFn) -> Result<()> {
     }
 
     // Check that receiver is &self (not &mut self or self)
-    if let Some(receiver) = method.sig.receiver() {
-        if receiver.mutability.is_some() {
-            return Err(Error::new_spanned(
-                receiver,
-                "resource methods should take &self, not &mut self\n\
+    if let Some(receiver) = method.sig.receiver()
+        && receiver.mutability.is_some()
+    {
+        return Err(Error::new_spanned(
+            receiver,
+            "resource methods should take &self, not &mut self\n\
                  help: use interior mutability (e.g., Mutex, RwLock) if you need to modify state",
-            ));
-        }
+        ));
     }
 
     Ok(())

--- a/crates/mcpkit-macros/src/server.rs
+++ b/crates/mcpkit-macros/src/server.rs
@@ -216,16 +216,16 @@ fn extract_tool_info(method: &mut ImplItemFn, attrs: ToolAttrs) -> Result<ToolMe
 
     // Validate task_support up front so a typo is a clear compile error rather
     // than a silently dropped attribute.
-    if let Some(ts) = &attrs.task_support {
-        if !matches!(ts.as_str(), "forbidden" | "optional" | "required") {
-            return Err(Error::new_spanned(
-                &method.sig.ident,
-                format!(
-                    "invalid task_support value {ts:?}\n\
+    if let Some(ts) = &attrs.task_support
+        && !matches!(ts.as_str(), "forbidden" | "optional" | "required")
+    {
+        return Err(Error::new_spanned(
+            &method.sig.ident,
+            format!(
+                "invalid task_support value {ts:?}\n\
                      help: expected \"forbidden\", \"optional\", or \"required\""
-                ),
-            ));
-        }
+            ),
+        ));
     }
 
     // Extract parameters (skip &self). `extract_param` also strips the
@@ -420,14 +420,12 @@ fn extract_prompt_param(arg: &FnArg) -> Option<PromptParam> {
             let doc = attrs
                 .iter()
                 .filter_map(|attr| {
-                    if attr.path().is_ident("doc") {
-                        if let syn::Meta::NameValue(nv) = &attr.meta {
-                            if let syn::Expr::Lit(lit) = &nv.value {
-                                if let syn::Lit::Str(s) = &lit.lit {
-                                    return Some(s.value().trim().to_string());
-                                }
-                            }
-                        }
+                    if attr.path().is_ident("doc")
+                        && let syn::Meta::NameValue(nv) = &attr.meta
+                        && let syn::Expr::Lit(lit) = &nv.value
+                        && let syn::Lit::Str(s) = &lit.lit
+                    {
+                        return Some(s.value().trim().to_string());
                     }
                     None
                 })
@@ -452,10 +450,10 @@ fn extract_prompt_param(arg: &FnArg) -> Option<PromptParam> {
 
 /// Check if a type is Option<T>.
 fn is_option_type(ty: &syn::Type) -> bool {
-    if let syn::Type::Path(path) = ty {
-        if let Some(segment) = path.path.segments.last() {
-            return segment.ident == "Option";
-        }
+    if let syn::Type::Path(path) = ty
+        && let Some(segment) = path.path.segments.last()
+    {
+        return segment.ident == "Option";
     }
     false
 }
@@ -463,16 +461,13 @@ fn is_option_type(ty: &syn::Type) -> bool {
 /// Extract the inner type from Option<T>.
 /// Returns the inner type T, or the original type if not an Option.
 fn extract_option_inner_type(ty: &syn::Type) -> syn::Type {
-    if let syn::Type::Path(path) = ty {
-        if let Some(segment) = path.path.segments.last() {
-            if segment.ident == "Option" {
-                if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
-                    if let Some(syn::GenericArgument::Type(inner)) = args.args.first() {
-                        return inner.clone();
-                    }
-                }
-            }
-        }
+    if let syn::Type::Path(path) = ty
+        && let Some(segment) = path.path.segments.last()
+        && segment.ident == "Option"
+        && let syn::PathArguments::AngleBracketed(args) = &segment.arguments
+        && let Some(syn::GenericArgument::Type(inner)) = args.args.first()
+    {
+        return inner.clone();
     }
     // Fallback: return the original type (shouldn't happen if is_option_type returned true)
     ty.clone()

--- a/crates/mcpkit-macros/src/tool.rs
+++ b/crates/mcpkit-macros/src/tool.rs
@@ -58,14 +58,14 @@ fn validate_tool_method(method: &ImplItemFn) -> Result<()> {
     }
 
     // Check that receiver is &self (not &mut self or self)
-    if let Some(receiver) = method.sig.receiver() {
-        if receiver.mutability.is_some() {
-            return Err(Error::new_spanned(
-                receiver,
-                "tool methods should take &self, not &mut self\n\
+    if let Some(receiver) = method.sig.receiver()
+        && receiver.mutability.is_some()
+    {
+        return Err(Error::new_spanned(
+            receiver,
+            "tool methods should take &self, not &mut self\n\
                  help: use interior mutability (e.g., Mutex, RwLock) if you need to modify state",
-            ));
-        }
+        ));
     }
 
     Ok(())

--- a/crates/mcpkit-rocket/README.md
+++ b/crates/mcpkit-rocket/README.md
@@ -27,7 +27,7 @@ fn rocket() -> _ {
 
 ## Requirements
 
-- Rust 1.85+
+- Rust 1.88+
 - Rocket 0.5+
 
 ## License

--- a/crates/mcpkit-server/src/metrics.rs
+++ b/crates/mcpkit-server/src/metrics.rs
@@ -171,11 +171,11 @@ impl ServerMetrics {
 
     fn increment_method_counter(&self, map: &RwLock<HashMap<String, AtomicU64>>, method: &str) {
         // Try to increment existing counter
-        if let Ok(counts) = map.read() {
-            if let Some(counter) = counts.get(method) {
-                counter.fetch_add(1, Ordering::Relaxed);
-                return;
-            }
+        if let Ok(counts) = map.read()
+            && let Some(counter) = counts.get(method)
+        {
+            counter.fetch_add(1, Ordering::Relaxed);
+            return;
         }
 
         // Counter doesn't exist, need to create it
@@ -189,11 +189,11 @@ impl ServerMetrics {
 
     fn add_method_latency(&self, method: &str, latency_us: u64) {
         // Try to add to existing counter
-        if let Ok(latencies) = self.method_latency_us.read() {
-            if let Some(counter) = latencies.get(method) {
-                counter.fetch_add(latency_us, Ordering::Relaxed);
-                return;
-            }
+        if let Ok(latencies) = self.method_latency_us.read()
+            && let Some(counter) = latencies.get(method)
+        {
+            counter.fetch_add(latency_us, Ordering::Relaxed);
+            return;
         }
 
         // Counter doesn't exist, need to create it

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -212,10 +212,10 @@ impl ServerState {
 
     /// Cancel a request by ID.
     pub fn cancel_request(&self, request_id: &str) {
-        if let Ok(cancellations) = self.cancellations.read() {
-            if let Some(token) = cancellations.get(request_id) {
-                token.cancel();
-            }
+        if let Ok(cancellations) = self.cancellations.read()
+            && let Some(token) = cancellations.get(request_id)
+        {
+            token.cancel();
         }
     }
 
@@ -1112,10 +1112,10 @@ where
         self.state.set_protocol_version(negotiated_version);
 
         // Extract client info and capabilities
-        if let Some(caps) = params.get("capabilities") {
-            if let Ok(client_caps) = serde_json::from_value::<ClientCapabilities>(caps.clone()) {
-                self.state.set_client_caps(client_caps);
-            }
+        if let Some(caps) = params.get("capabilities")
+            && let Ok(client_caps) = serde_json::from_value::<ClientCapabilities>(caps.clone())
+        {
+            self.state.set_client_caps(client_caps);
         }
 
         // Build response with negotiated version (serialized to string by serde)
@@ -1188,12 +1188,11 @@ where
         // the unowned id as the defect instead.
         // Not a `let`-chain: chained `let` in `if` is unstable before Rust 1.88
         // and this crate's MSRV is 1.85.
-        if let Some(unowned) = unowned_task {
-            if result.as_ref().err().map(McpError::code)
+        if let Some(unowned) = unowned_task
+            && result.as_ref().err().map(McpError::code)
                 == Some(mcpkit_core::error::codes::METHOD_NOT_FOUND)
-            {
-                return Err(unowned);
-            }
+        {
+            return Err(unowned);
         }
         result
     }
@@ -1411,25 +1410,25 @@ where
             return Ok(serde_json::json!({}));
         }
         let page_size = self.list_page_size;
-        if let Some(handler) = self.tools.as_tool_handler() {
-            if let Some(result) = route_tools(handler, method, params, ctx, page_size).await {
-                return result;
-            }
+        if let Some(handler) = self.tools.as_tool_handler()
+            && let Some(result) = route_tools(handler, method, params, ctx, page_size).await
+        {
+            return result;
         }
-        if let Some(handler) = self.resources.as_resource_handler() {
-            if let Some(result) = route_resources(handler, method, params, ctx, page_size).await {
-                return result;
-            }
+        if let Some(handler) = self.resources.as_resource_handler()
+            && let Some(result) = route_resources(handler, method, params, ctx, page_size).await
+        {
+            return result;
         }
-        if let Some(handler) = self.prompts.as_prompt_handler() {
-            if let Some(result) = route_prompts(handler, method, params, ctx, page_size).await {
-                return result;
-            }
+        if let Some(handler) = self.prompts.as_prompt_handler()
+            && let Some(result) = route_prompts(handler, method, params, ctx, page_size).await
+        {
+            return result;
         }
-        if let Some(handler) = self.tasks.as_task_handler() {
-            if let Some(result) = route_tasks(handler, method, params, ctx).await {
-                return result;
-            }
+        if let Some(handler) = self.tasks.as_task_handler()
+            && let Some(result) = route_tasks(handler, method, params, ctx).await
+        {
+            return result;
         }
         // `logging/setLevel` is handled by the base handler when the `logging`
         // capability is advertised (shared with the HTTP adapters).

--- a/crates/mcpkit-server/src/streams.rs
+++ b/crates/mcpkit-server/src/streams.rs
@@ -301,11 +301,11 @@ impl StreamRegistry {
     }
 
     fn mark_dead(&self, stream_id: u64) {
-        if let Ok(mut inner) = self.inner.lock() {
-            if let Some(slot) = inner.streams.iter_mut().find(|s| s.id == stream_id) {
-                slot.sender = None;
-                slot.died = Some(Instant::now());
-            }
+        if let Ok(mut inner) = self.inner.lock()
+            && let Some(slot) = inner.streams.iter_mut().find(|s| s.id == stream_id)
+        {
+            slot.sender = None;
+            slot.died = Some(Instant::now());
         }
     }
 

--- a/crates/mcpkit-server/src/validation.rs
+++ b/crates/mcpkit-server/src/validation.rs
@@ -159,44 +159,37 @@ impl<H: ToolHandler> ToolHandler for ValidatingToolHandler<H> {
             }
         };
 
-        if self.mode.inputs {
-            if let Some(tool) = &tool {
-                if let Some(errors) =
-                    collect_errors(&tool.input_schema, &Value::Object(args.clone()))
-                {
-                    let message = format!(
-                        "Input does not conform to the tool's inputSchema:\n{}",
-                        errors.join("\n")
-                    );
-                    return Ok(ToolOutput::Success(CallToolResult::error(message)));
-                }
-            }
+        if self.mode.inputs
+            && let Some(tool) = &tool
+            && let Some(errors) = collect_errors(&tool.input_schema, &Value::Object(args.clone()))
+        {
+            let message = format!(
+                "Input does not conform to the tool's inputSchema:\n{}",
+                errors.join("\n")
+            );
+            return Ok(ToolOutput::Success(CallToolResult::error(message)));
         }
 
         let output = self.inner.call_tool(name, args, ctx).await?;
 
-        if self.mode.outputs {
-            if let (Some(tool), ToolOutput::Success(result)) = (&tool, &output) {
-                if let (Some(schema), Some(structured)) =
-                    (&tool.output_schema, &result.structured_content)
-                {
-                    if let Some(errors) = collect_errors(schema, &Value::Object(structured.clone()))
-                    {
-                        tracing::error!(
-                            tool = name,
-                            ?errors,
-                            "tool output violates its declared outputSchema (server bug); \
+        if self.mode.outputs
+            && let (Some(tool), ToolOutput::Success(result)) = (&tool, &output)
+            && let (Some(schema), Some(structured)) =
+                (&tool.output_schema, &result.structured_content)
+            && let Some(errors) = collect_errors(schema, &Value::Object(structured.clone()))
+        {
+            tracing::error!(
+                tool = name,
+                ?errors,
+                "tool output violates its declared outputSchema (server bug); \
                              dropping structuredContent"
-                        );
-                        let message = format!(
-                            "The tool produced structured output that does not conform to its \
+            );
+            let message = format!(
+                "The tool produced structured output that does not conform to its \
                              declared outputSchema:\n{}",
-                            errors.join("\n")
-                        );
-                        return Ok(ToolOutput::Success(CallToolResult::error(message)));
-                    }
-                }
-            }
+                errors.join("\n")
+            );
+            return Ok(ToolOutput::Success(CallToolResult::error(message)));
         }
 
         Ok(output)

--- a/crates/mcpkit-testing/src/scenario.rs
+++ b/crates/mcpkit-testing/src/scenario.rs
@@ -207,11 +207,11 @@ fn get_json_path<'a>(value: &'a serde_json::Value, path: &str) -> Option<&'a ser
             continue;
         }
         // Handle array index
-        if let Some(index_str) = part.strip_prefix('[').and_then(|s| s.strip_suffix(']')) {
-            if let Ok(index) = index_str.parse::<usize>() {
-                current = current.get(index)?;
-                continue;
-            }
+        if let Some(index_str) = part.strip_prefix('[').and_then(|s| s.strip_suffix(']'))
+            && let Ok(index) = index_str.parse::<usize>()
+        {
+            current = current.get(index)?;
+            continue;
         }
         current = current.get(part)?;
     }
@@ -269,13 +269,13 @@ impl NotificationMatcher {
 
     /// Validate a notification against this matcher.
     pub fn validate(&self, notification: &Notification) -> Result<(), String> {
-        if let Some(expected_method) = &self.method {
-            if notification.method.as_ref() != expected_method {
-                return Err(format!(
-                    "Expected notification method '{}', got '{}'",
-                    expected_method, notification.method
-                ));
-            }
+        if let Some(expected_method) = &self.method
+            && notification.method.as_ref() != expected_method
+        {
+            return Err(format!(
+                "Expected notification method '{}', got '{}'",
+                expected_method, notification.method
+            ));
         }
 
         if let Some(custom) = &self.custom {

--- a/crates/mcpkit-transport/src/http/client.rs
+++ b/crates/mcpkit-transport/src/http/client.rs
@@ -204,10 +204,10 @@ impl HttpTransport {
         let status = response.status();
 
         // Check for session ID in response headers
-        if let Some(session_id) = response.headers().get(MCP_SESSION_ID_HEADER) {
-            if let Ok(sid) = session_id.to_str() {
-                self.state.lock().await.session_id = Some(sid.to_string());
-            }
+        if let Some(session_id) = response.headers().get(MCP_SESSION_ID_HEADER)
+            && let Ok(sid) = session_id.to_str()
+        {
+            self.state.lock().await.session_id = Some(sid.to_string());
         }
 
         match status {

--- a/crates/mcpkit-transport/src/middleware/batching.rs
+++ b/crates/mcpkit-transport/src/middleware/batching.rs
@@ -183,10 +183,10 @@ impl BatchBuffer {
         if self.total_bytes >= config.max_batch_bytes {
             return true;
         }
-        if let Some(first) = self.first_queued {
-            if first.elapsed() >= config.flush_interval {
-                return true;
-            }
+        if let Some(first) = self.first_queued
+            && first.elapsed() >= config.flush_interval
+        {
+            return true;
         }
         false
     }

--- a/crates/mcpkit-transport/src/pool/manager.rs
+++ b/crates/mcpkit-transport/src/pool/manager.rs
@@ -228,12 +228,12 @@ where
                 }
 
                 // Check max connection lifetime
-                if let Some(max_lifetime) = self.config.max_connection_lifetime {
-                    if conn.is_expired(max_lifetime) {
-                        self.stats_recycled_lifetime.fetch_add(1, Ordering::Relaxed);
-                        self.stats_closed.fetch_add(1, Ordering::Relaxed);
-                        continue;
-                    }
+                if let Some(max_lifetime) = self.config.max_connection_lifetime
+                    && conn.is_expired(max_lifetime)
+                {
+                    self.stats_recycled_lifetime.fetch_add(1, Ordering::Relaxed);
+                    self.stats_closed.fetch_add(1, Ordering::Relaxed);
+                    continue;
                 }
 
                 conn.touch();
@@ -323,14 +323,14 @@ where
         }
 
         // Check max connection lifetime on release
-        if let Some(max_lifetime) = self.config.max_connection_lifetime {
-            if conn.is_expired(max_lifetime) {
-                self.stats_recycled_lifetime.fetch_add(1, Ordering::Relaxed);
-                self.stats_closed.fetch_add(1, Ordering::Relaxed);
-                // Notify waiters so they can try to create a new connection
-                self.notify.notify(1);
-                return;
-            }
+        if let Some(max_lifetime) = self.config.max_connection_lifetime
+            && conn.is_expired(max_lifetime)
+        {
+            self.stats_recycled_lifetime.fetch_add(1, Ordering::Relaxed);
+            self.stats_closed.fetch_add(1, Ordering::Relaxed);
+            // Notify waiters so they can try to create a new connection
+            self.notify.notify(1);
+            return;
         }
 
         conn.touch();

--- a/crates/mcpkit-warp/README.md
+++ b/crates/mcpkit-warp/README.md
@@ -28,7 +28,7 @@ async fn main() {
 
 ## Requirements
 
-- Rust 1.85+
+- Rust 1.88+
 - Warp 0.3+
 
 ## License

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -7,7 +7,7 @@
 # ============================================================================
 # Stage 1: Build environment
 # ============================================================================
-FROM rust:1.85-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 # Install required build dependencies
 RUN apt-get update && apt-get install -y \

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -105,7 +105,7 @@ Based on [Rust API Guidelines](https://rust-lang.github.io/api-guidelines/) and 
 
 Minimum Supported Rust Version policy:
 
-- **Current MSRV**: Rust 1.85 (Edition 2024)
+- **Current MSRV**: Rust 1.88 (Edition 2024)
 - **MSRV increases**: Treated as minor version changes
 - **Support window**: 4 most recent stable Rust versions
 - **CI verification**: MSRV is tested on every commit

--- a/docs/client-guide.md
+++ b/docs/client-guide.md
@@ -4,7 +4,7 @@ This guide walks you through building MCP clients using the Rust MCP SDK. MCP cl
 
 ## Prerequisites
 
-- Rust 1.85 or later
+- Rust 1.88 or later
 - Basic familiarity with async Rust (Tokio)
 - An MCP server to connect to (or use the examples in this repository)
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@ This guide walks you through creating your first MCP server using the Rust MCP S
 
 ## Prerequisites
 
-- Rust 1.85 or later (see [MSRV policy](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/))
+- Rust 1.88 or later (see [MSRV policy](https://blog.rust-lang.org/2025/02/20/Rust-1.85.0/))
 - Basic familiarity with async Rust (Tokio)
 
 ## Installation

--- a/docs/migration-to-1.0.md
+++ b/docs/migration-to-1.0.md
@@ -137,10 +137,10 @@ mcpkit = "1"
 
 #### Step 2: Update MSRV
 
-mcpkit 1.0 requires Rust 1.85+. Update your `rust-version` in `Cargo.toml`:
+mcpkit 1.0 requires Rust 1.88+. Update your `rust-version` in `Cargo.toml`:
 
 ```toml
-rust-version = "1.85"
+rust-version = "1.88"
 ```
 
 #### Step 3: Update ServerCapabilities Pattern
@@ -360,7 +360,7 @@ If you encounter issues during migration:
 
 | mcpkit | MCP Protocol | Rust | Status |
 |--------|--------------|------|--------|
-| 1.0.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Stable |
+| 1.0.x  | 2024-11-05 → 2025-11-25 | 1.88+ | Stable |
 | 0.7.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Current RC |
 | 0.6.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Maintenance |
 | 0.4.x  | 2024-11-05 → 2025-11-25 | 1.85+ | Maintenance |

--- a/docs/performance-baseline.md
+++ b/docs/performance-baseline.md
@@ -5,7 +5,7 @@ Performance benchmarks captured using Criterion on 2025-12-18.
 ## Environment
 
 - **OS**: Linux (WSL2)
-- **Rust**: 1.85+
+- **Rust**: 1.88+
 - **Profile**: Release (`--release`)
 
 ## Request Processing

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -39,7 +39,7 @@ struct MyServer;
 
 **Problem**: Compilation fails with errors about unstable features.
 
-**Solution**: Update to Rust 1.85 or later. Check your version:
+**Solution**: Update to Rust 1.88 or later. Check your version:
 
 ```bash
 rustc --version

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -152,7 +152,7 @@ Note: We follow a "release when ready" philosophy. The 1.0 release will occur wh
 
 ### Minimum Supported Rust Version (MSRV)
 
-The current MSRV is **Rust 1.85**.
+The current MSRV is **Rust 1.88**.
 
 MSRV policy:
 - MSRV increases are treated as minor version bumps

--- a/examples/http-server/Dockerfile
+++ b/examples/http-server/Dockerfile
@@ -9,7 +9,7 @@
 # ============================================================
 # Stage 1: Build
 # ============================================================
-FROM rust:1.85-bookworm AS builder
+FROM rust:1.88-bookworm AS builder
 
 WORKDIR /build
 

--- a/mcpkit/tests/websocket_e2e.rs
+++ b/mcpkit/tests/websocket_e2e.rs
@@ -37,56 +37,55 @@ fn extract_text(msg: WsMessage) -> Option<String> {
 /// Simple WebSocket server that echoes JSON-RPC responses
 async fn spawn_test_server(listener: TcpListener) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        if let Ok((stream, _addr)) = listener.accept().await {
-            if let Ok(ws_stream) = accept_async(stream).await {
-                let (mut tx, mut rx) = ws_stream.split();
+        if let Ok((stream, _addr)) = listener.accept().await
+            && let Ok(ws_stream) = accept_async(stream).await
+        {
+            let (mut tx, mut rx) = ws_stream.split();
 
-                while let Some(Ok(msg)) = rx.next().await {
-                    if let Some(text) = extract_text(msg.clone()) {
-                        // Parse as MCP message
-                        if let Ok(mcp_msg) = serde_json::from_str::<Message>(&text) {
-                            let response = match mcp_msg {
-                                Message::Request(req) => {
-                                    let resp = match req.method.as_ref() {
-                                        "initialize" => Response::success(
-                                            req.id,
-                                            json!({
-                                                "protocolVersion": "2025-11-25",
-                                                "serverInfo": {
-                                                    "name": "test-ws-server",
-                                                    "version": "1.0.0"
-                                                },
-                                                "capabilities": {}
-                                            }),
-                                        ),
-                                        "tools/list" => {
-                                            Response::success(req.id, json!({ "tools": [] }))
-                                        }
-                                        "ping" => Response::success(req.id, json!({})),
-                                        _ => Response::error(
-                                            req.id,
-                                            mcpkit::error::JsonRpcError::method_not_found(
-                                                req.method.to_string(),
-                                            ),
-                                        ),
-                                    };
-                                    Some(Message::Response(resp))
-                                }
-                                Message::Notification(_) => None,
-                                Message::Response(_) => None,
-                            };
-
-                            if let Some(resp) = response {
-                                if let Ok(json) = serde_json::to_string(&resp) {
-                                    if tx.send(ws_text(json)).await.is_err() {
-                                        break;
+            while let Some(Ok(msg)) = rx.next().await {
+                if let Some(text) = extract_text(msg.clone()) {
+                    // Parse as MCP message
+                    if let Ok(mcp_msg) = serde_json::from_str::<Message>(&text) {
+                        let response = match mcp_msg {
+                            Message::Request(req) => {
+                                let resp = match req.method.as_ref() {
+                                    "initialize" => Response::success(
+                                        req.id,
+                                        json!({
+                                            "protocolVersion": "2025-11-25",
+                                            "serverInfo": {
+                                                "name": "test-ws-server",
+                                                "version": "1.0.0"
+                                            },
+                                            "capabilities": {}
+                                        }),
+                                    ),
+                                    "tools/list" => {
+                                        Response::success(req.id, json!({ "tools": [] }))
                                     }
-                                }
+                                    "ping" => Response::success(req.id, json!({})),
+                                    _ => Response::error(
+                                        req.id,
+                                        mcpkit::error::JsonRpcError::method_not_found(
+                                            req.method.to_string(),
+                                        ),
+                                    ),
+                                };
+                                Some(Message::Response(resp))
                             }
+                            Message::Notification(_) => None,
+                            Message::Response(_) => None,
+                        };
+
+                        if let Some(resp) = response
+                            && let Ok(json) = serde_json::to_string(&resp)
+                            && tx.send(ws_text(json)).await.is_err()
+                        {
+                            break;
                         }
-                    } else if let WsMessage::Close(_) = msg {
-                        break;
                     }
+                } else if let WsMessage::Close(_) = msg {
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Works the 2026-07-17 CI report (`~/ci-reports/mcpkit.md`), with every finding re-verified against the current tree rather than inherited — two had already been fixed since it was written.

## The two that mattered

**MSRV was a false claim on a published crate.** `mcpkit-actix` ships declaring `rust-version = "1.85"` and cannot build on 1.85:

```
cargo +1.85 check -p mcpkit-actix --all-features
error: rustc 1.85.1 is not supported by the following packages:
  actix-http@3.12.1 requires rustc 1.88
  time@0.3.47 requires rustc 1.88.0
```

CI passed because the job checked `--lib -p mcpkit` only, whose closure excludes actix — and the comment justifying that narrow scope blamed `wiremock`, a dev-dependency `cargo check` never compiles. Floor raised to 1.88, the job now **reads `rust-version` from Cargo.toml at runtime** so declared and verified cannot drift, and scope widened to the whole workspace. Verified both ways: clean on 1.88 including `--all-targets`; reverting the declaration to 1.85 exits 101.

**The nightly fuzzer was discarding everything it found.** `continue-on-error: true` on the run step keeps the *job* green, so `if: failure()` on the crash-artifact upload and on the issue-filer never fired. Six targets, nightly, findings dropped on the floor. Also in that file: the coverage job's "Restore all corpus caches" was a loop whose body was `echo` — no cache restored, so the summary reported "No corpus" for all six every run.

## Dead and unfailable

- `stress-test.yml`'s `regression-check` was gated on `pull_request` in a workflow with no PR trigger — unreachable, and its restore path (`target/criterion-baseline`) didn't match the save path (`target/criterion`) so it would have compared against an empty directory anyway. Deleted. `notify-on-failure` also didn't `need` the schedule-only `stability-test`, so a stability failure filed nothing.
- **`just vet` asserted "[OK] Supply chain audit passed" while running nothing** — no `supply-chain/` config, cargo-vet not installed, `cargo vet` failing, and the recipe exiting 0 because it has no `set -e` and ends in a printf. Removed.

## Security config that had rotted

`deny.toml` and `.cargo/audit.toml` suppressed **disjoint** advisory sets — two IDs vs a third. Not cosmetic: because audit.toml lacked `RUSTSEC-2023-0071`, `cargo audit` failed, and with it `just audit`, `just ci-full` and `just release-check`. Verified against the pre-change config, so this has been red for a while.

`RUSTSEC-2024-0436` (paste) removed — `paste` isn't in the tree at all any more. A hygiene step now compares the two parsed arrays and fails on mismatch (parsed, not grepped: the IDs appear in prose comments, which produced a phantom diff on my first attempt).

## Speed

| Change | Effect |
|---|---|
| nextest + explicit doctest step | 1387 tests in ~6.5s; doctests separate |
| `--locked` on CI's tests | CI was laxer than local; now stricter |
| `CARGO_PROFILE_{DEV,TEST}_DEBUG=line-tables-only` | ~10% faster compiles, ~39% smaller caches |
| Semver → advisory pre-1.0 | ~6m off the critical path |

nextest **does not run doctests**, and reports 1387 where `cargo test` reports 1469. The 82-test gap is exactly the doctest count — reconciled before the swap, so CI and both Justfile recipes get an explicit `cargo test --doc`. The Justfile's existing `nextest` recipes already had that defect. They also lacked `set -euo pipefail`, so a nextest failure followed by passing doctests exited 0; verified fixed (exit 100 with a deliberately panicking test).

Semver becoming advisory is a *deliberate* non-gate, unlike the accidental ones above — the job still runs and is visible, with a comment to revisit at 1.0.

## Hardening

Least-privilege `permissions: contents: read` across all five workflows that lacked it, with `issues: write` opted in for the two jobs that file issues (a bare baseline would have broken them silently). `cargo install cargo-fuzz` → `taiki-e/install-action`.

---

**Not swept, needs your call:** `just vet` is one instance of a class — **44 shebang recipes run commands without `set -e` and end in a printf**, so their exit code is the printf's. Verified: `just udeps`, `just minimal-versions`, `just geiger` all exit 0 with their tools absent. `just release-check` transitively depends on seven of them (`audit`, `deny`, `semver`, `msrv-check`, `test-features`, `typos`, `machete`) and cannot fail on any. Details in the PR discussion.

Local gate green: fmt, cross-check, schema baseline, typos, shellcheck, machete, cargo audit, nextest+doctests, all workflows parse.