### PR TITLE
test(ci): prove the gates can fail

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,81 +173,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # Extracted to a script so it can be exercised. Three checks live in it,
+      # each added after a real miss, and until now nothing confirmed any of
+      # them still fired. The harness runs first and plants a defect per check.
+      - name: Prove the version gate can fail
+        run: scripts/version-sync-test.sh
       - name: Check documentation versions match Cargo.toml
-        run: |
-          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "mcpkit") | .version')
-          MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
-
-          echo "Checking documentation references mcpkit version $MAJOR_MINOR..."
-          FAIL=0
-
-          # Every snippet-bearing doc must reference the current version at
-          # least once (umbrella crate or subcrate — all published mcpkit-*
-          # crates share the workspace version).
-          for f in README.md docs/getting-started.md docs/client-guide.md \
-                   docs/extensions.md docs/runtimes.md docs/wasm.md \
-                   docs/migration-from-rmcp.md; do
-            if ! grep -qE "mcpkit(-[a-z]+)? = \"$MAJOR_MINOR\"" "$f"; then
-              echo "ERROR: $f does not reference mcpkit(-*) = \"$MAJOR_MINOR\""
-              FAIL=1
-            fi
-          done
-
-          # No doc may pin any OTHER mcpkit version — this catches partially
-          # bumped files, which the per-file presence check alone would pass.
-          #
-          # Exemptions are per line, not per file. This used to pass
-          # --exclude=migration-to-1.0.md --exclude=api-stability.md
-          # --exclude-dir=adr, because each holds legitimately-old versions
-          # (migration paths, post-1.0 contract examples, point-in-time ADRs).
-          # But a whole-file exclusion means one justified pin exempts every
-          # other line in that file forever — so a genuinely stale install
-          # snippet added to any of them would never be caught.
-          #
-          # A pin is exempt only where explicitly marked:
-          #   <!-- version-sync:ok — reason -->    on the line before a fenced
-          #                                        block, exempting that block
-          #   mcpkit = "1"  <!-- version-sync:ok -->   inline, one line
-          # HTML comments render invisibly, so this costs readers nothing and
-          # keeps the justification at the point of use.
-          STALE=$(find README.md docs -name '*.md' -print0 \
-            | xargs -0 awk '
-                /<!-- *version-sync:ok/ {
-                  if ($0 ~ /mcpkit[a-z-]* *= *"/) { next }
-                  pending = 1; next
-                }
-                /^[ \t]*```/ {
-                  if (in_block) { in_block = 0; exempt = 0 }
-                  else { in_block = 1; exempt = pending; pending = 0 }
-                  next
-                }
-                /mcpkit(-[a-z]+)? *= *"[0-9]/ {
-                  if (in_block && exempt) next
-                  print FILENAME ":" FNR ":" $0
-                }
-              ' \
-            | grep -vE "mcpkit(-[a-z]+)? = \"$MAJOR_MINOR\"" || true)
-          if [ -n "$STALE" ]; then
-            echo "ERROR: stale mcpkit version references (expected $MAJOR_MINOR):"
-            echo "$STALE"
-            FAIL=1
-          fi
-
-          # RELEASING.md declares the release it documents in its own header,
-          # using a different syntax from the dependency snippets above and
-          # living at the repo root — so neither the per-file presence check nor
-          # the stale sweep could see it. It sat at 0.6.0 for the whole 0.7.0
-          # cycle and was only caught by hand during release prep.
-          if ! grep -qE "^\*\*Version:\*\* ${VERSION}( |$)" RELEASING.md; then
-            echo "ERROR: RELEASING.md header does not declare **Version:** $VERSION"
-            grep -nE "^\*\*Version:\*\*" RELEASING.md || true
-            FAIL=1
-          fi
-
-          if [ "$FAIL" -ne 0 ]; then
-            exit 1
-          fi
-          echo "All version references are correct!"
+        run: scripts/version-sync.sh
 
   # Relative links and anchors in markdown — offline, no network.
   #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,6 +300,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      # Runs before the gate it guards. This asserts schema-diff.sh still
+      # *rejects* planted defects — rows 1 and 2 once could not fail at all, and
+      # a conformance gate that always passes is worse than no gate, because it
+      # converts "unchecked" into "checked and fine".
+      - name: Prove the schema gate can fail
+        run: scripts/schema-diff-test.sh
       - name: Diff against the vendored 2025-11-25 schema
         run: |
           set -euo pipefail

--- a/.github/workflows/stress-test.yml
+++ b/.github/workflows/stress-test.yml
@@ -153,20 +153,35 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - name: Build stress test binary
-        run: cargo build --release --example stress-test 2>/dev/null || echo "Stress test example not found, running inline tests"
+      # The "Build stress test binary" step was removed. It built
+      # `--example stress-test`, which does not exist in this workspace, under
+      # `2>/dev/null || echo "... not found, running inline tests"` — so it
+      # silently took the fallback on every run and reported success. There are
+      # no "inline tests" it was falling back to; the steps below are the job.
 
       - name: Run concurrent request stress test
         run: |
-          # Run transport stress test with multiple concurrent connections
+          # Deliberately NOT `cargo test ... | head -100` under pipefail: this
+          # command emits far more than 100 lines, so `head` closes the pipe
+          # early, the producer takes SIGPIPE, and pipefail reports 141 — a red
+          # job on a passing run. Capture, keep the real status, then truncate.
+          set -uo pipefail
+          status=0
           cargo test --release --package mcpkit-transport -- \
             --test-threads=1 \
             concurrent \
-            --nocapture 2>&1 | head -100 || true
+            --nocapture > stress.log 2>&1 || status=$?
+          if [ "$status" -eq 0 ]; then
+            head -100 stress.log
+          else
+            echo "::error::concurrent stress test failed (exit $status)"
+            tail -100 stress.log
+          fi
+          exit "$status"
 
       - name: Run high-throughput serialization stress
         run: |
-          # Run serialization benchmark with maximum samples
+          set -euo pipefail
           cargo bench --package mcpkit-benches --bench serialization -- \
             --sample-size 500 \
             --measurement-time 30 \
@@ -174,7 +189,7 @@ jobs:
 
       - name: Memory pressure test
         run: |
-          # Run memory benchmark to detect leaks under pressure
+          set -euo pipefail
           cargo bench --package mcpkit-benches --bench memory -- \
             --sample-size 200 \
             --measurement-time 20 \

--- a/Justfile
+++ b/Justfile
@@ -561,6 +561,22 @@ clippy-fix:
     printf '{{green}}[OK]{{reset}}   Clippy fixes applied\n'
 
 [group('security')]
+[doc("Diff the wire vocabulary against the vendored MCP schema")]
+schema-diff:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    scripts/schema-diff.sh
+
+[group('security')]
+[doc("Prove the schema gate still rejects planted defects")]
+schema-diff-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf '{{cyan}}[INFO]{{reset}} Checking that schema-diff.sh can fail...\n'
+    scripts/schema-diff-test.sh
+    printf '{{green}}[OK]{{reset}}   Schema gate rejected every planted defect\n'
+
+[group('security')]
 [doc("Security vulnerability audit via cargo-audit")]
 audit:
     #!/usr/bin/env bash

--- a/Justfile
+++ b/Justfile
@@ -561,6 +561,15 @@ clippy-fix:
     printf '{{green}}[OK]{{reset}}   Clippy fixes applied\n'
 
 [group('security')]
+[doc("Prove the version gate still rejects planted defects")]
+version-sync-test:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    printf '{{cyan}}[INFO]{{reset}} Checking that version-sync.sh can fail...\n'
+    scripts/version-sync-test.sh
+    printf '{{green}}[OK]{{reset}}   Version gate behaved as intended\n'
+
+[group('security')]
 [doc("Diff the wire vocabulary against the vendored MCP schema")]
 schema-diff:
     #!/usr/bin/env bash
@@ -1086,27 +1095,19 @@ ci-watch:
     fi
     gh run watch
 
+# Calls the same script CI runs. This recipe used to carry its own weaker copy
+# — README.md and docs/getting-started.md only, with neither the stale-pin
+# sweep nor the RELEASING.md header check — so `just ci` passed on trees where
+# the Version Sync job would have failed. A local gate weaker than the real one
+# is worse than no local gate: it reports "checked" for things it never looked
+# at.
 [group('ci')]
 [doc("Check documentation versions match Cargo.toml")]
 version-sync:
     #!/usr/bin/env bash
     set -euo pipefail
     printf '{{cyan}}[INFO]{{reset}} Checking version sync...\n'
-    VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[] | select(.name == "mcpkit") | .version')
-    MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
-
-    # Check README.md
-    if ! grep -q "mcpkit = \"$MAJOR_MINOR\"" README.md; then
-        printf '{{red}}[ERR]{{reset}}  README.md version mismatch (expected %s)\n' "$MAJOR_MINOR"
-        exit 1
-    fi
-
-    # Check docs/getting-started.md
-    if ! grep -q "mcpkit = \"$MAJOR_MINOR\"" docs/getting-started.md; then
-        printf '{{red}}[ERR]{{reset}}  docs/getting-started.md version mismatch (expected %s)\n' "$MAJOR_MINOR"
-        exit 1
-    fi
-    printf '{{green}}[OK]{{reset}}   Version sync passed (v%s)\n' "$MAJOR_MINOR"
+    scripts/version-sync.sh
 
 # cross-check runs early and cheaply (~32s cold, ~3s warm) so a Windows-only
 # compile break is caught here instead of 13 minutes into a CI run. It is the

--- a/crates/mcpkit-server/src/server.rs
+++ b/crates/mcpkit-server/src/server.rs
@@ -1355,6 +1355,21 @@ where
 ///
 /// This trait is implemented by Server with different bounds depending on
 /// which handlers are registered.
+///
+/// # The returned futures are not declared `Send`
+///
+/// `async_fn_in_trait` desugars to `impl Future` with no auto-trait bounds, so
+/// nothing here promises `Send`. [`ServerRuntime::run`] is therefore `Send`
+/// only at concrete instantiations whose handler futures happen to be `Send` —
+/// which is what every `tokio::spawn(runtime.run())` call site relies on today,
+/// and why it compiles despite the bound being unprovable generically.
+///
+/// The practical consequence is that `run`'s internals cannot type-erase a
+/// future they hold across an await: erasing to `dyn Future` drops `Send`
+/// unconditionally, and adding `+ Send` to the erased type fails to compile in
+/// the generic context. Adding `+ Send` here instead would fix that, but it is
+/// a breaking change for every implementor, so it wants its own decision rather
+/// than arriving as a side effect. See ADR 0006.
 #[allow(async_fn_in_trait)]
 pub trait RequestRouter: Send + Sync {
     /// Get the server info.

--- a/scripts/schema-diff-test.sh
+++ b/scripts/schema-diff-test.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Harness for scripts/schema-diff.sh: proves the gate can fail.
+#
+# A conformance gate that reports success without having verified anything is
+# worse than no gate — it converts "unchecked" into "checked and fine". This
+# repo has shipped that twice: schema-diff rows 1 and 2 extracted method names
+# with a wide literal sweep that matched every spec method in doc comments and
+# test fixtures, so the comparison was saturated and could not fail; and the
+# baseline header stated a guarantee the gate did not provide.
+#
+# So: plant a defect the gate is supposed to notice, and assert it notices.
+# Each mutation below maps to a specific row, and each is a real regression
+# someone could introduce — a renamed method constant, a dropped `_meta`, a
+# removed enum variant.
+#
+# Reads only, and works on a copy, so the working tree is never touched.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+command -v jq >/dev/null || { echo "error: jq not found" >&2; exit 1; }
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/scripts"
+cp -r "$ROOT/spec" "$ROOT/crates" "$TMP/"
+cp "$ROOT/scripts/schema-diff.sh" "$TMP/scripts/"
+cd "$TMP"
+
+failures=0
+fail() { echo "FAIL: $*"; failures=$((failures + 1)); }
+
+# --- The clean run must reproduce the checked-in baseline -------------------
+# Guards the harness itself: if this drifts, every mutation below is comparing
+# against the wrong reference and "detected" means nothing.
+./scripts/schema-diff.sh --baseline > clean.txt 2>/dev/null
+grep -vE '^\s*(#|$)' "$ROOT/spec/schema-diff-baseline.txt" > expected.txt
+if ! diff -q expected.txt clean.txt >/dev/null; then
+  echo "FAIL: a clean run does not match spec/schema-diff-baseline.txt."
+  echo "      The harness cannot attribute any difference to its mutations."
+  diff -u expected.txt clean.txt | head -20
+  exit 1
+fi
+
+# --- Mutations -------------------------------------------------------------
+# probe <label> <file> <sed-expr>
+probe() {
+  local label="$1" file="$2" expr="$3"
+  cp "$ROOT/$file" "$file"
+  sed -i "$expr" "$file"
+  if diff -q "$ROOT/$file" "$file" >/dev/null; then
+    fail "$label: the mutation changed nothing — the sed expression no longer matches."
+    return
+  fi
+  ./scripts/schema-diff.sh --baseline > mutated.txt 2>/dev/null || true
+  if diff -q clean.txt mutated.txt >/dev/null; then
+    fail "$label: schema-diff.sh did not notice. This row cannot fail."
+  else
+    echo "  ok  $label -> $(diff clean.txt mutated.txt | grep -m1 '^[<>]' | cut -c1-72)"
+  fi
+  cp "$ROOT/$file" "$file"
+}
+
+METHODS="crates/mcpkit-core/src/methods.rs"
+
+# Row 1, schema -> mcpkit: a spec method we stop declaring.
+probe "row 1: dropped request method" "$METHODS" '/= "tools\/call";/d'
+
+# Row 1, mcpkit -> schema: a method we declare that the spec does not have.
+# The reverse direction is separate: a gate that only looks one way is blind to
+# our own typos and renames.
+probe "row 1: method renamed off-spec" "$METHODS" 's|"tools/call"|"tools/kall"|'
+
+# Row 2: notification methods, same two directions.
+probe "row 2: dropped notification method" "$METHODS" '\|notifications/initialized|d'
+
+# Row 3: a variant removed from a closed enum.
+probe "row 3: dropped enum variant" "crates/mcpkit-core/src/types/content.rs" '/^\s*Assistant,$/d'
+
+# Field presence: `_meta` on a request type. This is the shape of a real
+# conformance failure — elicitation params carried no `_meta` for a spec MUST,
+# and the gate's alias map was hiding it.
+probe "fields: dropped _meta" "crates/mcpkit-core/src/types/elicitation.rs" '/pub meta: Option<Meta>/d'
+
+if [ "$failures" -ne 0 ]; then
+  echo
+  echo "$failures mutation(s) went unnoticed by scripts/schema-diff.sh."
+  exit 1
+fi
+
+echo
+echo "schema-diff.sh rejected every planted defect."

--- a/scripts/version-sync-test.sh
+++ b/scripts/version-sync-test.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Harness for scripts/version-sync.sh: proves each of its three checks can fail,
+# and that the exemption mechanism still exempts.
+#
+# Every check in that script was added after a real miss — a doc left at the old
+# version, a partially bumped file that the per-file presence check happily
+# passed, and a RELEASING.md header that sat a full minor behind for an entire
+# release cycle. None of them had anything confirming they still fire.
+#
+# The exemption case matters as much as the failures: line-level exemptions
+# replaced whole-file excludes precisely so that one justified pin stops
+# blanketing a file. If the exemption silently widened back out, the stale sweep
+# would go quiet again — and quiet looks exactly like passing.
+#
+# Works on a copy; the working tree is never touched.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="9.9.9"          # what the fixture is "at"
+OLD="1.2"                # a plausibly stale pin
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP" || exit 1
+
+failures=0
+fail() { echo "FAIL: $*"; failures=$((failures + 1)); }
+
+DOCS="getting-started client-guide extensions runtimes wasm migration-from-rmcp"
+
+# Build a minimal tree that passes, so any later failure is attributable to the
+# single mutation rather than to pre-existing drift.
+fixture() {
+  rm -rf "$TMP/fx"; mkdir -p "$TMP/fx/docs"; cd "$TMP/fx" || exit 1
+  printf '# mcpkit\n\n```toml\nmcpkit = "9.9"\n```\n' > README.md
+  for d in $DOCS; do
+    printf '# %s\n\n```toml\nmcpkit = "9.9"\n```\n' "$d" > "docs/$d.md"
+  done
+  printf '# Releasing\n\n**Version:** %s\n' "$VERSION" > RELEASING.md
+}
+
+run() { MCPKIT_VERSION="$VERSION" bash "$ROOT/scripts/version-sync.sh" > "$TMP/out.log" 2>&1; }
+
+# expect <pass|fail> <label>
+expect() {
+  local want="$1" label="$2"
+  run; local got=$?
+  if [ "$want" = pass ] && [ "$got" -ne 0 ]; then
+    fail "$label: expected the check to pass, got exit $got"; sed 's/^/      /' "$TMP/out.log"
+  elif [ "$want" = fail ] && [ "$got" -eq 0 ]; then
+    fail "$label: expected the check to FAIL, but it passed — this check cannot fail"
+  else
+    echo "  ok  $label"
+  fi
+}
+
+# --- Baseline: a clean fixture must pass -----------------------------------
+fixture
+expect pass "clean fixture passes"
+
+# --- Check 1: a doc that never mentions the current version ----------------
+fixture
+printf '# runtimes\n\nno snippet here\n' > docs/runtimes.md
+expect fail "check 1: doc missing any current-version reference"
+
+# --- Check 2: a partially bumped file ---------------------------------------
+# The per-file presence check passes here — the file *does* mention 9.9 — so
+# only the stale sweep can catch it. This is the case that motivated it.
+fixture
+printf '# wasm\n\n```toml\nmcpkit = "9.9"\n```\n\n```toml\nmcpkit = "%s"\n```\n' "$OLD" > docs/wasm.md
+expect fail "check 2: file with both a current and a stale pin"
+
+# --- Check 3: RELEASING.md header left behind -------------------------------
+fixture
+printf '# Releasing\n\n**Version:** 0.6.0\n' > RELEASING.md
+expect fail "check 3: RELEASING.md header a release behind"
+
+# --- Exemptions: still exempt, and still narrow -----------------------------
+fixture
+{ printf '# migration\n\n<!-- version-sync:ok — historical migration path -->\n'
+  printf '```toml\nmcpkit = "%s"\n```\n' "$OLD"; } > docs/migration.md
+expect pass "exemption: marked block is exempt"
+
+fixture
+{ printf '# migration\n\nmcpkit = "%s"  <!-- version-sync:ok -->\n' "$OLD"; } > docs/migration.md
+expect pass "exemption: marked inline pin is exempt"
+
+# The exemption must NOT blanket the rest of the file. A whole-file exclude is
+# exactly what this replaced, so if it ever widens back out, this goes quiet.
+fixture
+{ printf '# migration\n\n<!-- version-sync:ok — historical -->\n'
+  printf '```toml\nmcpkit = "%s"\n```\n\n' "$OLD"
+  printf '```toml\nmcpkit = "%s"\n```\n' "$OLD"; } > docs/migration.md
+expect fail "exemption is per block, not per file"
+
+if [ "$failures" -ne 0 ]; then
+  echo
+  echo "$failures check(s) in version-sync.sh do not behave as intended."
+  exit 1
+fi
+
+echo
+echo "version-sync.sh fired on every planted defect and honoured every exemption."

--- a/scripts/version-sync.sh
+++ b/scripts/version-sync.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Check that documentation version references match the workspace version.
+#
+# Extracted from .github/workflows/ci.yml so it can be exercised by
+# scripts/version-sync-test.sh and run locally (`just version-sync`). An inline
+# workflow step cannot be tested, and this one grew three distinct checks —
+# each added after a real miss — with no way to confirm any of them still fire.
+#
+# Set MCPKIT_VERSION to override the version under test (used by the harness so
+# it needs neither cargo nor a real workspace).
+set -uo pipefail
+
+if [ -n "${MCPKIT_VERSION:-}" ]; then
+  VERSION="$MCPKIT_VERSION"
+else
+  VERSION=$(cargo metadata --no-deps --format-version 1 \
+    | jq -r '.packages[] | select(.name == "mcpkit") | .version')
+fi
+MAJOR_MINOR=$(echo "$VERSION" | cut -d. -f1,2)
+
+echo "Checking documentation references mcpkit version $MAJOR_MINOR..."
+FAIL=0
+
+# Every snippet-bearing doc must reference the current version at least once
+# (umbrella crate or subcrate — all published mcpkit-* crates share the
+# workspace version).
+for f in README.md docs/getting-started.md docs/client-guide.md \
+         docs/extensions.md docs/runtimes.md docs/wasm.md \
+         docs/migration-from-rmcp.md; do
+  if ! grep -qE "mcpkit(-[a-z]+)? = \"$MAJOR_MINOR\"" "$f"; then
+    echo "ERROR: $f does not reference mcpkit(-*) = \"$MAJOR_MINOR\""
+    FAIL=1
+  fi
+done
+
+# No doc may pin any OTHER mcpkit version — this catches partially bumped
+# files, which the per-file presence check alone would pass.
+#
+# Exemptions are per line, not per file. This used to pass
+# --exclude=migration-to-1.0.md --exclude=api-stability.md --exclude-dir=adr,
+# because each holds legitimately-old versions (migration paths, post-1.0
+# contract examples, point-in-time ADRs). But a whole-file exclusion means one
+# justified pin exempts every other line in that file forever — so a genuinely
+# stale install snippet added to any of them would never be caught.
+#
+# A pin is exempt only where explicitly marked:
+#   <!-- version-sync:ok — reason -->    on the line before a fenced block,
+#                                        exempting that block
+#   mcpkit = "1"  <!-- version-sync:ok -->   inline, one line
+# HTML comments render invisibly, so this costs readers nothing and keeps the
+# justification at the point of use.
+STALE=$(find README.md docs -name '*.md' -print0 \
+  | xargs -0 awk '
+      /<!-- *version-sync:ok/ {
+        if ($0 ~ /mcpkit[a-z-]* *= *"/) { next }
+        pending = 1; next
+      }
+      /^[ \t]*```/ {
+        if (in_block) { in_block = 0; exempt = 0 }
+        else { in_block = 1; exempt = pending; pending = 0 }
+        next
+      }
+      /mcpkit(-[a-z]+)? *= *"[0-9]/ {
+        if (in_block && exempt) next
+        print FILENAME ":" FNR ":" $0
+      }
+    ' \
+  | grep -vE "mcpkit(-[a-z]+)? = \"$MAJOR_MINOR\"" || true)
+if [ -n "$STALE" ]; then
+  echo "ERROR: stale mcpkit version references (expected $MAJOR_MINOR):"
+  echo "$STALE"
+  FAIL=1
+fi
+
+# RELEASING.md declares the release it documents in its own header, using a
+# different syntax from the dependency snippets above and living at the repo
+# root — so neither the per-file presence check nor the stale sweep could see
+# it. It sat at 0.6.0 for the whole 0.7.0 cycle and was only caught by hand
+# during release prep.
+if ! grep -qE "^\*\*Version:\*\* ${VERSION}( |$)" RELEASING.md; then
+  echo "ERROR: RELEASING.md header does not declare **Version:** $VERSION"
+  grep -nE "^\*\*Version:\*\*" RELEASING.md || true
+  FAIL=1
+fi
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+echo "All version references are correct!"


### PR DESCRIPTION
Nearly everything the recent audit work found was one class: **verification
that reports success without having verified anything.** Eleven instances —
schema-diff rows 1–2 saturated by a wide literal sweep, `just release-check`
unable to fail on seven of its dependencies, `just` recipes swallowing exit
codes, fuzz jobs green under `continue-on-error` while discarding crashes, a
`regression-check` job that could never run, a false MSRV claim, disjoint
advisory suppressions, and `test_bufreader_cancellation_safety`, which was
named for a property it never tested.

Each was found by hand, one at a time. Nothing structurally prevented the
twelfth. This adds that.

## Three more instances, fixed

**`stress-test.yml` — 3 of 4 steps could not fail.**
- "Build stress test binary" built `--example stress-test`, which does not
  exist in this workspace, under `2>/dev/null || echo "... running inline
  tests"`. It silently took the fallback every run; there are no inline tests.
  Removed.
- The concurrent stress test carried both `| head -100` and a trailing
  `|| true`.
- Both benchmark steps piped to `tail -50`, so their exit code was `tail`'s.

`notify-on-failure` depends on this job, so a real failure filed no issue.

**`just version-sync` was a weaker copy of the CI check** — README.md and
docs/getting-started.md only, with neither the stale-pin sweep nor the
RELEASING.md header check. It is wired into `just ci`, so the local gate passed
on trees where CI's would fail. Now calls the same script.

**`RequestRouter`'s undeclared `Send` futures** are now documented, with why
`run()`'s internals cannot type-erase across an await.

## Harnesses

Following the existing `publish-crates-test.sh` precedent — plant a defect the
gate should notice, assert it notices.

- **`scripts/schema-diff-test.sh`** — five mutations, one per row: a dropped
  method constant, a method renamed off-spec (the reverse direction, which a
  one-way gate is blind to), a dropped notification, a removed enum variant, a
  dropped `_meta`. Guards itself first: a clean run must reproduce
  `spec/schema-diff-baseline.txt`, so a "detection" cannot be attributed to
  unrelated drift. ~15s.
- **`scripts/version-sync.sh`** extracted from inline YAML so it can be tested
  and run locally, plus **`scripts/version-sync-test.sh`** — one defect per
  check, *and* both exemption directions. Line-level exemptions replaced
  whole-file excludes so one justified pin stops blanketing a file; if that
  widens back out the sweep goes quiet, and quiet looks like passing.

Both verified by neutering the gate they guard: each goes red and names the
check that stopped working, then returns green when restored.

Exposed as `just schema-diff-test` and `just version-sync-test`.

## Deliberately not harnessed

**Proto Drift** and **MSRV** are already falsifiable, and proven so by live
failures this session — Proto Drift caught `clippy --fix` editing the generated
file in #193, MSRV caught `Duration::from_mins` as `E0658`. Proto Drift is
`git diff --exit-code` after a regeneration whose only no-op path is explicitly
`exit 1`. A harness there would cost a full protobuf-src build for no coverage.

**Semver Check**'s `continue-on-error` is intentional — advisory pre-1.0, by
your earlier decision.

## One thing worth noting

The first version of the stress-test fix used `set -o pipefail` with
`| head -100`. That is wrong: `head` closes the pipe early on longer output,
the producer takes SIGPIPE, and pipefail reports 141 — turning a *passing* run
red. `tail` reads to EOF and is safe; `head` is not. Verified both ways; the
concurrent step now captures to a file and keeps the real status.