### PR TITLE
fix: transports deadlocked on their own responses; run loop starved its tail

### DIFF
--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -747,6 +747,8 @@ where
         // handler parked on its own server-initiated request (which needs an
         // inbound response to complete) cannot deadlock the loop.
         let mut queued: std::collections::VecDeque<Request> = std::collections::VecDeque::new();
+        // Advanced every iteration; see the select below.
+        let mut rotation: usize = 0;
 
         let outcome = loop {
             // Dispatch queued requests while concurrency slots are free.
@@ -759,32 +761,72 @@ where
 
             // Always receive (so responses to our own outbound requests are
             // routed even when every slot is parked) while making progress on
-            // in-flight requests and background tasks.
-            // Ambient notifications race every other source, so a state change
-            // reaches the client even while the loop is otherwise idle.
-            let recv = std::pin::pin!(self.transport.recv());
-            let published = std::pin::pin!(next_ambient(&mut ambient));
-            let idle = in_flight.is_empty() && background.is_empty() && notifications.is_empty();
-            let step = if idle {
-                match select(recv, published).await {
-                    Either::Left((Ok(opt), _)) => Step::Message(opt),
-                    Either::Left((Err(e), _)) => break Err(e.into()),
-                    Either::Right((notification, _)) => Step::Ambient(notification),
-                }
-            } else {
-                let progress = std::pin::pin!(drive_sets(
-                    &mut in_flight,
-                    &mut background,
-                    &mut notifications
-                ));
-                match select(select(recv, progress), published).await {
-                    Either::Left((Either::Left((Ok(opt), _)), _)) => Step::Message(opt),
-                    Either::Left((Either::Left((Err(e), _)), _)) => break Err(e.into()),
-                    Either::Left((Either::Right((maybe_exec, _)), _)) => {
-                        Step::Progress(maybe_exec.map(Box::new))
+            // in-flight requests and background tasks, and while draining
+            // ambient notifications so a state change reaches the client even
+            // when the loop is otherwise busy.
+            //
+            // `select` polls its left argument first and returns the moment it
+            // is ready, so a source pinned to the right only runs when
+            // everything to its left is pending. All three sources here can be
+            // continuously ready, so a fixed order starves the tail:
+            //
+            // - ambient sat rightmost, so a notification published before the
+            //   loop even started came out behind 200 queued responses;
+            // - `progress` sat right of `recv`, so during an inbound burst
+            //   requests were accepted but none completed until the burst
+            //   drained — every response landed after every request.
+            //
+            // Rotate which source gets first refusal instead. Each is polled
+            // first every third iteration, so none can be starved by the
+            // others.
+            let turn = rotation % 3;
+            rotation = rotation.wrapping_add(1);
+
+            // Scoped so the borrows on the future sets end before the match
+            // below pushes new work into them.
+            let outcome = {
+                let recv_step = std::pin::pin!(async {
+                    match self.transport.recv().await {
+                        Ok(opt) => Ok(Step::Message(opt)),
+                        Err(e) => Err(e.into()),
                     }
-                    Either::Right((notification, _)) => Step::Ambient(notification),
+                });
+                // `drive_sets` parks on every set that is empty, so this is
+                // simply pending when there is no work — no idle special case.
+                let progress_step = std::pin::pin!(async {
+                    let exec =
+                        drive_sets(&mut in_flight, &mut background, &mut notifications).await;
+                    Ok(Step::Progress(exec.map(Box::new)))
+                });
+                let ambient_step =
+                    std::pin::pin!(async { Ok(Step::Ambient(next_ambient(&mut ambient).await)) });
+
+                // Every arm yields the same type, so the nested `Either`
+                // collapses and the three orderings differ only in poll order.
+                match turn {
+                    0 => match select(recv_step, select(progress_step, ambient_step)).await {
+                        Either::Left((step, _))
+                        | Either::Right((Either::Left((step, _)) | Either::Right((step, _)), _)) => {
+                            step
+                        }
+                    },
+                    1 => match select(progress_step, select(ambient_step, recv_step)).await {
+                        Either::Left((step, _))
+                        | Either::Right((Either::Left((step, _)) | Either::Right((step, _)), _)) => {
+                            step
+                        }
+                    },
+                    _ => match select(ambient_step, select(recv_step, progress_step)).await {
+                        Either::Left((step, _))
+                        | Either::Right((Either::Left((step, _)) | Either::Right((step, _)), _)) => {
+                            step
+                        }
+                    },
                 }
+            };
+            let step = match outcome {
+                Ok(step) => step,
+                Err(e) => break Err(e),
             };
 
             // Borrows on the future sets are released here, so we may push work.

--- a/crates/mcpkit-transport/src/runtime.rs
+++ b/crates/mcpkit-transport/src/runtime.rs
@@ -275,6 +275,13 @@ pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
 pub struct BufReader<R> {
     inner: R,
     buffer: BytesMut,
+    /// Bytes of a line seen so far, when it spans more than one read.
+    ///
+    /// This lives here rather than in a local so that dropping a
+    /// `read_line_bytes` future does not take the partial line with it. The
+    /// server run loop cancels reads routinely, and losing a prefix truncates
+    /// the frame and desynchronizes the stream from that point on.
+    partial: BytesMut,
     capacity: usize,
     max_message_size: usize,
 }
@@ -290,6 +297,7 @@ impl<R> BufReader<R> {
         Self {
             inner,
             buffer: BytesMut::with_capacity(capacity),
+            partial: BytesMut::new(),
             capacity,
             max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
         }
@@ -373,15 +381,12 @@ impl<R: AsyncRead + Unpin> BufReader<R> {
     pub async fn read_line_bytes(&mut self) -> io::Result<Bytes> {
         use futures::io::AsyncReadExt;
 
-        // Accumulator for lines that span multiple buffer reads
-        let mut line_buf: Option<BytesMut> = None;
-
         loop {
             // Enforce the maximum message size *during* accumulation so a peer
             // that never sends a newline cannot exhaust memory. Each iteration
             // reads at most `capacity` bytes, so the buffer can overshoot the
             // limit by at most one chunk before this check fires.
-            let accumulated = line_buf.as_ref().map_or(0, BytesMut::len) + self.buffer.len();
+            let accumulated = self.partial.len() + self.buffer.len();
             if accumulated > self.max_message_size {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,
@@ -398,26 +403,25 @@ impl<R: AsyncRead + Unpin> BufReader<R> {
                 let line_with_newline = self.buffer.split_to(newline_pos + 1);
 
                 // If we had accumulated data from previous reads, append to it
-                if let Some(mut accumulated) = line_buf.take() {
-                    accumulated.extend_from_slice(&line_with_newline);
-                    return Ok(accumulated.freeze());
+                if self.partial.is_empty() {
+                    // Otherwise return the line directly (zero-copy path)
+                    return Ok(line_with_newline.freeze());
                 }
-
-                // Otherwise return the line directly (zero-copy path)
-                return Ok(line_with_newline.freeze());
+                let mut accumulated = std::mem::take(&mut self.partial);
+                accumulated.extend_from_slice(&line_with_newline);
+                return Ok(accumulated.freeze());
             }
 
-            // No newline found - save current buffer contents and read more
+            // No newline found - move current buffer contents into the partial
+            // accumulator and read more. `partial` is a field, so a cancelled
+            // read leaves it in place and the next call resumes from it.
             if !self.buffer.is_empty() {
                 let current = self.buffer.split();
-                match &mut line_buf {
-                    Some(accumulated) => accumulated.extend_from_slice(&current),
-                    None => line_buf = Some(current),
-                }
+                self.partial.extend_from_slice(&current);
             }
 
-            // IMPORTANT: Clear buffer state BEFORE the await for cancellation safety.
-            // If cancelled during read, next call sees empty buffer and refills cleanly.
+            // Clear buffer state before the await: everything worth keeping is
+            // already in `partial`, so a cancelled read refills cleanly.
             self.buffer.clear();
             self.buffer.reserve(self.capacity);
 
@@ -431,7 +435,7 @@ impl<R: AsyncRead + Unpin> BufReader<R> {
 
             if n == 0 {
                 // EOF - return any accumulated data
-                return Ok(line_buf.map_or_else(Bytes::new, BytesMut::freeze));
+                return Ok(std::mem::take(&mut self.partial).freeze());
             }
 
             self.buffer.extend_from_slice(&temp_buf[..n]);
@@ -489,6 +493,78 @@ mod tests {
         assert_eq!(n4, 0);
         assert_eq!(eof, "");
         Ok(())
+    }
+
+    /// A line spanning several reads must survive a cancelled `read_line_bytes`.
+    ///
+    /// The test above cannot fail for the property it names — it never cancels
+    /// anything, as its own comment concedes. This one does: the accumulated
+    /// prefix used to live in a local, so dropping the future truncated the
+    /// frame and desynchronized the stream.
+    #[cfg(feature = "tokio-runtime")]
+    #[tokio::test]
+    async fn read_line_bytes_keeps_a_partial_line_across_cancellation() {
+        use futures::io::AsyncRead;
+        use std::pin::Pin;
+        use std::sync::{Arc, Mutex};
+        use std::task::{Context, Poll};
+
+        /// Hands out queued chunks, then pends — so a read can be caught parked.
+        #[derive(Clone)]
+        struct ChunkReader(Arc<Mutex<Vec<Vec<u8>>>>);
+
+        impl AsyncRead for ChunkReader {
+            fn poll_read(
+                self: Pin<&mut Self>,
+                _cx: &mut Context<'_>,
+                buf: &mut [u8],
+            ) -> Poll<io::Result<usize>> {
+                let mut queue = self.0.lock().expect("chunk queue poisoned");
+                if queue.is_empty() {
+                    return Poll::Pending;
+                }
+                let chunk = queue.remove(0);
+                let n = chunk.len().min(buf.len());
+                buf[..n].copy_from_slice(&chunk[..n]);
+                if n < chunk.len() {
+                    queue.insert(0, chunk[n..].to_vec());
+                }
+                Poll::Ready(Ok(n))
+            }
+        }
+
+        let queue = Arc::new(Mutex::new(Vec::new()));
+        // A capacity below the first chunk forces the line to span reads.
+        let mut reader = BufReader::with_capacity(8, ChunkReader(Arc::clone(&queue)));
+
+        queue
+            .lock()
+            .expect("chunk queue poisoned")
+            .push(b"AAAAAAAAAAAAAAAA".to_vec());
+
+        // Poll until the read parks mid-accumulation, then drop it.
+        {
+            let read = reader.read_line_bytes();
+            tokio::pin!(read);
+            assert!(
+                tokio::time::timeout(std::time::Duration::from_millis(100), &mut read)
+                    .await
+                    .is_err(),
+                "the read should still be parked; otherwise nothing is cancelled"
+            );
+        }
+
+        queue
+            .lock()
+            .expect("chunk queue poisoned")
+            .push(b"BBBB\n".to_vec());
+
+        let line = reader.read_line_bytes().await.expect("read after cancel");
+        assert_eq!(
+            String::from_utf8_lossy(&line).trim_end(),
+            "AAAAAAAAAAAAAAAABBBB",
+            "the prefix read before the cancellation was lost"
+        );
     }
 
     /// Test `BufReader` handles partial buffer consumption correctly.

--- a/crates/mcpkit-transport/src/traits.rs
+++ b/crates/mcpkit-transport/src/traits.rs
@@ -100,6 +100,25 @@ impl TransportMetadata {
 /// safely. The send and receive operations should be independent and
 /// can be called from different tasks.
 ///
+/// Two requirements follow from how the server run loop drives a transport,
+/// and both were violated by transports in this crate before they were
+/// written down:
+///
+/// 1. **`send` must not wait on `recv`.** The loop is parked in `recv`
+///    awaiting the client's next message at the moment it needs to write a
+///    response. An implementation that guards both directions with one lock,
+///    held across the read, can never write that response — every session
+///    deadlocks on its first request. Guard each direction separately, or use
+///    a split that takes a shared lock per poll rather than across an await.
+///
+/// 2. **`recv` must be cancel-safe.** The loop races `recv` against other
+///    work and drops the future whenever another arm wins, which is most
+///    iterations. A dropped `recv` must lose neither buffered bytes nor the
+///    reader itself: anything moved out of `self` before the await and
+///    restored after it is gone, and a partially accumulated frame left in a
+///    local is gone with it. Keep both in `self`, and treat a cancelled read
+///    as resumable.
+///
 /// # Example
 ///
 /// Use one of the built-in transports:
@@ -127,6 +146,10 @@ pub trait Transport: Send + Sync {
     ///
     /// Returns `Ok(None)` when the connection is cleanly closed.
     /// Returns `Err` on transport errors.
+    ///
+    /// Must be cancel-safe, and must not block a concurrent [`send`](Self::send).
+    /// See the trait-level "Implementing Transport" notes — the server run loop
+    /// relies on both, and neither is optional.
     ///
     /// # Errors
     ///

--- a/crates/mcpkit-transport/src/unix.rs
+++ b/crates/mcpkit-transport/src/unix.rs
@@ -108,16 +108,27 @@ type UnixReader = BufReader<tokio::net::unix::OwnedReadHalf>;
 #[cfg(feature = "tokio-runtime")]
 type UnixWriter = BufWriter<tokio::net::unix::OwnedWriteHalf>;
 
-/// Internal state for Unix socket transport.
-struct UnixTransportState {
+/// Read side of the Unix socket transport.
+///
+/// Separate from the write side so that `recv`, which holds this lock for as
+/// long as it takes the peer to send a line, cannot block a concurrent `send`.
+/// The two halves are independent (`into_split`), so a single mutex over both
+/// bought nothing and deadlocked any server that answers a request: the run
+/// loop parks in `recv` awaiting the next message while holding the lock the
+/// response write needs.
+struct UnixReadState {
     /// Reader half of the Unix stream.
     #[cfg(feature = "tokio-runtime")]
     reader: Option<UnixReader>,
+    /// Line buffer for reading complete messages.
+    line_buffer: String,
+}
+
+/// Write side of the Unix socket transport. See [`UnixReadState`].
+struct UnixWriteState {
     /// Writer half of the Unix stream.
     #[cfg(feature = "tokio-runtime")]
     writer: Option<UnixWriter>,
-    /// Line buffer for reading complete messages.
-    line_buffer: String,
 }
 
 /// Unix domain socket transport.
@@ -125,7 +136,8 @@ struct UnixTransportState {
 /// Provides low-latency local IPC using Unix domain sockets.
 pub struct UnixTransport {
     config: UnixSocketConfig,
-    state: AsyncMutex<UnixTransportState>,
+    read_state: AsyncMutex<UnixReadState>,
+    write_state: AsyncMutex<UnixWriteState>,
     connected: AtomicBool,
     messages_sent: AtomicU64,
     messages_received: AtomicU64,
@@ -141,10 +153,12 @@ impl UnixTransport {
         let writer = BufWriter::new(write_half);
 
         Self {
-            state: AsyncMutex::new(UnixTransportState {
+            read_state: AsyncMutex::new(UnixReadState {
                 reader: Some(reader),
-                writer: Some(writer),
                 line_buffer: String::with_capacity(4096),
+            }),
+            write_state: AsyncMutex::new(UnixWriteState {
+                writer: Some(writer),
             }),
             config,
             connected: AtomicBool::new(true),
@@ -158,9 +172,10 @@ impl UnixTransport {
     #[cfg(not(feature = "tokio-runtime"))]
     fn new_disconnected(config: UnixSocketConfig, is_server_side: bool) -> Self {
         Self {
-            state: AsyncMutex::new(UnixTransportState {
+            read_state: AsyncMutex::new(UnixReadState {
                 line_buffer: String::with_capacity(4096),
             }),
+            write_state: AsyncMutex::new(UnixWriteState {}),
             config,
             connected: AtomicBool::new(false),
             messages_sent: AtomicU64::new(0),
@@ -263,7 +278,7 @@ impl Transport for UnixTransport {
         data.push(b'\n');
 
         // Write to the socket
-        let mut state = self.state.lock().await;
+        let mut state = self.write_state.lock().await;
         if let Some(writer) = state.writer.as_mut() {
             writer
                 .write_all(&data)
@@ -297,7 +312,7 @@ impl Transport for UnixTransport {
             return Ok(None);
         }
 
-        let mut state = self.state.lock().await;
+        let mut state = self.read_state.lock().await;
 
         // Take the reader temporarily to avoid borrowing issues
         let Some(reader) = state.reader.take() else {
@@ -373,9 +388,8 @@ impl Transport for UnixTransport {
         self.connected.store(false, Ordering::Release);
 
         // Drop the stream parts
-        let mut state = self.state.lock().await;
-        state.reader = None;
-        state.writer = None;
+        self.read_state.lock().await.reader = None;
+        self.write_state.lock().await.writer = None;
 
         // Cleanup socket file if this is server-side and cleanup is enabled
         if self.is_server_side && self.config.cleanup_on_close && self.config.path.exists() {

--- a/crates/mcpkit-transport/src/unix.rs
+++ b/crates/mcpkit-transport/src/unix.rs
@@ -312,33 +312,31 @@ impl Transport for UnixTransport {
             return Ok(None);
         }
 
-        let mut state = self.read_state.lock().await;
+        let mut guard = self.read_state.lock().await;
+        // Borrow the two fields disjointly through one guard. The reader used to
+        // be `take`n out and only restored after the await below; if the future
+        // was dropped while parked there — which the server run loop does on
+        // nearly every iteration — the reader went with it, and every later
+        // `recv` returned `Ok(None)` while `is_connected()` still said true. The
+        // run loop reads that as a clean close and ends the session.
+        let state = &mut *guard;
 
-        // Take the reader temporarily to avoid borrowing issues
-        let Some(reader) = state.reader.take() else {
+        let Some(reader) = state.reader.as_mut() else {
             return Ok(None);
         };
 
         // Clear the buffer and read a line
         state.line_buffer.clear();
 
-        // We need to read into a separate buffer to avoid borrow issues.
         // Bound the read to one byte past the limit so a peer that never sends a
         // newline cannot grow `line_buffer` without bound; the size check below
         // then rejects it. Without this, `read_line` would buffer unboundedly
         // before the post-read check could fire.
         let max = self.config.max_message_size;
-        let (result, reader) = {
-            let mut reader = reader;
-            let result = {
-                let mut limited = (&mut reader).take(max as u64 + 1);
-                limited.read_line(&mut state.line_buffer).await
-            };
-            (result, reader)
+        let result = {
+            let mut limited = (&mut *reader).take(max as u64 + 1);
+            limited.read_line(&mut state.line_buffer).await
         };
-
-        // Put the reader back
-        state.reader = Some(reader);
 
         match result {
             Ok(0) => {

--- a/crates/mcpkit-transport/src/websocket/client.rs
+++ b/crates/mcpkit-transport/src/websocket/client.rs
@@ -14,7 +14,10 @@ use super::config::{ConnectionState, WebSocketConfig};
 
 #[cfg(feature = "websocket")]
 use {
-    futures::{SinkExt, StreamExt},
+    futures::{
+        SinkExt, StreamExt,
+        stream::{SplitSink, SplitStream},
+    },
     tokio::net::TcpStream,
     tokio_tungstenite::{
         MaybeTlsStream, WebSocketStream, connect_async_with_config,
@@ -25,13 +28,25 @@ use {
 /// Internal WebSocket state.
 #[cfg(feature = "websocket")]
 struct WebSocketState {
-    /// The WebSocket stream (split for concurrent read/write).
-    stream: Option<WebSocketStream<MaybeTlsStream<TcpStream>>>,
     /// Queue of received messages.
     message_queue: VecDeque<Message>,
     /// Reconnection attempt counter.
     reconnect_attempt: u32,
 }
+
+/// Write half of the WebSocket, guarded separately from the read half.
+///
+/// Both halves used to sit in one `WebSocketState` mutex. `recv` holds its
+/// guard across `stream.next().await`, which waits for the peer, so a
+/// concurrent `send` could never acquire the lock — a client that receives
+/// while sending deadlocked. `StreamExt::split` gives two independent halves,
+/// so each direction takes only its own lock.
+#[cfg(feature = "websocket")]
+type WsSink = SplitSink<WebSocketStream<MaybeTlsStream<TcpStream>>, WsMessage>;
+
+/// Read half of the WebSocket. See [`WsSink`].
+#[cfg(feature = "websocket")]
+type WsSource = SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>;
 
 #[cfg(not(feature = "websocket"))]
 struct WebSocketState {
@@ -52,6 +67,10 @@ pub struct WebSocketTransport {
     config: WebSocketConfig,
     #[allow(dead_code)] // Used when websocket feature is enabled
     state: AsyncMutex<WebSocketState>,
+    #[cfg(feature = "websocket")]
+    sink: AsyncMutex<Option<WsSink>>,
+    #[cfg(feature = "websocket")]
+    source: AsyncMutex<Option<WsSource>>,
     connected: AtomicBool,
     connection_state: AtomicU32, // ConnectionState as u32
     messages_sent: AtomicU64,
@@ -65,11 +84,13 @@ impl WebSocketTransport {
         Self {
             config,
             state: AsyncMutex::new(WebSocketState {
-                #[cfg(feature = "websocket")]
-                stream: None,
                 message_queue: VecDeque::new(),
                 reconnect_attempt: 0,
             }),
+            #[cfg(feature = "websocket")]
+            sink: AsyncMutex::new(None),
+            #[cfg(feature = "websocket")]
+            source: AsyncMutex::new(None),
             connected: AtomicBool::new(false),
             connection_state: AtomicU32::new(ConnectionState::Disconnected as u32),
             messages_sent: AtomicU64::new(0),
@@ -138,11 +159,12 @@ impl WebSocketTransport {
             message: format!("WebSocket connection failed: {e}"),
         })?;
 
-        // Store the stream
+        // Store the two halves separately so the directions never contend.
         {
-            let mut state = self.state.lock().await;
-            state.stream = Some(ws_stream);
-            state.reconnect_attempt = 0;
+            let (tx, rx) = ws_stream.split();
+            *self.sink.lock().await = Some(tx);
+            *self.source.lock().await = Some(rx);
+            self.state.lock().await.reconnect_attempt = 0;
         }
 
         self.connected.store(true, Ordering::Release);
@@ -229,13 +251,10 @@ impl WebSocketTransport {
             message: format!("Failed to serialize message: {e}"),
         })?;
 
-        let mut state = self.state.lock().await;
-        let stream = state
-            .stream
-            .as_mut()
-            .ok_or_else(|| TransportError::Connection {
-                message: "WebSocket not connected".to_string(),
-            })?;
+        let mut sink = self.sink.lock().await;
+        let stream = sink.as_mut().ok_or_else(|| TransportError::Connection {
+            message: "WebSocket not connected".to_string(),
+        })?;
 
         stream
             .send(WsMessage::Text(json))
@@ -244,7 +263,7 @@ impl WebSocketTransport {
                 message: format!("Failed to send WebSocket message: {e}"),
             })?;
 
-        drop(state);
+        drop(sink);
         self.messages_sent.fetch_add(1, Ordering::Relaxed);
 
         Ok(())
@@ -264,10 +283,11 @@ impl WebSocketTransport {
                 }
             }
 
-            // Try to receive from the stream
+            // Try to receive from the stream. Only the read half is locked, so a
+            // concurrent `send` is free to proceed while this waits on the peer.
             let ws_msg = {
-                let mut state = self.state.lock().await;
-                let Some(stream) = state.stream.as_mut() else {
+                let mut source = self.source.lock().await;
+                let Some(stream) = source.as_mut() else {
                     return Ok(None);
                 };
 
@@ -280,7 +300,7 @@ impl WebSocketTransport {
 
                         // Try to reconnect if auto-reconnect is enabled
                         if self.config.auto_reconnect {
-                            drop(state);
+                            drop(source);
                             if self.reconnect().await.is_ok() {
                                 // Retry receive after reconnection (loop continues)
                                 continue;
@@ -322,8 +342,7 @@ impl WebSocketTransport {
                 }
                 WsMessage::Ping(data) => {
                     // Respond to ping with pong
-                    let mut state = self.state.lock().await;
-                    if let Some(stream) = state.stream.as_mut() {
+                    if let Some(stream) = self.sink.lock().await.as_mut() {
                         let _ = stream.send(WsMessage::Pong(data)).await;
                     }
                     // Continue receiving (loop continues)
@@ -372,14 +391,18 @@ impl WebSocketTransport {
     /// Close the WebSocket connection.
     #[cfg(feature = "websocket")]
     async fn do_close(&self) -> Result<(), TransportError> {
-        let mut state = self.state.lock().await;
-
-        if let Some(stream) = state.stream.as_mut() {
-            // Send close frame
-            let _ = stream.close(None).await;
+        {
+            let mut sink = self.sink.lock().await;
+            if let Some(stream) = sink.as_mut() {
+                // Sends the close frame and drives the closing handshake. The
+                // split sink's `close` takes no frame argument, where
+                // `WebSocketStream::close` accepted an optional one; this call
+                // site always passed `None`, so nothing is lost.
+                let _ = SinkExt::close(stream).await;
+            }
+            *sink = None;
         }
-
-        state.stream = None;
+        *self.source.lock().await = None;
         self.connected.store(false, Ordering::Release);
         self.set_connection_state(ConnectionState::Closed);
 

--- a/crates/mcpkit-transport/src/windows.rs
+++ b/crates/mcpkit-transport/src/windows.rs
@@ -147,13 +147,24 @@ struct NamedPipeState {
 #[cfg(all(windows, feature = "tokio-runtime"))]
 pub struct NamedPipeTransport {
     config: NamedPipeConfig,
-    pipe: AsyncMutex<Option<tokio::net::windows::named_pipe::NamedPipeClient>>,
-    server_pipe: AsyncMutex<Option<tokio::net::windows::named_pipe::NamedPipeServer>>,
+    /// Read half of the pipe.
+    ///
+    /// A named pipe is one bidirectional handle, so it cannot be split the way
+    /// a socket can; `tokio::io::split` supplies halves that take the shared
+    /// lock only for the duration of a single poll, never across a pending
+    /// read. That is the property that matters here: `recv` used to hold the
+    /// pipe mutex across the await that waits for the peer, and `send` needed
+    /// the same mutex, so a transport that answers requests deadlocked.
+    ///
+    /// Boxing erases client from server, which also removed the duplicated
+    /// client/server branch from every I/O site.
+    reader: AsyncMutex<Option<Box<dyn tokio::io::AsyncRead + Send + Unpin>>>,
+    /// Write half of the pipe. See `reader`.
+    writer: AsyncMutex<Option<Box<dyn tokio::io::AsyncWrite + Send + Unpin>>>,
     state: AsyncMutex<NamedPipeState>,
     connected: AtomicBool,
     messages_sent: AtomicU64,
     messages_received: AtomicU64,
-    is_server_side: bool,
 }
 
 #[cfg(all(windows, feature = "tokio-runtime"))]
@@ -163,10 +174,11 @@ impl NamedPipeTransport {
         config: NamedPipeConfig,
         pipe: tokio::net::windows::named_pipe::NamedPipeClient,
     ) -> Self {
+        let (read_half, write_half) = tokio::io::split(pipe);
         Self {
             config,
-            pipe: AsyncMutex::new(Some(pipe)),
-            server_pipe: AsyncMutex::new(None),
+            reader: AsyncMutex::new(Some(Box::new(read_half))),
+            writer: AsyncMutex::new(Some(Box::new(write_half))),
             state: AsyncMutex::new(NamedPipeState {
                 line_buffer: String::with_capacity(4096),
                 read_buffer: Vec::with_capacity(8192),
@@ -174,7 +186,6 @@ impl NamedPipeTransport {
             connected: AtomicBool::new(true),
             messages_sent: AtomicU64::new(0),
             messages_received: AtomicU64::new(0),
-            is_server_side: false,
         }
     }
 
@@ -183,10 +194,11 @@ impl NamedPipeTransport {
         config: NamedPipeConfig,
         pipe: tokio::net::windows::named_pipe::NamedPipeServer,
     ) -> Self {
+        let (read_half, write_half) = tokio::io::split(pipe);
         Self {
             config,
-            pipe: AsyncMutex::new(None),
-            server_pipe: AsyncMutex::new(Some(pipe)),
+            reader: AsyncMutex::new(Some(Box::new(read_half))),
+            writer: AsyncMutex::new(Some(Box::new(write_half))),
             state: AsyncMutex::new(NamedPipeState {
                 line_buffer: String::with_capacity(4096),
                 read_buffer: Vec::with_capacity(8192),
@@ -194,7 +206,6 @@ impl NamedPipeTransport {
             connected: AtomicBool::new(true),
             messages_sent: AtomicU64::new(0),
             messages_received: AtomicU64::new(0),
-            is_server_side: true,
         }
     }
 
@@ -260,39 +271,22 @@ impl NamedPipeTransport {
 
         data.push(b'\n');
 
-        // Write to the appropriate pipe
-        if self.is_server_side {
-            let mut guard = self.server_pipe.lock().await;
-            if let Some(pipe) = guard.as_mut() {
-                pipe.write_all(&data)
-                    .await
-                    .map_err(|e| TransportError::Io {
-                        message: format!("Failed to write to named pipe: {e}"),
-                    })?;
-                pipe.flush().await.map_err(|e| TransportError::Io {
-                    message: format!("Failed to flush named pipe: {e}"),
-                })?;
-            } else {
+        // Write half only, so a concurrent read cannot block this.
+        {
+            let mut guard = self.writer.lock().await;
+            let Some(pipe) = guard.as_mut() else {
                 return Err(TransportError::Connection {
                     message: "Named pipe not available".to_string(),
                 });
-            }
-        } else {
-            let mut guard = self.pipe.lock().await;
-            if let Some(pipe) = guard.as_mut() {
-                pipe.write_all(&data)
-                    .await
-                    .map_err(|e| TransportError::Io {
-                        message: format!("Failed to write to named pipe: {e}"),
-                    })?;
-                pipe.flush().await.map_err(|e| TransportError::Io {
-                    message: format!("Failed to flush named pipe: {e}"),
+            };
+            pipe.write_all(&data)
+                .await
+                .map_err(|e| TransportError::Io {
+                    message: format!("Failed to write to named pipe: {e}"),
                 })?;
-            } else {
-                return Err(TransportError::Connection {
-                    message: "Named pipe not available".to_string(),
-                });
-            }
+            pipe.flush().await.map_err(|e| TransportError::Io {
+                message: format!("Failed to flush named pipe: {e}"),
+            })?;
         }
 
         self.messages_sent.fetch_add(1, Ordering::Relaxed);
@@ -330,43 +324,23 @@ impl NamedPipeTransport {
         // Need to read more data
         let mut temp_buf = [0u8; 4096];
 
-        let bytes_read = if self.is_server_side {
-            let mut guard = self.server_pipe.lock().await;
-            if let Some(pipe) = guard.as_mut() {
-                match pipe.read(&mut temp_buf).await {
-                    Ok(0) => {
-                        self.connected.store(false, Ordering::Release);
-                        return Ok(None);
-                    }
-                    Ok(n) => n,
-                    Err(e) => {
-                        self.connected.store(false, Ordering::Release);
-                        return Err(TransportError::Io {
-                            message: format!("Failed to read from named pipe: {e}"),
-                        });
-                    }
-                }
-            } else {
+        let bytes_read = {
+            let mut guard = self.reader.lock().await;
+            let Some(pipe) = guard.as_mut() else {
                 return Ok(None);
-            }
-        } else {
-            let mut guard = self.pipe.lock().await;
-            if let Some(pipe) = guard.as_mut() {
-                match pipe.read(&mut temp_buf).await {
-                    Ok(0) => {
-                        self.connected.store(false, Ordering::Release);
-                        return Ok(None);
-                    }
-                    Ok(n) => n,
-                    Err(e) => {
-                        self.connected.store(false, Ordering::Release);
-                        return Err(TransportError::Io {
-                            message: format!("Failed to read from named pipe: {e}"),
-                        });
-                    }
+            };
+            match pipe.read(&mut temp_buf).await {
+                Ok(0) => {
+                    self.connected.store(false, Ordering::Release);
+                    return Ok(None);
                 }
-            } else {
-                return Ok(None);
+                Ok(n) => n,
+                Err(e) => {
+                    self.connected.store(false, Ordering::Release);
+                    return Err(TransportError::Io {
+                        message: format!("Failed to read from named pipe: {e}"),
+                    });
+                }
             }
         };
 
@@ -440,13 +414,8 @@ impl Transport for NamedPipeTransport {
         self.connected.store(false, Ordering::Release);
 
         // Drop the pipe handles
-        if self.is_server_side {
-            let mut guard = self.server_pipe.lock().await;
-            *guard = None;
-        } else {
-            let mut guard = self.pipe.lock().await;
-            *guard = None;
-        }
+        *self.reader.lock().await = None;
+        *self.writer.lock().await = None;
 
         Ok(())
     }

--- a/crates/mcpkit-transport/tests/named_pipe_concurrent_io.rs
+++ b/crates/mcpkit-transport/tests/named_pipe_concurrent_io.rs
@@ -1,0 +1,59 @@
+//! `NamedPipeTransport` must support sending while a receive is outstanding.
+//!
+//! A named pipe is a single bidirectional handle, so both directions used to
+//! share one mutex, and `recv` held it across the read that waits for the peer.
+//! `send` needed that same mutex, so a transport that answers requests
+//! deadlocked. `tokio::io::split` takes the shared lock only for the duration
+//! of one poll, never across a pending read.
+//!
+//! Windows-only: the transport does not exist on other platforms.
+
+#![cfg(all(windows, feature = "tokio-runtime"))]
+
+use mcpkit_core::protocol::{Message, Request, RequestId};
+use mcpkit_transport::windows::{NamedPipeServer, NamedPipeTransport};
+use mcpkit_transport::{Transport, TransportListener};
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::test]
+async fn send_completes_while_recv_is_parked() {
+    let name = format!("mcpkit-test-{}", std::process::id());
+    let listener = NamedPipeServer::new(&name).expect("create server");
+
+    let client_name = name.clone();
+    let client = tokio::spawn(async move {
+        // Give the server a moment to post its first pipe instance.
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let t = NamedPipeTransport::connect(client_name)
+            .await
+            .expect("connect");
+        // Stay connected and silent so the server's receive remains parked.
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        drop(t);
+    });
+
+    let server = Arc::new(listener.accept().await.expect("accept"));
+
+    let parked = {
+        let server = Arc::clone(&server);
+        tokio::spawn(async move { server.recv().await })
+    };
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let sent = tokio::time::timeout(
+        Duration::from_secs(5),
+        server.send(Message::Request(Request::new("ping", RequestId::Number(1)))),
+    )
+    .await;
+
+    assert!(
+        sent.is_ok(),
+        "send() blocked while recv() was parked — the read and write halves are \
+         contending on one lock again"
+    );
+    sent.expect("not timed out").expect("send succeeded");
+
+    parked.abort();
+    client.abort();
+}

--- a/crates/mcpkit-transport/tests/unix_concurrent_io.rs
+++ b/crates/mcpkit-transport/tests/unix_concurrent_io.rs
@@ -59,3 +59,50 @@ async fn send_completes_while_recv_is_parked() {
     client.abort();
     let _ = std::fs::remove_file(&path);
 }
+
+#[tokio::test]
+async fn dropping_a_parked_recv_leaves_the_transport_usable() {
+    let path = sock_path("cancel");
+    let _ = std::fs::remove_file(&path);
+    let listener = UnixListener::bind(&path).await.expect("bind");
+
+    let client_path = path.clone();
+    let client = tokio::spawn(async move {
+        let t = UnixTransport::connect(&client_path).await.expect("connect");
+        // Send only after the server has polled and dropped its first `recv`.
+        tokio::time::sleep(Duration::from_millis(300)).await;
+        t.send(Message::Request(Request::new("ping", RequestId::Number(1))))
+            .await
+            .expect("send");
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    });
+
+    let server = listener.accept().await.expect("accept");
+
+    // Poll a receive to the point where it parks, then drop it. The server run
+    // loop does exactly this whenever another arm of its `select` wins.
+    {
+        let recv = server.recv();
+        tokio::pin!(recv);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), &mut recv)
+                .await
+                .is_err(),
+            "recv() should still be parked; the test cannot exercise a drop otherwise"
+        );
+    }
+
+    let received = tokio::time::timeout(Duration::from_secs(5), server.recv())
+        .await
+        .expect("recv() did not return after the earlier one was dropped")
+        .expect("recv() errored");
+
+    assert!(
+        received.is_some(),
+        "recv() returned Ok(None) after a dropped receive — the reader was lost, \
+         and the run loop reads this as a closed connection"
+    );
+
+    client.abort();
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/mcpkit-transport/tests/unix_concurrent_io.rs
+++ b/crates/mcpkit-transport/tests/unix_concurrent_io.rs
@@ -1,0 +1,61 @@
+//! `UnixTransport` must support sending while a receive is outstanding.
+//!
+//! A server run loop is always parked in `recv` awaiting the client's next
+//! message at the moment it needs to write a response. When both directions
+//! shared one mutex, that write could never acquire it and every session
+//! deadlocked on its first request.
+
+#![cfg(all(unix, feature = "tokio-runtime"))]
+
+use mcpkit_core::protocol::{Message, Request, RequestId};
+use mcpkit_transport::{Transport, TransportListener, UnixListener, UnixTransport};
+use std::sync::Arc;
+use std::time::Duration;
+
+/// A socket path unique to this test binary and case.
+fn sock_path(case: &str) -> String {
+    format!("/tmp/mcp-unix-{}-{case}.sock", std::process::id())
+}
+
+#[tokio::test]
+async fn send_completes_while_recv_is_parked() {
+    let path = sock_path("concurrent");
+    let _ = std::fs::remove_file(&path);
+    let listener = UnixListener::bind(&path).await.expect("bind");
+
+    let client_path = path.clone();
+    let client = tokio::spawn(async move {
+        let t = UnixTransport::connect(&client_path).await.expect("connect");
+        // Hold the connection open without sending, so the server's `recv`
+        // stays parked for the duration of the test.
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        drop(t);
+    });
+
+    let server = Arc::new(listener.accept().await.expect("accept"));
+
+    // Park a receive. No data is coming, so it remains pending.
+    let parked = {
+        let server = Arc::clone(&server);
+        tokio::spawn(async move { server.recv().await })
+    };
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // The write must not wait on the reader.
+    let sent = tokio::time::timeout(
+        Duration::from_secs(5),
+        server.send(Message::Request(Request::new("ping", RequestId::Number(1)))),
+    )
+    .await;
+
+    assert!(
+        sent.is_ok(),
+        "send() blocked while recv() was parked — the read and write halves are \
+         contending on one lock again"
+    );
+    sent.expect("not timed out").expect("send succeeded");
+
+    parked.abort();
+    client.abort();
+    let _ = std::fs::remove_file(&path);
+}

--- a/crates/mcpkit-transport/tests/websocket_concurrent_io.rs
+++ b/crates/mcpkit-transport/tests/websocket_concurrent_io.rs
@@ -1,0 +1,59 @@
+//! `WebSocketTransport` must support sending while a receive is outstanding.
+//!
+//! Both directions used to share one mutex, and `recv` holds its guard across
+//! the await that waits for the peer. Any client that sends while a receive is
+//! in flight — the normal shape of a request/response client — deadlocked.
+
+#![cfg(feature = "websocket")]
+
+use futures::StreamExt;
+use mcpkit_core::protocol::{Message, Request, RequestId};
+use mcpkit_transport::websocket::WebSocketConfig;
+use mcpkit_transport::{Transport, WebSocketTransport};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+
+#[tokio::test]
+async fn send_completes_while_recv_is_parked() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+
+    // Accept, then stay silent so the client's receive stays parked.
+    let server = tokio::spawn(async move {
+        if let Ok((stream, _)) = listener.accept().await
+            && let Ok(ws) = tokio_tungstenite::accept_async(stream).await
+        {
+            let (_tx, mut rx) = ws.split();
+            while let Some(Ok(_)) = rx.next().await {}
+        }
+    });
+
+    let transport = Arc::new(
+        WebSocketTransport::connect(WebSocketConfig::new(format!("ws://{addr}/mcp")))
+            .await
+            .expect("connect"),
+    );
+
+    let parked = {
+        let transport = Arc::clone(&transport);
+        tokio::spawn(async move { transport.recv().await })
+    };
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let sent = tokio::time::timeout(
+        Duration::from_secs(5),
+        transport.send(Message::Request(Request::new("ping", RequestId::Number(1)))),
+    )
+    .await;
+
+    assert!(
+        sent.is_ok(),
+        "send() blocked while recv() was parked — the read and write halves are \
+         contending on one lock again"
+    );
+    sent.expect("not timed out").expect("send succeeded");
+
+    parked.abort();
+    server.abort();
+}

--- a/mcpkit/tests/run_loop_fairness.rs
+++ b/mcpkit/tests/run_loop_fairness.rs
@@ -1,0 +1,104 @@
+//! Neither the inbound stream nor the ambient notification queue may starve
+//! the other in `ServerRuntime::run`.
+//!
+//! `futures::future::select` polls its left argument first and returns as soon
+//! as it is ready, so a source that always sits on the right only runs when
+//! every source to its left is pending. Ambient notifications sat there, and a
+//! client with a backlog pushed them behind the whole backlog.
+
+use mcpkit_core::protocol::{Message, Notification, Request, RequestId};
+use mcpkit_server::{ServerBuilder, ServerHandler, ServerRuntime};
+use mcpkit_transport::{MemoryTransport, Transport};
+use std::time::Duration;
+use tokio::time::timeout;
+
+struct Bare;
+impl ServerHandler for Bare {
+    fn server_info(&self) -> mcpkit_core::capability::ServerInfo {
+        mcpkit_core::capability::ServerInfo::new("fairness", "1.0.0")
+    }
+}
+
+const FLOOD: usize = 200;
+
+/// Set up a server with `FLOOD` requests already queued and `ambient`
+/// notifications published before the loop starts, then report the index at
+/// which each kind of message came back.
+async fn drain(ambient: usize) -> (Vec<usize>, Vec<usize>) {
+    let (client, server) = MemoryTransport::pair_with_capacity(FLOOD + 8);
+    let built = ServerBuilder::new(Bare).build();
+    let runtime = ServerRuntime::new(built, server);
+
+    for _ in 0..ambient {
+        runtime
+            .state()
+            .publish_notification(Notification::new("notifications/probe"));
+    }
+    for i in 0..FLOOD {
+        client
+            .send(Message::Request(Request::new(
+                "ping",
+                RequestId::Number(i as u64),
+            )))
+            .await
+            .expect("preload");
+    }
+
+    tokio::spawn(async move {
+        let _ = runtime.run().await;
+    });
+
+    let (mut notes, mut responses) = (Vec::new(), Vec::new());
+    for i in 0..(FLOOD + ambient) {
+        let Ok(Ok(Some(msg))) = timeout(Duration::from_secs(10), client.recv()).await else {
+            break;
+        };
+        match msg {
+            Message::Notification(_) => notes.push(i),
+            Message::Response(_) => responses.push(i),
+            Message::Request(_) => {}
+        }
+    }
+    (notes, responses)
+}
+
+#[tokio::test]
+async fn an_ambient_notification_is_not_starved_by_queued_requests() {
+    let (notes, responses) = drain(1).await;
+
+    assert_eq!(
+        responses.len(),
+        FLOOD,
+        "every request must still be answered"
+    );
+    assert_eq!(notes.len(), 1, "the notification must be delivered");
+    // Alternating gives the notification first refusal on every other
+    // iteration, so it cannot land behind more than a couple of responses.
+    assert!(
+        notes[0] < 4,
+        "notification came out at index {} of {}; it is starving behind the \
+         inbound backlog again",
+        notes[0],
+        FLOOD
+    );
+}
+
+#[tokio::test]
+async fn queued_requests_are_not_starved_by_ambient_notifications() {
+    // The inverse failure: giving ambient absolute priority instead of
+    // alternating would push every response behind every notification.
+    let (notes, responses) = drain(FLOOD).await;
+
+    assert_eq!(
+        responses.len(),
+        FLOOD,
+        "every request must still be answered"
+    );
+    assert_eq!(notes.len(), FLOOD, "every notification must be delivered");
+    assert!(
+        responses[0] < 4,
+        "first response came out at index {}; requests are starving behind the \
+         notification queue",
+        responses[0]
+    );
+}


### PR DESCRIPTION
Investigating **D.1** (normalize the server run loop) turned up four measured
defects rather than the tidiness item it was filed as. This fixes all of them.
Every claim below was measured on Linux, before and after.

## What was wrong

| # | Defect | Before | After |
|---|---|---|---|
| 1 | `UnixTransport` deadlocks | ServerRuntime answered **0 of 5** pings, `run()` never returned | 5/5 |
| 2 | Dropping a polled `recv()` bricks the Unix transport | `Ok(None)` forever, `is_connected()` still `true` | recovers |
| 3 | `WebSocketTransport` deadlocks the same way | `send()` blocked until timeout | completes |
| 4 | stdio loses the prefix of a multi-read line | `AAAA…AAAA` + `BBBB\n` came back as `"BBBB"` | full line |
| 5 | Run loop starves its lowest-priority source | notification queued *before* the loop delivered at index **200/200** | index 0–1 |

**The generator.** 1–4 are one contract gap: `Transport::recv` never documented
that it must be cancel-safe and must not block a concurrent `send`, but the run
loop requires both — it re-creates and drops `recv` on nearly every iteration,
and is parked in `recv` at the moment it needs to write a response. Every impl
was written as if `recv` runs to completion. The contract is now on the trait,
which matters because it is public and third parties implement it.

## Fixes

- **Unix** — `recv` held `state` across the read that waits for the peer and
  `send` needed the same lock. The halves come from `into_split` and are
  already independent, so one mutex over both bought nothing: split it. `recv`
  also took the reader out and restored it only after the await; both fields
  now live in the read state and are borrowed disjointly.
- **WebSocket** — same shape. The struct comment already claimed the stream was
  "split for concurrent read/write"; it was not. `StreamExt::split` makes it so.
- **Named pipes** — same shape, and a pipe is one bidirectional handle that
  cannot be split like a socket. `tokio::io::split` takes the shared lock per
  poll rather than across a pending read, which is the property that matters.
- **stdio** — `read_line_bytes` accumulated a multi-read line into a *local*.
  Moved into the reader as `partial`.
- **Run loop** — rotate first refusal between `recv`, `progress` and ambient
  instead of a fixed order.

## Two corrections to ADR 0006

- Its sketched end state ("boxed streams via `select_all`") does not work:
  `SelectAll` is homogeneous and its `push` adds *streams*, not futures into a
  member set, while the loop must push new futures into `in_flight`/`background`
  mid-flight.
- "The loop grows one drain, not one arm per feature" held structurally but not
  behaviourally — the pump was added as the *last* arm, so it yielded to
  everything else.

## Tests

Six new regression tests, each verified to fail against its pre-fix source and
pass after. Notably the fairness pair: writing only the ambient-starvation test
would have left the `recv`-starves-`progress` axis in place and green — its
inverse is what caught it.

`test_bufreader_cancellation_safety` could not fail for the property it names;
it never cancels anything, as its own comment concedes. Left as a
sequential-read test, paired with one that actually drops a parked read.

## Not covered

- ~~Windows is unverified at runtime~~ — resolved: the named-pipe regression
  test ran on the `windows-latest` CI job and passed. It was unverified locally
  (this machine is Linux), only type-checked against `x86_64-pc-windows-gnu`.
- A partial *line* is still lost if a Unix `recv` is dropped mid-message.
  tokio's `read_line` moves the caller's `String` into the future, so it cannot
  be recovered from outside. Unix would need the crate's own `read_line_bytes`
  to close that.
- The four HTTP adapters have no run loop and were not examined.

Local gate: `just ci`, `just clippy-strict`, `just cross-check`, workspace
nextest (1393 pass) and doctests all green.